### PR TITLE
docs: post-split module paths + on-demand pricing API

### DIFF
--- a/docs/guides/finding-instances.md
+++ b/docs/guides/finding-instances.md
@@ -89,10 +89,10 @@ Common `truffle search` flags:
 Before committing, check current Spot prices. Spot can be 60–90% cheaper than on-demand:
 
 ```sh
-truffle spot m8a.4xlarge --sort-by-price --active-only
+truffle spot m8a.4xlarge --sort-by-price --active-only --show-savings
 ```
 
-Output:
+Output (`--show-savings` adds the On-Demand and Savings columns, using live AWS Price List rates):
 ```
 ┌───────────────┬───────────┬───────────────────┬───────────────┬───────────┬─────────┐
 │ Instance Type │ Region    │ Availability Zone │ Spot Price/hr │ On-Demand │ Savings │

--- a/docs/guides/go-library.md
+++ b/docs/guides/go-library.md
@@ -8,13 +8,13 @@ Each tool lives in its own Go module. Add only the packages you need:
 
 ```sh
 # Instance type discovery
-go get github.com/spore-host/spore-host/truffle
+go get github.com/spore-host/truffle
 
 # Instance lifecycle management
-go get github.com/spore-host/spore-host/spawn
+go get github.com/spore-host/spawn
 
 # Capacity watching
-go get github.com/spore-host/spore-host/lagotto
+go get github.com/spore-host/lagotto
 ```
 
 All modules require Go 1.26+ and load AWS credentials from the standard chain (`AWS_*` environment variables, `~/.aws/credentials`, or EC2/ECS metadata).
@@ -25,8 +25,8 @@ No extra configuration is needed beyond standard AWS credentials:
 
 ```go
 import (
-    truffleaws "github.com/spore-host/spore-host/truffle/pkg/aws"
-    spawnclient "github.com/spore-host/spore-host/spawn/pkg/aws"
+    truffleaws "github.com/spore-host/truffle/pkg/aws"
+    spawnclient "github.com/spore-host/spawn/pkg/aws"
 )
 
 // Both use the same credential chain as the AWS CLI
@@ -42,8 +42,8 @@ To use a specific profile, set `AWS_PROFILE` in the environment before calling `
 
 ```go
 import (
-    truffleaws "github.com/spore-host/spore-host/truffle/pkg/aws"
-    "github.com/spore-host/spore-host/truffle/pkg/find"
+    truffleaws "github.com/spore-host/truffle/pkg/aws"
+    "github.com/spore-host/truffle/pkg/find"
 )
 
 // Parse a free-text query into structured criteria
@@ -76,7 +76,7 @@ Supported query terms: vendor names (`intel`, `amd`, `graviton`), processor code
 
 ```go
 prices, err := client.GetSpotPricing(ctx, results, truffleaws.SpotOptions{
-    ShowSavings: true, // populate SavingsPercent field
+    ShowSavings: true, // populate OnDemandPrice + SavingsPercent
 })
 
 cheapest := prices[0]
@@ -90,10 +90,45 @@ fmt.Printf("Cheapest: %s %s $%.4f/hr (%.0f%% savings)\n",
     cheapest.SpotPrice, cheapest.SavingsPercent)
 ```
 
+With `ShowSavings: true`, each `SpotPriceResult` gets its `OnDemandPrice` and
+`SavingsPercent` filled in. On-demand rates come from the AWS Price List API
+(cached, refreshed at most once a day per type/region) and fall back to an
+embedded estimate table when the API is unavailable. Without `ShowSavings`,
+those fields stay `0` and no pricing call is made.
+
+### On-demand prices
+
+For the on-demand rate alone — no spot lookup — use `HourlyRate`, a single-number
+convenience that takes a purchase model:
+
+```go
+// "on-demand" (or "") → the on-demand rate; "spot" → cheapest spot across AZs.
+rate, err := client.HourlyRate(ctx, "c6i.4xlarge", "us-east-1", "on-demand")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("c6i.4xlarge on-demand: $%.4f/hr\n", rate) // → $0.6800/hr
+```
+
+`OnDemandPrice(ctx, instanceType, region)` returns the same on-demand figure
+directly. To control the price source — for tests, an offline fixture, or a
+shared cache across clients — inject your own with `SetOnDemandPricer`:
+
+```go
+// Implements truffleaws.OnDemandPricer
+client.SetOnDemandPricer(myPricer)
+```
+
+::: tip
+`"reserved"` is rejected by `HourlyRate` — reserved pricing depends on term,
+payment option, and offering class, so it isn't a point-in-time rate. Use the
+on-demand figure as a baseline and apply your own reserved discount.
+:::
+
 ### Quota check
 
 ```go
-import "github.com/spore-host/spore-host/truffle/pkg/quotas"
+import "github.com/spore-host/truffle/pkg/quotas"
 
 qc, err := quotas.NewClient(ctx)
 info, err := qc.GetQuotas(ctx, "us-east-1")
@@ -204,8 +239,8 @@ Embed capacity watches into your own tools without shelling out to the CLI.
 
 ```go
 import (
-    "github.com/spore-host/spore-host/lagotto/pkg/watcher"
-    truffleaws "github.com/spore-host/spore-host/truffle/pkg/aws"
+    "github.com/spore-host/lagotto/pkg/watcher"
+    truffleaws "github.com/spore-host/truffle/pkg/aws"
     "github.com/aws/aws-sdk-go-v2/config"
 )
 
@@ -285,11 +320,11 @@ matches, err := store.ListMatchHistory(ctx, "w-mywatch01")
 
 Full API documentation is on pkg.go.dev:
 
-- [truffle/pkg/aws](https://pkg.go.dev/github.com/spore-host/spore-host/truffle/pkg/aws) — `Client`, `InstanceTypeResult`, `SpotPriceResult`, `FilterOptions`, `SpotOptions`
-- [truffle/pkg/find](https://pkg.go.dev/github.com/spore-host/spore-host/truffle/pkg/find) — `ParseQuery`, `ParsedQuery`, `SearchCriteria`, `FindResult`, `ExplainMatch`
-- [truffle/pkg/quotas](https://pkg.go.dev/github.com/spore-host/spore-host/truffle/pkg/quotas) — `Client`, `QuotaInfo`, `CanLaunch`, `GetQuotaFamily`
-- [spawn/pkg/aws](https://pkg.go.dev/github.com/spore-host/spore-host/spawn/pkg/aws) — `Client`, `LaunchConfig`, `LaunchResult`, `InstanceInfo`
-- [lagotto/pkg/watcher](https://pkg.go.dev/github.com/spore-host/spore-host/lagotto/pkg/watcher) — `Store`, `Watch`, `MatchResult`, `NotifyChannel`, `Poller`, `ActionMode`, `WatchStatus`
+- [truffle/pkg/aws](https://pkg.go.dev/github.com/spore-host/truffle/pkg/aws) — `Client`, `InstanceTypeResult`, `SpotPriceResult`, `FilterOptions`, `SpotOptions`, `HourlyRate`, `OnDemandPrice`, `OnDemandPricer`, `SetOnDemandPricer`
+- [truffle/pkg/find](https://pkg.go.dev/github.com/spore-host/truffle/pkg/find) — `ParseQuery`, `ParsedQuery`, `SearchCriteria`, `FindResult`, `ExplainMatch`
+- [truffle/pkg/quotas](https://pkg.go.dev/github.com/spore-host/truffle/pkg/quotas) — `Client`, `QuotaInfo`, `CanLaunch`, `GetQuotaFamily`
+- [spawn/pkg/aws](https://pkg.go.dev/github.com/spore-host/spawn/pkg/aws) — `Client`, `LaunchConfig`, `LaunchResult`, `InstanceInfo`
+- [lagotto/pkg/watcher](https://pkg.go.dev/github.com/spore-host/lagotto/pkg/watcher) — `Store`, `Watch`, `MatchResult`, `NotifyChannel`, `Poller`, `ActionMode`, `WatchStatus`
 
 ## Real-world usage
 

--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -3,7 +3,7 @@
 ::: tip Two SDKs are available
 **REST API client** (`sdk/python/`) — manages instances and queries truffle via the spore.host HTTP API. Covered on this page.
 
-**Native CGO bindings** (`truffle/bindings/python/`) — calls the truffle Go library directly from Python, 10–50× faster. Covered in [Python Bindings (native)](/guides/python-bindings).
+**Native CGO bindings** (`truffle/bindings/python/`) — calls the truffle Go library directly from Python, 10–50× faster. See [`bindings/python/`](https://github.com/spore-host/truffle/tree/main/bindings/python) in the truffle repo.
 :::
 
 The `spore-host` Python package lets you discover EC2 instances, check Spot prices, and manage running instances from Python scripts, Jupyter notebooks, and reactive notebooks like marimo.

--- a/docs/guides/spot-instances.md
+++ b/docs/guides/spot-instances.md
@@ -22,8 +22,10 @@ spore.host will request a Spot instance. If no capacity is available, it fails i
 ## Check Spot prices first
 
 ```sh
-truffle spot g5.xlarge --regions us-east-1,us-west-2,eu-west-1
+truffle spot g5.xlarge --regions us-east-1,us-west-2,eu-west-1 --show-savings
 ```
+
+`--show-savings` adds On-Demand and Savings columns so you can see the real discount per AZ (on-demand rates are pulled live from the AWS Price List API).
 
 ::: tip Finding the right instance type
 Not sure which instance to use? See [Finding the Right Instance](/guides/finding-instances) for a step-by-step walkthrough: `truffle find` → `truffle search` → `truffle spot` → `truffle quotas`.

--- a/docs/tools/reference/truffle.md
+++ b/docs/tools/reference/truffle.md
@@ -102,7 +102,11 @@ Find Spot instance availability and current pricing.
 truffle spot <pattern>
 ```
 
-Queries AWS Spot price history for all instance types matching the pattern across all enabled regions (or those specified with `--regions`). Prints price range summary plus a per-AZ table.
+Queries AWS Spot price history for all instance types matching the pattern across all enabled regions (or those specified with `--regions`). Prints a price-range summary plus a per-AZ table.
+
+With `--show-savings`, the table adds On-Demand and Savings columns. On-demand rates are fetched live from the AWS Price List API (cached for a day) and fall back to a built-in estimate when the API is unavailable.
+
+The summary block is printed only for the default `table` output; `--output json`, `csv`, and `yaml` emit just the structured data, so they pipe cleanly into `jq` and other tools.
 
 **Examples:**
 ```sh


### PR DESCRIPTION
Brings the docs in line with recent truffle work (on-demand pricing #1, output-format fix #3) and the monorepo split.

## Changes

- **`go-library.md`** — fixed **15 stale `github.com/spore-host/spore-host/{truffle,spawn,lagotto}` paths** to the post-split `github.com/spore-host/{tool}` modules; the documented `go get`/import lines no longer resolved. Added docs for the new pricing API: `HourlyRate`, `OnDemandPrice`, `OnDemandPricer`/`SetOnDemandPricer`, and that `ShowSavings` now populates `OnDemandPrice` + `SavingsPercent` from the live AWS Price List.
- **`tools/reference/truffle.md`** — documented `--show-savings` (live Price List, with fallback) and that the summary prints only for `table`, so `json`/`csv`/`yaml` pipe cleanly (truffle#3).
- **`spot-instances.md`, `finding-instances.md`** — added `--show-savings` to the spot examples so the On-Demand/Savings columns shown actually appear.
- **`python-sdk.md`** — fixed a pre-existing dead link (`/guides/python-bindings`, a page that never existed) → points at the truffle repo's `bindings/python/`. This was failing the VitePress build.

## Verification

`npm run build` (VitePress) passes — previously failed on the dead link. No stale monorepo tool paths remain in any source `.md`.