### PR TITLE
test: bootstrap rest-api coverage 0% → 10.8% + Lambda CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lambda-tests:
+    name: Lambda module tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: lambda/rest-api
+            min_coverage: '10'   # target 60% (CLAUDE.md); current ~10.8%
+          - module: lambda/spore-bot
+            min_coverage: '12'   # current ~13.8%
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+          cache-dependency-path: ${{ matrix.module }}/go.sum
+
+      - name: Build
+        working-directory: ${{ matrix.module }}
+        run: go build ./...
+
+      - name: Test
+        working-directory: ${{ matrix.module }}
+        run: go test -coverprofile=coverage.out ./...
+
+      - name: Coverage gate
+        working-directory: ${{ matrix.module }}
+        env:
+          MIN_COVERAGE: ${{ matrix.min_coverage }}
+        run: |
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {sub(/%/,"",$3); print $3}')
+          echo "${{ matrix.module }} coverage: ${total}% (floor: ${MIN_COVERAGE}%)"
+          awk -v t="$total" -v m="$MIN_COVERAGE" 'BEGIN { exit !(t+0 >= m+0) }' \
+            || { echo "::error::coverage ${total}% is below floor ${MIN_COVERAGE}%"; exit 1; }
+
+      - name: Vet
+        working-directory: ${{ matrix.module }}
+        run: go vet ./...

--- a/lambda/rest-api/util_test.go
+++ b/lambda/rest-api/util_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func TestParseJSON(t *testing.T) {
+	var v struct {
+		Name string `json:"name"`
+		N    int    `json:"n"`
+	}
+	if err := parseJSON(`{"name":"x","n":3}`, &v); err != nil {
+		t.Fatalf("parseJSON: %v", err)
+	}
+	if v.Name != "x" || v.N != 3 {
+		t.Errorf("parsed %+v, want {x 3}", v)
+	}
+	if err := parseJSON(`{not json`, &v); err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestTrimAndSplit(t *testing.T) {
+	if trim("  hi  ") != "hi" {
+		t.Error("trim failed")
+	}
+	if got := splitString("a,b,c", ","); !reflect.DeepEqual(got, []string{"a", "b", "c"}) {
+		t.Errorf("splitString = %v", got)
+	}
+}
+
+func TestSplitCSV(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"us-east-1,us-west-2", []string{"us-east-1", "us-west-2"}},
+		{" a , b ,, c ", []string{"a", "b", "c"}}, // trims + drops empties
+		{"", []string{}},
+		{",,", []string{}},
+	}
+	for _, tt := range tests {
+		got := splitCSV(tt.in)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("splitCSV(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestErrResp(t *testing.T) {
+	resp := errResp(http.StatusNotFound, "nope")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+	if resp.Headers["Content-Type"] != "application/json" {
+		t.Errorf("missing JSON content-type header")
+	}
+	var body map[string]string
+	if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if body["error"] != "nope" {
+		t.Errorf("error body = %q, want nope", body["error"])
+	}
+}
+
+func TestJSONResp(t *testing.T) {
+	resp := jsonResp(http.StatusOK, map[string]int{"count": 5})
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(resp.Body, `"count":5`) {
+		t.Errorf("body = %q, want count:5", resp.Body)
+	}
+}
+
+func TestGenerateAPIKey(t *testing.T) {
+	k1, err := GenerateAPIKey()
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+	if !strings.HasPrefix(k1, "sk_") {
+		t.Errorf("key %q missing sk_ prefix", k1)
+	}
+	// sk_ + 48 hex chars (24 bytes).
+	if len(k1) != 3+48 {
+		t.Errorf("key length = %d, want 51", len(k1))
+	}
+	// Keys must be unique.
+	k2, _ := GenerateAPIKey()
+	if k1 == k2 {
+		t.Error("two generated keys collided")
+	}
+}
+
+func TestDecodeOptions(t *testing.T) {
+	got := decodeOptions("ttl=4h,idle=30m,bad,name=test")
+	want := map[string]string{"ttl": "4h", "idle": "30m", "name": "test"} // "bad" (no =) skipped
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("decodeOptions = %v, want %v", got, want)
+	}
+	if len(decodeOptions("")) != 0 {
+		t.Error("decodeOptions(\"\") should be empty")
+	}
+}
+
+func TestBuildOptionsHint(t *testing.T) {
+	// Keys are sorted for stable output.
+	got := buildOptionsHint(map[string]string{"ttl": "4h", "idle": "30m", "name": "x"})
+	if got != "idle, name, ttl" {
+		t.Errorf("buildOptionsHint = %q, want 'idle, name, ttl'", got)
+	}
+}
+
+// --- handler routing (auth happens before any AWS call) ---
+
+func TestHandler_MissingAPIKey(t *testing.T) {
+	req := events.APIGatewayV2HTTPRequest{}
+	req.RequestContext.HTTP.Method = "GET"
+	req.RequestContext.HTTP.Path = "/v1/instances"
+
+	resp, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler transport error: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for missing API key", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Closes #336.

The rest-api Lambda (the hosted SaaS API fronting spawn + truffle) had **no tests**, and the monorepo had **no CI running `go test`** on its Go Lambda modules — only `security.yml` (govulncheck/trivy/semgrep). This bootstraps both.

## Coverage: 0% → 10.8%

`lambda/rest-api/util_test.go`:
- Pure helpers: `parseJSON`, `trim`, `splitString`, `splitCSV`, `errResp`, `jsonResp`, `GenerateAPIKey` (prefix/length/uniqueness), `decodeOptions`, `buildOptionsHint`.
- `handler`: missing-API-key → 401 (auth runs before any AWS config load, so it's testable without AWS).

## CI

New `.github/workflows/ci.yml` runs **build + test + coverage gate + vet** for both Go Lambda modules via a matrix:
- `lambda/rest-api` — floor 10%
- `lambda/spore-bot` — floor 12% (currently 13.8%)

## Note

The bulk of the remaining uncovered code is the route handlers' AWS-call paths (list/launch/get/action, search/spot/quota, SMS). Covering those needs injected spawn/truffle client seams — a good follow-up. This PR gets the public API surface off zero and ensures its tests actually run in CI.

## Verification

Both modules: `go build`, `go vet`, `gofmt`, `go test ./...` pass locally. Gates: rest-api 10.8% ≥ 10%, spore-bot 13.8% ≥ 12%.