### PR TITLE
docs: add CI + Codecov badges, upload Lambda coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
           awk -v t="$total" -v m="$MIN_COVERAGE" 'BEGIN { exit !(t+0 >= m+0) }' \
             || { echo "::error::coverage ${total}% is below floor ${MIN_COVERAGE}%"; exit 1; }
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ${{ matrix.module }}/coverage.out
+          flags: ${{ matrix.module }}
+          fail_ci_if_error: false
+
       - name: Vet
         working-directory: ${{ matrix.module }}
         run: go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <h1 align="center">🍄 spore.host</h1>
 
 <p align="center">
+  <a href="https://github.com/spore-host/spore-host/actions/workflows/ci.yml"><img src="https://github.com/spore-host/spore-host/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/spore-host/spore-host"><img src="https://codecov.io/gh/spore-host/spore-host/branch/main/graph/badge.svg" alt="codecov"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License: Apache 2.0"></a>
   <a href="https://spore.host"><img src="https://img.shields.io/badge/docs-spore.host-blue" alt="Documentation"></a>
 </p>


### PR DESCRIPTION
Adds CI and Codecov badges to the infra-hub README and uploads each Lambda module's coverage to Codecov (flagged per module) from the CI matrix.