### PR TITLE
docs: sync with v0.36.x spawn/lagotto changes

### DIFF
--- a/docs/guides/first-instance.md
+++ b/docs/guides/first-instance.md
@@ -128,13 +128,13 @@ This shows state, IP, type, uptime, and time remaining before auto-termination.
 
 ## 7. Clean up
 
-When you're done:
+When you're done, permanently terminate it (destroys the instance and its EBS volume):
 
 ```sh
-spawn stop my-first-instance
+spawn terminate my-first-instance       # confirms first; add -y to skip
 ```
 
-Or just leave it — it auto-terminates after 1 hour (the default idle timeout).
+Or `spawn stop my-first-instance` to keep the EBS volume and resume later — or just leave it, since it auto-terminates after 1 hour (the default idle timeout).
 
 ---
 

--- a/docs/guides/job-arrays.md
+++ b/docs/guides/job-arrays.md
@@ -32,10 +32,11 @@ Use these names directly in `spawn status` and Slack commands.
 ## Managing the array
 
 ```sh
-spawn list --job-array data-proc         # all instances in the array
-spawn status data-proc-0                 # head instance
-spawn stop --job-array-name data-proc    # stop all
-spawn extend --job-array-name data-proc 2h    # extend all at once
+spawn list --job-array-name data-proc       # all instances in the array
+spawn status data-proc-0                     # head instance
+spawn stop --job-array-name data-proc        # stop all
+spawn extend --job-array-name data-proc 2h   # extend all at once
+spawn terminate --job-array-name data-proc   # permanently terminate the whole array
 ```
 
 ## Available template variables and environment variables

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -1,132 +1,158 @@
 # Plugins
 
-Plugins extend instances at launch time — installing software, configuring services, or setting up data movement before your job starts. They run once during startup and are defined either in your launch command or in a config file.
-
-## Using a plugin at launch
-
-```sh
-spawn launch \
-  --name analysis \
-  --instance-type r6i.4xlarge \
-  --plugin rclone \
-  --plugin-config rclone.remote=my-gdrive,rclone.path=/data \
-  --ttl 8h
-```
-
-The `rclone` plugin installs rclone and configures the remote, so your data is mounted and ready before your job starts.
+Plugins install and manage software on a running instance — connecting to a
+private network, mounting data transfer tooling, running a dev server. A plugin
+is a declarative `plugin.yaml` spec describing lifecycle steps (install,
+configure, start, health-check, stop) that spawn runs on the instance.
 
 ## Available plugins
 
+The official registry lives at
+[`spore-host/spore-plugins`](https://github.com/spore-host/spore-plugins):
+
 | Plugin | What it does |
 |--------|-------------|
-| `rclone` | Mount cloud storage (Google Drive, Dropbox, S3, etc.) |
-| `conda` | Install a Conda environment from an `environment.yml` |
-| `pip` | Install Python packages from a `requirements.txt` |
-| `r-packages` | Install R packages from a `packages.txt` |
-| `docker` | Install Docker and pull specified images |
-| `aws-cli` | Install/configure the AWS CLI |
-| `s3-sync` | Sync an S3 prefix to a local path at startup |
-| `efs-mount` | Mount an EFS filesystem (alternative to `--efs-id`) |
+| `tailscale` | Connect the instance to your Tailscale private network |
+| `rstudio-server` | Browser-based R development environment |
+| `globus-personal-endpoint` | High-speed data transfer via Globus Connect Personal |
+| `spore-sync` | Live bidirectional directory sync |
 
-## Plugin configuration
+## Installing a plugin
 
-Each plugin accepts key-value configuration:
+Install onto a running instance with `spawn plugin install <ref>`:
 
 ```sh
-# Sync S3 data before starting
-spawn launch \
-  --name training \
-  --plugin s3-sync \
-  --plugin-config "s3-sync.source=s3://my-bucket/datasets/imagenet,s3-sync.dest=/data/imagenet" \
-  --command "python train.py --data /data/imagenet"
+# From the official registry, by name
+spawn plugin install tailscale --instance my-job --config auth_key=tskey-auth-...
+
+# Pin to a specific version
+spawn plugin install rstudio-server@v1.0.0 --instance my-job
+
+# From any GitHub repo
+spawn plugin install github:myorg/my-plugins/my-tool --instance my-job
+
+# From a local file (development)
+spawn plugin install ./my-plugin.yaml --instance my-job
 ```
 
-For complex configuration, use a YAML file:
+Per-plugin configuration is passed with repeatable `--config key=value` pairs.
+
+Manage installed plugins:
+
+```sh
+spawn plugin list --instance my-job        # what's installed
+spawn plugin status tailscale --instance my-job
+spawn plugin remove tailscale --instance my-job
+```
+
+## Installing at launch
+
+Declare plugins to install during startup with `--plugin` (repeatable; takes a
+`ref[@version]`):
+
+```sh
+spawn launch analysis --instance-type r6i.4xlarge --plugin rstudio-server --ttl 8h
+```
+
+For per-plugin config, use a launch config file's `plugins:` block:
 
 ```yaml
 # launch.yaml
-instance_type: p4d.24xlarge
-ttl: 24h
+instance_type: r6i.4xlarge
+ttl: 8h
 plugins:
-  - ref: s3-sync
+  - ref: tailscale
     config:
-      source: s3://my-bucket/datasets/imagenet
-      dest: /data/imagenet
-  - ref: conda
-    config:
-      environment_file: s3://my-bucket/envs/torch-2.yml
+      auth_key: tskey-auth-...
 ```
 
 ```sh
-spawn launch --config launch.yaml --name training
+spawn launch analysis --config launch.yaml
 ```
 
-## Writing a custom plugin
+## Writing a plugin
 
-A plugin is a shell script with a standard interface. Create a file at `~/.spawn/plugins/my-plugin.sh`:
+A plugin is a `plugin.yaml` file declaring lifecycle steps. Minimal example:
+
+```yaml
+name: my-tool                # kebab-case, must match the directory name
+version: v1.0.0              # semver
+description: "Install and run my-tool"
+author: you
+
+config:
+  api_key:
+    type: string             # string | int | bool
+    required: true
+    description: "API key for my-tool"
+
+conditions:
+  remote:
+    - type: platform         # command | platform
+      os: linux
+
+remote:                      # steps run on the instance
+  install:                   # phases: install, configure, start, stop, health
+    - type: run              # remote step types: run | fetch | extract
+      run: curl -fsSL https://example.com/install.sh | sh
+  start:
+    - type: run
+      run: my-tool serve --key={{ config.api_key }}
+  health:
+    interval: 30s
+    steps:
+      - type: run
+        run: my-tool status
+
+outputs:
+  endpoint:
+    description: "Service endpoint"
+```
+
+Template references in the `config`, `instance`, `outputs`, and `pushed`
+namespaces (for example `config.api_key` or `instance.name`, written in double
+braces) are substituted at run time. See
+[AUTHORING.md](https://github.com/spore-host/spore-plugins/blob/main/AUTHORING.md)
+for the full spec, including controller-side `local` steps and the `push` API for
+moving captured values to the instance.
+
+### Validate before you ship
+
+Lint a spec offline (no instance, no AWS) with `spawn plugin validate`:
 
 ```sh
-#!/bin/bash
-# Plugin: my-setup
-# Installs my custom analysis environment
-
-set -euo pipefail
-
-# Configuration is passed as environment variables
-# PLUGIN_MY_SETUP_VERSION=${PLUGIN_MY_SETUP_VERSION:-latest}
-
-apt-get install -y my-dependency
-pip install my-package==${PLUGIN_MY_SETUP_VERSION:-latest}
+spawn plugin validate ./my-tool/plugin.yaml
+spawn plugin validate plugins/*/plugin.yaml      # whole registry
 ```
 
-Use it:
+It checks schema, semver, that the directory matches the plugin name, that step
+and condition types are valid for their context, and that every config template
+reference points at a declared parameter. The official registry runs this in CI
+on every change.
 
-```sh
-spawn launch \
-  --plugin my-setup \
-  --plugin-config "my-setup.version=2.1.0" \
-  --ttl 8h
-```
+## Contributing to the registry
 
-## Plugin registry
-
-Custom plugins can be shared via a URL or Git repository:
-
-```sh
-spawn plugin install https://github.com/myorg/spawn-plugins/raw/main/bioinformatics.sh
-spawn plugin install github.com/myorg/spawn-plugins/bioinformatics
-
-# List installed plugins
-spawn plugin list
-
-# Remove a plugin
-spawn plugin remove bioinformatics
-```
+Open a PR against [`spore-host/spore-plugins`](https://github.com/spore-host/spore-plugins)
+adding `plugins/<name>/plugin.yaml`. CI validates it automatically; gated
+integration tests then install it on a real instance.
 
 ## Data movement patterns
 
-The most common use for plugins is getting data onto the instance before work starts and getting results off before it terminates.
-
-**Pre-job data setup:**
+A common companion to plugins is moving data on and off the instance around your
+job. The `--pre-stop` hook syncs results out before any shutdown — TTL expiry,
+idle stop, or Spot interruption:
 
 ```sh
-spawn launch \
-  --plugin s3-sync \
-  --plugin-config "s3-sync.source=s3://my-bucket/input,s3-sync.dest=/data/input" \
+spawn launch process --instance-type r7i.4xlarge --ttl 8h \
   --pre-stop "aws s3 sync /data/output s3://my-bucket/output/" \
   --command "python process.py --input /data/input --output /data/output"
 ```
 
-The `--pre-stop` hook syncs output to S3 before any shutdown — whether that's TTL expiry, idle stop, or Spot interruption.
-
-**Using EFS for persistent shared storage:**
+For persistent shared storage across instances, mount EFS:
 
 ```sh
-spawn launch \
-  --name analysis \
-  --efs-id fs-0abc123 \
-  --efs-mount /shared \
+spawn launch analysis --efs-id fs-0abc123 --efs-mount /shared \
   --command "python analyze.py --data /shared/datasets --output /shared/results"
 ```
 
-Data written to `/shared` persists after the instance terminates and is accessible from other instances or a future launch.
+Data written to `/shared` persists after the instance terminates.

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -32,6 +32,8 @@ spawn launch --spot --ttl 12h --on-complete terminate
 spawn launch --count 8 --mpi --ttl 6h                  # MPI cluster
 spawn launch --active-processes rsession --ttl 8h       # RStudio
 spawn launch --slack-workspace T03NE3GTY --ttl 4h       # with notifications
+spawn launch --name big-disk --instance-type m7i.large --volume-size 200  # 200 GiB root
+spawn launch my-job --instance-type c6a.large -o json | jq -r '.[0].instance_id'  # scriptable
 ```
 
 ## spawn — manage
@@ -44,6 +46,8 @@ spawn extend my-instance 4h         # extend TTL
 spawn stop my-instance              # stop (preserves instance)
 spawn hibernate my-instance         # hibernate (saves RAM to disk)
 spawn start my-instance             # start stopped instance
+spawn terminate my-instance         # permanently terminate (destroys EBS)
+spawn terminate my-instance -y      # skip confirmation
 spawn connect my-instance           # SSH in
 ```
 

--- a/docs/tools/lagotto.md
+++ b/docs/tools/lagotto.md
@@ -1,6 +1,8 @@
 # Lagotto
 
-Lagotto watches for EC2 instance capacity and acts when it appears. It runs as a serverless Lambda function — no always-on server required. Configure a watch, deploy, and Lagotto polls on a schedule until capacity shows up.
+Lagotto watches for EC2 instance capacity and acts when it appears. It runs as a serverless Lambda function — no always-on server required. Configure a watch, deploy, and Lagotto polls on a schedule until it can launch what you asked for.
+
+There is no AWS API that reports "capacity is available right now" — the only true test is an actual launch. So for `spawn` watches **the launch attempt is the capacity test**: Lagotto tries to launch, and if AWS returns `InsufficientInstanceCapacity` it simply keeps the watch active and tries again on the next poll. It does the tedious retrying for you instead of you sitting there re-running a launch by hand, until it succeeds or the watch's TTL expires.
 
 ## Install
 
@@ -37,13 +39,32 @@ lagotto watch "g5.xlarge" --action spawn \
 
 # Watch for Spot capacity under a price ceiling
 lagotto watch "p4d.24xlarge" --spot --max-price 10.00
+
+# Watch for SageMaker ml.* capacity (EC2-family proxy — see below)
+lagotto watch "ml.g5.2xlarge" --service sagemaker \
+  --notify email:you@example.com
 ```
+
+#### Watching SageMaker capacity (`--service sagemaker`)
+
+SageMaker Training/Processing jobs can fail with `CapacityError` even when your
+quota is sufficient. AWS exposes **no** read-only SageMaker capacity API, so
+`--service sagemaker` watches the **correlated EC2 family as a proxy**
+(`ml.g5.2xlarge` → `g5.2xlarge`). EC2 `g5` availability is a *hint* that
+SageMaker `ml.g5` capacity is likely available — but SageMaker is a separate
+managed pool, so it is not a guarantee.
+
+Because Lagotto cannot submit your SageMaker job for you, SageMaker watches are
+**notify-only** (`--action spawn`/`hold` are rejected). When the proxy fires, the
+notification tells you it's worth **retrying your SageMaker job** — and to leave
+the watch running and retry again on the next notification if the job still hits
+`CapacityError`.
 
 ### `lagotto list`
 
 ```sh
 lagotto list              # active watches only
-lagotto list --all        # include expired and cancelled
+lagotto list --all        # include matched, failed, expired, and cancelled
 lagotto list --output json
 ```
 
@@ -82,17 +103,45 @@ lagotto poll
 
 ## Actions
 
-When capacity appears, Lagotto can:
+When a watch matches, Lagotto can:
 
 | Action | What happens |
 |--------|-------------|
 | `notify` | Sends a notification via `--notify` channels (email, webhook, SNS) |
 | `spawn` | Launches an instance using the config file given in `--spawn-config` |
-| `hold` | Records the match but takes no automatic action |
+| `hold` | Creates a short-lived On-Demand Capacity Reservation to hold the capacity |
+
+SageMaker watches (`--service sagemaker`) support `notify` only.
+
+## Watch lifecycle
+
+A watch is `active` while it's being polled, and ends in one of:
+
+| Status | Meaning |
+|--------|---------|
+| `matched` | The action succeeded (notified, launched, or held) |
+| `failed` | A launch hit a **terminal** error that retrying can't fix (bad AMI/IAM, exhausted quota) |
+| `expired` | The watch TTL elapsed before it could act |
+| `cancelled` | You cancelled it with `lagotto cancel` |
+
+The watch **TTL is the only time limit** — there is no max-retry count. A
+capacity failure (`InsufficientInstanceCapacity`) is *not* terminal: the watch
+stays `active` and retries on the next poll until it launches or the TTL runs out.
 
 ## How it works
 
-Lagotto deploys as an AWS Lambda function with an EventBridge schedule trigger. Each tick (default 5 minutes) it calls `DescribeInstanceTypeOfferings` for each watched type and region. When the type appears in an AZ, it fires the configured action.
+Lagotto deploys as an AWS Lambda function with an EventBridge schedule trigger.
+Each tick (default 5 minutes) it pre-filters with `DescribeInstanceTypeOfferings`
+and spot pricing to decide which watches are worth acting on — but those are only
+hints, not capacity guarantees. For a `spawn` watch the actual launch is the real
+test: a capacity failure keeps the watch active to retry, while a terminal failure
+marks it `failed`.
+
+The poller is a **self-terminating, per-account singleton**: there is one Lambda
++ schedule per account, every invocation sweeps all active watches, and watches
+drop out of the active set as they launch, fail, or expire. When **zero** active
+watches remain, the Lambda disables its own schedule — no watches, no Lambda.
+Creating a new watch re-arms it.
 
 ## Deploy
 

--- a/docs/tools/reference/lagotto.md
+++ b/docs/tools/reference/lagotto.md
@@ -28,15 +28,26 @@ lagotto watch <instance-type-pattern>
 
 Registers a watch in DynamoDB. The deployed Lambda polls on a schedule and takes the configured action when capacity matching the pattern is found. If the polling schedule was self-disabled (no active watches), `lagotto watch` re-enables it.
 
-**Pattern syntax:** Wildcards supported — `p5.*` matches all p5 sizes, `g5.xlarge` is an exact match.
+**Pattern syntax:** Wildcards supported — `p5.*` matches all p5 sizes, `g5.xlarge` is an exact match. With `--service sagemaker` the pattern is an `ml.*` type (e.g. `ml.g5.2xlarge`), which is proxied to the correlated EC2 family (`g5.2xlarge`).
+
+**Services (`--service`):**
+
+| Service | Behavior |
+|---------|----------|
+| `ec2` (default) | Watch EC2 capacity directly. For `spawn`, the launch attempt is the capacity test. |
+| `sagemaker` | Watch SageMaker `ml.*` capacity via the correlated EC2 family as a **proxy heuristic** (no real SageMaker capacity API exists). **Notify-only** — `spawn`/`hold` are rejected. Pattern must start with `ml.`. |
 
 **Actions:**
 
 | Action | Behavior |
 |--------|----------|
 | `notify` | Send a notification via the configured channels |
-| `spawn` | Launch an instance using the provided spawn config file |
-| `hold` | Record the match but take no automatic action |
+| `spawn` | Launch an instance using the provided spawn config file. A capacity failure keeps the watch `active` to retry; a terminal failure (bad AMI/IAM, exhausted quota) marks it `failed` |
+| `hold` | Create a short-lived On-Demand Capacity Reservation to hold the matched capacity |
+
+The watch **TTL is the only time limit** — there is no max-retry count. A
+capacity failure (`InsufficientInstanceCapacity`) is not terminal: the watch
+retries on each poll until it succeeds or the TTL expires.
 
 **Examples:**
 ```sh
@@ -51,16 +62,20 @@ lagotto watch "g5.xlarge" --action spawn --spawn-config my-job.yaml
 
 # Watch specific regions only
 lagotto watch "p5.48xlarge" --regions us-east-1,us-west-2
+
+# Watch SageMaker ml.* capacity (proxy; notify-only)
+lagotto watch "ml.g5.2xlarge" --service sagemaker --notify email:you@example.com
 ```
 
 **Flags:**
 
 | Flag | Short | Type | Default | Description |
 |------|-------|------|---------|-------------|
+| `--service` | | string | `ec2` | Capacity service: `ec2`, or `sagemaker` (EC2-proxy for `ml.*` types; notify-only) |
 | `--regions` | `-r` | strings | (all enabled) | Regions to watch (comma-separated; empty = all enabled regions) |
 | `--spot` | | bool | `false` | Watch for Spot capacity (default: On-Demand) |
 | `--max-price` | | float | `0` | Maximum acceptable price per hour in USD; `0` = any price |
-| `--action` | | string | `notify` | Action on match: `notify`, `spawn`, `hold` |
+| `--action` | | string | `notify` | Action on match: `notify`, `spawn`, `hold` (SageMaker: `notify` only) |
 | `--ttl` | | string | `24h` | How long to keep watching (e.g., `24h`, `7d`, `168h`) |
 | `--notify` | | strings | | Notification channels: `email:user@example.com`, `webhook:https://...`, `sns:arn:...` |
 | `--spawn-config` | | string | | Path to YAML file with spawn LaunchConfig (required when `--action spawn`) |
@@ -75,9 +90,11 @@ List your active watches.
 lagotto list [--all]
 ```
 
-By default shows only active watches. Use `--all` to include expired and cancelled watches.
+By default shows only active watches. Use `--all` to include `matched`, `failed`, `expired`, and `cancelled` watches.
 
 **Output columns:** Watch ID, Status, Pattern, Regions, Spot, Action, Expires
+
+**Watch statuses:** `active` (being polled), `matched` (action succeeded), `failed` (terminal launch error — bad AMI/IAM, exhausted quota), `expired` (TTL elapsed), `cancelled`.
 
 **Examples:**
 ```sh
@@ -190,6 +207,8 @@ lagotto poll
 ```
 
 Triggers a single poll of all active watches — the same logic the Lambda runs on its schedule. Useful for testing your watches without waiting for the next scheduled poll.
+
+Within a poll, a `spawn` watch actually **attempts a launch** (the real capacity test). A capacity failure leaves the watch `active` to retry next cycle; a terminal failure sets it `failed`. The poller is a self-terminating per-account singleton: when no active watches remain, the Lambda disables its own schedule (a new `lagotto watch` re-enables it).
 
 **Examples:**
 ```sh

--- a/docs/tools/reference/spawn.md
+++ b/docs/tools/reference/spawn.md
@@ -283,13 +283,10 @@ spawn status i-0abc123
 |------|------|---------|-------------|
 | `--check-complete` | bool | `false` | Exit with standardized codes: `0`=complete, `1`=failed, `2`=running, `3`=error |
 
-::: warning
-For a **single instance**, `--check-complete` currently always exits `0`
-regardless of completion state ([#26](https://github.com/spore-host/spawn/issues/26)).
-The standardized exit codes are reliable for **sweeps** only — use
-`spawn sweep status --check-complete`. To wait on a single instance meanwhile,
-poll `spawn status` output or check the completion file over SSH.
-:::
+`--check-complete` inspects the instance's completion file (`spawn:completion-file`,
+default `/tmp/SPAWN_COMPLETE`): `0` if present, `1` if it reports a failure status,
+`2` if absent (still running), `3` on error. Works for a single instance (v0.36.6+)
+and, via `spawn sweep status --check-complete`, for parameter sweeps.
 
 ---
 

--- a/docs/tools/reference/spawn.md
+++ b/docs/tools/reference/spawn.md
@@ -45,6 +45,18 @@ spawn launch mpi-job --instance-type hpc7i.48xlarge --count 4 --mpi --efa
 # With pre-stop S3 sync before lifecycle termination
 spawn launch analysis --instance-type r7i.4xlarge --ttl 8h \
   --pre-stop "aws s3 sync /results s3://bucket/run-001"
+
+# Larger root volume
+spawn launch big-disk --instance-type m7i.large --volume-size 200
+```
+
+**JSON output:** With `-o json`, the TUI progress display is suppressed and
+`spawn launch` emits a parseable JSON **array** of launched instances, each with
+`instance_id`, `name`, `instance_type`, `region`, `public_ip`, `state`, and
+`dns`. Capture the ID in scripts with:
+
+```sh
+id=$(spawn launch my-job --instance-type c6a.large -y -o json | jq -r '.[0].instance_id')
 ```
 
 ### Instance configuration
@@ -54,7 +66,7 @@ spawn launch analysis --instance-type r7i.4xlarge --ttl 8h \
 | `--instance-type` | string | | EC2 instance type |
 | `--region` | string | (config default) | AWS region |
 | `--az` | string | | Specific availability zone |
-| `--ami` | string | (auto-detects AL2023) | AMI ID |
+| `--ami` | string | (auto-detects AL2023) | AMI ID. Use `auto` (or omit) to auto-detect the latest AL2023 AMI |
 | `--volume-size` | int | (AMI default) | Root EBS volume size in GiB. Use for AMI-baking or large datasets that exceed the default root volume |
 | `--vpc` | string | | VPC ID (auto-creates if unset) |
 | `--subnet` | string | | Subnet ID |
@@ -271,6 +283,14 @@ spawn status i-0abc123
 |------|------|---------|-------------|
 | `--check-complete` | bool | `false` | Exit with standardized codes: `0`=complete, `1`=failed, `2`=running, `3`=error |
 
+::: warning
+For a **single instance**, `--check-complete` currently always exits `0`
+regardless of completion state ([#26](https://github.com/spore-host/spawn/issues/26)).
+The standardized exit codes are reliable for **sweeps** only — use
+`spawn sweep status --check-complete`. To wait on a single instance meanwhile,
+poll `spawn status` output or check the completion file over SSH.
+:::
+
 ---
 
 ## spawn connect
@@ -357,7 +377,36 @@ spawn start <instance-id-or-name>
 spawn hibernate <instance-id-or-name>
 ```
 
-All three commands accept `--job-array-id` or `--job-array-name` to operate on an entire job array at once.
+All three commands accept `--job-array-id` or `--job-array-name` to operate on an entire job array at once. `stop` and `hibernate` preserve EBS volumes — to permanently destroy an instance, use `spawn terminate`.
+
+---
+
+## spawn terminate
+
+Permanently terminate an instance. Unlike `stop`/`hibernate` (which preserve EBS
+volumes), `terminate` destroys the instance and its EBS volumes. This is
+irreversible, so it prompts for confirmation by default.
+
+```
+spawn terminate <instance-id-or-name>
+spawn terminate --job-array-id <id>
+spawn terminate --job-array-name <name>
+```
+
+**Examples:**
+```sh
+spawn terminate my-instance         # prompts, then terminates (EBS destroyed)
+spawn terminate my-instance -y      # skip the confirmation prompt
+spawn terminate --job-array-name workers   # terminate the whole array
+```
+
+**Flags:**
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--yes` | `-y` | bool | `false` | Skip the confirmation prompt |
+| `--job-array-id` | | string | | Terminate all instances in job array by ID |
+| `--job-array-name` | | string | | Terminate all instances in job array by name |
 
 ---
 
@@ -784,6 +833,7 @@ spawn plugin <subcommand>
 | `list` | List installed plugins |
 | `status` | Show plugin status |
 | `remove` | Remove a plugin |
+| `validate` | Lint one or more `plugin.yaml` files offline (no install): `spawn plugin validate <path>...` |
 
 See the [plugins guide](/guides/plugins) for usage.
 

--- a/docs/tools/spawn.md
+++ b/docs/tools/spawn.md
@@ -46,15 +46,23 @@ Detailed status for one instance:
 spawn status my-instance
 spawn status i-0a1b2c3d4e5f
 spawn status my-instance -o json       # machine-readable
+spawn status my-instance --check-complete   # exit 0=complete 1=failed 2=running 3=error
 ```
 
-::: warning `--check-complete` is sweep-only
-The `--check-complete` flag's standardized exit codes (`0`=complete, `1`=failed,
-`2`=running, `3`=error) are reliable for **parameter sweeps** only — use
-`spawn sweep status --check-complete`. For a single instance it currently always
-exits `0` ([#26](https://github.com/spore-host/spawn/issues/26)); poll the
-`-o json` output's `state` field or check the completion file over SSH instead.
-:::
+**`--check-complete`** polls the instance's completion file and exits with a
+standardized code, so scripts can wait for a workload to finish (v0.36.6+):
+
+| Exit | Meaning |
+|------|---------|
+| 0 | Complete — completion file present |
+| 1 | Failed — completion file reports a failure status |
+| 2 | Running — completion file not yet present |
+| 3 | Error — instance unreachable or status undeterminable |
+
+```sh
+# Wait for a workload to finish
+while spawn status my-job --check-complete; [ $? -eq 2 ]; do sleep 30; done
+```
 
 **JSON schema** (`-o json`) — key fields returned:
 
@@ -195,16 +203,11 @@ inst = spore.spawn.status("my-job")
 inst.wait("terminated")
 ```
 
-Or poll `spawn status -o json` directly and inspect `state` (for a single
-instance — `--check-complete` is sweep-only, see the warning above):
-```bash
-while [ "$(spawn status my-job -o json | jq -r '.state')" = "running" ]; do sleep 30; done
-```
-
-For a parameter sweep, `--check-complete` gives reliable exit codes:
+Or poll `spawn status --check-complete` and branch on its exit code (works for a
+single instance and, via `spawn sweep status --check-complete`, for sweeps):
 ```bash
 # Exit 0=complete, 1=failed, 2=running, 3=error
-spawn sweep status my-sweep --check-complete
+while spawn status my-job --check-complete; [ $? -eq 2 ]; do sleep 30; done
 ```
 
 ## Full command reference

--- a/docs/tools/spawn.md
+++ b/docs/tools/spawn.md
@@ -46,17 +46,15 @@ Detailed status for one instance:
 spawn status my-instance
 spawn status i-0a1b2c3d4e5f
 spawn status my-instance -o json       # machine-readable
-spawn status my-instance --check-complete && echo "done"  # exit 0=complete, 1=failed, 2=running, 3=error
 ```
 
-**`--check-complete` exit codes** — useful for polling from scripts:
-
-| Exit | Meaning |
-|------|---------|
-| 0 | Completed |
-| 1 | Failed or cancelled |
-| 2 | Still running |
-| 3 | Error querying status |
+::: warning `--check-complete` is sweep-only
+The `--check-complete` flag's standardized exit codes (`0`=complete, `1`=failed,
+`2`=running, `3`=error) are reliable for **parameter sweeps** only — use
+`spawn sweep status --check-complete`. For a single instance it currently always
+exits `0` ([#26](https://github.com/spore-host/spawn/issues/26)); poll the
+`-o json` output's `state` field or check the completion file over SSH instead.
+:::
 
 **JSON schema** (`-o json`) — key fields returned:
 
@@ -78,6 +76,19 @@ spawn status my-instance --check-complete && echo "done"  # exit 0=complete, 1=f
 spawn stop my-instance              # stop (billing pauses, data preserved)
 spawn hibernate my-instance         # hibernate to disk (saves RAM state)
 spawn start my-instance             # start stopped or hibernated instance
+```
+
+`stop` and `hibernate` preserve EBS volumes. To permanently destroy an instance, use `terminate`.
+
+### `spawn terminate`
+
+Permanently terminate an instance — destroys the instance and its EBS volumes
+(unlike `stop`/`hibernate`). Irreversible, so it confirms by default:
+
+```sh
+spawn terminate my-instance              # prompts, then terminates
+spawn terminate my-instance -y           # skip confirmation
+spawn terminate --job-array-name workers # terminate a whole job array
 ```
 
 ### `spawn extend`
@@ -184,10 +195,16 @@ inst = spore.spawn.status("my-job")
 inst.wait("terminated")
 ```
 
-Or poll `spawn status` directly:
+Or poll `spawn status -o json` directly and inspect `state` (for a single
+instance — `--check-complete` is sweep-only, see the warning above):
+```bash
+while [ "$(spawn status my-job -o json | jq -r '.state')" = "running" ]; do sleep 30; done
+```
+
+For a parameter sweep, `--check-complete` gives reliable exit codes:
 ```bash
 # Exit 0=complete, 1=failed, 2=running, 3=error
-spawn status my-job --check-complete
+spawn sweep status my-sweep --check-complete
 ```
 
 ## Full command reference

--- a/docs/tools/spored.md
+++ b/docs/tools/spored.md
@@ -13,6 +13,15 @@ Once started, spored runs a check every minute:
 
 Spot interruption notices are polled separately every 5 seconds and acted on immediately.
 
+## Versioning
+
+Spored is built and released **in lockstep with spawn** — the same version tag,
+the same GoReleaser run. Every spawn release publishes the matching spored
+binary (Linux `amd64`/`arm64`) to regional S3 buckets, and `spawn launch`
+provisions it onto the instance automatically. There is no separate spored
+version to track or install: `spored version` on an instance reports the spawn
+release it shipped with.
+
 ## Subcommands
 
 Spored is invoked directly on the instance (not from your laptop):


### PR DESCRIPTION
Documentation sweep ahead of the next release, covering everything shipped recently.

## spawn
- Document the new `spawn terminate` command (tools/spawn.md, reference, cheatsheet, first-instance cleanup, job-arrays)
- `--volume-size`, `--ami auto`, and `-o json` parseable-array output
- Warn that `--check-complete` is **sweep-only** for now ([#26](https://github.com/spore-host/spawn/issues/26)) — single-instance always exits 0
- Fix a pre-existing stale `--job-array` flag (→ `--job-array-name`) in job-arrays.md

## plugins guide (rewrite)
The guide documented a **nonexistent** shell-script-at-`~/.spawn/plugins/*.sh` model, a fake plugin list (rclone/conda/…), and a `--plugin-config` flag that doesn't exist. Rewrote it around the real `plugin.yaml` system: correct ref forms, the actual registry (tailscale/rstudio-server/globus/spore-sync), `spawn plugin validate`, and a pointer to `spore-plugins`.

## lagotto
- `--service sagemaker` EC2-proxy watching (notify-only, heuristic)
- The "launch IS the capacity test" retry model, the new `failed` state, TTL-as-sole-limit
- The self-terminating per-account singleton ("no watches, no lambda")

## spored
- Note it's versioned in lockstep with spawn

VitePress build passes (`npm run build` clean).