### PR TITLE
ci: force Node 24 for bundled actions (#345)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Force bundled Node 20 actions (e.g. github-script inside
+# codecov-action@v5) onto Node 24 ahead of GitHub's 2026-06-16 cutover
+# (spore-host#345). These jobs run on GitHub-hosted runners.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lambda-tests:
     name: Lambda module tests


### PR DESCRIPTION
Final piece of spore-host#345 (already closed via the runner-level fix). Adds workflow-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to `ci.yml` so the `github-script` bundled inside `codecov-action@v5` runs on Node 24 ahead of the 2026-06-16 cutover.

These jobs run on GitHub-hosted runners (not orion), so the runner `.env` fix didn't cover them — this does. `docs.yaml` and `security.yml` use only Node 24-capable actions, so no change needed there.