### PR TITLE
docs: make README Windows-current + add changelog policy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,14 @@
 - `component:truffle`, `component:spawn`, `component:spawnd`
 - Create custom labels as needed for project-specific categories
 
+## Versioning & Changelog
+- Follow **[Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)**: MAJOR for breaking changes, MINOR for backward-compatible features, PATCH for fixes (pre-1.0, breaking changes bump MINOR).
+- Maintain a **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/)**-format `CHANGELOG.md` at the repo root.
+- Update `CHANGELOG.md` in the **same PR** as any user-facing change: add an entry under `## [Unreleased]` in the right group (Added/Changed/Deprecated/Removed/Fixed/Security). Write for humans — describe the effect, not the implementation.
+- On release: promote `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, open a fresh empty Unreleased, update the comparison links, and tag `vX.Y.Z`.
+- GoReleaser auto-generates the GitHub Release notes from commits; `CHANGELOG.md` is the curated, human-facing source of truth. Keep both.
+- This applies to every spore.host repo (truffle, spawn, lagotto, …), each with its own `CHANGELOG.md`.
+
 ## Go Standards
 - Go 1.21+ with modules
 - `gofmt`, `goimports` on all code

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://spore.host"><img src="https://img.shields.io/badge/docs-spore.host-blue" alt="Documentation"></a>
 </p>
 
-**spore.host** is a suite of tools for launching and managing AWS EC2 instances — with automatic lifecycle management so instances clean up after themselves.
+**spore.host** is a suite of tools for launching and managing AWS EC2 instances (Linux **and Windows**) — with automatic lifecycle management so instances clean up after themselves.
 
 This repository (`spore-host/spore-host`) holds the **shared infrastructure** behind spore.host: the hosted REST API, the dashboard, the Python SDK, deployment automation, AMI builds, and the documentation site. **The CLI tools each live in their own repository** (see below).
 
@@ -20,7 +20,7 @@ Each tool is developed and released independently:
 | Tool | Repo | What it does |
 |------|------|--------------|
 | 🔍 **truffle** | [spore-host/truffle](https://github.com/spore-host/truffle) | Find capacity, compare spot prices, check quotas |
-| 🚀 **spawn** | [spore-host/spawn](https://github.com/spore-host/spawn) | Launch and manage instances (includes the `spored` lifecycle daemon) |
+| 🚀 **spawn** | [spore-host/spawn](https://github.com/spore-host/spawn) | Launch and manage Linux & Windows instances (build a Windows AMI from an ISO; connect via SSH, RDP, or SSM; includes the `spored` lifecycle daemon) |
 | 👁️ **lagotto** | [spore-host/lagotto](https://github.com/spore-host/lagotto) | Watch for EC2 capacity and act when it appears |
 | 🤖 **spore-host-mcp** | [spore-host/spore-host-mcp](https://github.com/spore-host/spore-host-mcp) | AI assistant integration (Claude, Cursor) |
 | 🧩 **spore-plugins** | [spore-host/spore-plugins](https://github.com/spore-host/spore-plugins) | Official plugin registry for spawn |
@@ -60,6 +60,16 @@ spawn connect my-job
 # Watch for scarce GPU capacity and auto-launch when it appears
 lagotto watch "p5.48xlarge" --action spawn --spawn-config training.yaml --ttl 7d
 ```
+
+**Windows, too** — turn a Windows 11 ISO into a fast-booting AMI, launch it, and connect by RDP or SSH:
+
+```bash
+spawn image import --iso Win11_Enterprise.iso --name win11   # ISO → AMI (auto-warmed)
+spawn launch winbox --ami <ami-id> --os windows --ttl 4h
+spawn connect winbox --rdp        # graphical desktop  (or --ssh, or a PowerShell-over-SSM shell)
+```
+
+See the [Windows beta guide](https://github.com/spore-host/spawn/blob/main/docs/windows-beta-guide.md) for the full walkthrough.
 
 Full usage at **[spore.host/docs](https://spore.host)**.
 


### PR DESCRIPTION
**README was not current** — it never mentioned that spawn can launch and run **Windows** instances (build a Windows AMI from an ISO; connect via RDP/SSH/PowerShell-over-SSM), a major shipped capability. The only "Windows" reference was the Scoop install line. Fixes:
- intro: "Linux **and Windows**"
- spawn blurb: notes Windows AMI build + RDP/SSH/SSM connect
- Quick Start: a Windows example (ISO → AMI → launch → connect) linking the [Windows beta guide](https://github.com/spore-host/spawn/blob/main/docs/windows-beta-guide.md)

**CLAUDE.md:** added the **SemVer 2.0.0 + Keep a Changelog** policy that now applies across every spore.host repo (each maintains its own `CHANGELOG.md`, updated in the same PR as each user-facing change).

Companion CLAUDE.md + CHANGELOG work landed in spawn/truffle/lagotto; reconstruction issues filed there.