### PR TITLE
feat(spore-bot): Discord lifecycle notifications (Phase 1 of spawn#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **spore-bot** delivers Discord lifecycle notifications (Phase 1 of
+  spore-host/spawn#2): when an instance's notify platform is `discord`, the
+  `/notify` handler posts a color-coded Discord embed (severity-colored, with
+  instance/region/URL fields) to the workspace's channel webhook. Adds a
+  `PublicKey` field to the workspace registry for Discord's Ed25519 interaction
+  verification (used by Phase 2 slash commands). New `docs/guides/discord-setup.md`.
 - **spore-bot** honors the friendly account-name DNS segment: it displays
   `{name}.{account-name}.spore.host` when the instance has a `spawn:account-name`
   tag (falling back to base36) and matches a user-typed target against either

--- a/docs/guides/discord-setup.md
+++ b/docs/guides/discord-setup.md
@@ -1,0 +1,79 @@
+# Discord Setup
+
+Connecting spore.host to Discord posts instance lifecycle notifications —
+TTL warnings, idle stops, spot interruptions, completion — to a channel of your
+choice, as color-coded embeds.
+
+> **Status:** Phase 1 ships **notifications** (this guide). Discord slash
+> commands (`/spore list|status|extend|stop`) are Phase 2 — see
+> [spore-host/spawn#2](https://github.com/spore-host/spawn/issues/2).
+
+## What you'll get
+
+Channel notifications for lifecycle events, as Discord embeds color-coded by
+severity:
+- ⏱️ **rstudio terminates in 5 minutes** (yellow)
+- ✅ **bert-finetune has completed** (green)
+- 💤 **analysis has hibernated — idle timeout reached** (red)
+- ⚠️ **training received a Spot interruption notice** (yellow)
+
+Each embed carries the instance ID, region, and URL.
+
+## Step 1: Create a Discord channel webhook
+
+The simplest delivery path — no bot user required for notifications.
+
+1. In Discord, open the target channel's **Edit Channel → Integrations →
+   Webhooks**.
+2. **New Webhook**, name it `spore-bot`, pick the channel, **Copy Webhook URL**
+   (looks like `https://discord.com/api/webhooks/<id>/<token>`).
+
+## Step 2 (optional, for Phase 2): Create a Discord application
+
+Only needed later for slash commands; skip if you just want notifications.
+
+1. Go to [discord.com/developers/applications](https://discord.com/developers/applications)
+   → **New Application**, name it `spore-bot`.
+2. On the **General Information** page, copy the **Public Key** (hex) — this is
+   what verifies inbound interactions (Discord has no signing secret).
+3. Under **Bot**, add a bot and copy its **token** if you want bot DMs later.
+
+## Step 3: Register the workspace with spawn
+
+Store the webhook (and, optionally, the application public key for Phase 2) so
+the spore-bot service can deliver to your channel. Your Discord **server (guild)
+ID** is the workspace ID — enable Developer Mode in Discord, right-click the
+server, **Copy Server ID**.
+
+```bash
+spawn notify workspace-add \
+  --platform discord \
+  --workspace-id <GUILD_ID> \
+  --workspace-name "My Server" \
+  --webhook-url "https://discord.com/api/webhooks/<id>/<token>" \
+  --public-key <APPLICATION_PUBLIC_KEY>     # optional; for Phase 2 slash commands
+```
+
+`--public-key` is required only when you intend to use slash commands; for
+notifications alone, just the `--webhook-url` is needed. (Discord uses the
+public key for Ed25519 interaction verification, not a signing secret — so
+`--signing-secret` does not apply to `--platform discord`.)
+
+## Step 4: Launch with Discord notifications
+
+Tell the instance to route lifecycle notifications to Discord:
+
+```bash
+spawn launch rstudio --instance-type r7i.xlarge \
+  --slack-workspace <GUILD_ID> \
+  --notify-platform discord
+```
+
+(`--slack-workspace` is the workspace-id flag — it carries the Discord guild ID
+here; the flag name is shared across platforms.) The instance is tagged
+`spawn:notify-platform=discord` and `spawn:slack-workspace-id=<GUILD_ID>`, and
+spored sends its lifecycle events to the spore-bot `/notify` endpoint, which
+posts the embed to your channel webhook.
+
+That's it — you'll see embeds in the channel as the instance warns, stops, or
+completes.

--- a/lambda/spore-bot/discord.go
+++ b/lambda/spore-bot/discord.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Discord embed colors (decimal RGB), keyed by event severity (#2).
+const (
+	discordColorGreen  = 0x2ECC71 // completion / healthy
+	discordColorYellow = 0xF1C40F // warnings (ttl/idle warn, spot interrupt)
+	discordColorRed    = 0xE74C3C // terminated / stopped
+	discordColorBlue   = 0x3498DB // informational / in-progress
+)
+
+// discordEmbed is the subset of Discord's embed object we populate.
+type discordEmbed struct {
+	Title       string              `json:"title,omitempty"`
+	Description string              `json:"description,omitempty"`
+	Color       int                 `json:"color,omitempty"`
+	URL         string              `json:"url,omitempty"`
+	Fields      []discordEmbedField `json:"fields,omitempty"`
+	Timestamp   string              `json:"timestamp,omitempty"`
+}
+
+type discordEmbedField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline"`
+}
+
+// buildDiscordEmbed turns a lifecycle notification into a color-coded Discord
+// embed: title summarizes the event, fields carry instance/region/URL (#2).
+func buildDiscordEmbed(nr NotifyRequest) discordEmbed {
+	name := nr.InstanceName
+	if name == "" {
+		name = nr.InstanceID
+	}
+
+	var icon, title string
+	color := discordColorBlue
+	switch nr.EventType {
+	case "ttl_warning":
+		icon, title, color = "⏱️", fmt.Sprintf("%s terminates in %s", name, nr.Detail), discordColorYellow
+	case "ttl_expired":
+		icon, title, color = "🔴", fmt.Sprintf("%s has terminated — scheduled end time reached", name), discordColorRed
+	case "idle_warning":
+		icon, title, color = "💤", fmt.Sprintf("%s will stop in %s — no activity detected", name, nr.Detail), discordColorYellow
+	case "idle_stopped":
+		icon, title, color = "⏹️", fmt.Sprintf("%s has stopped — idle timeout reached", name), discordColorRed
+	case "idle_hibernated":
+		icon, title, color = "💤", fmt.Sprintf("%s has hibernated — idle timeout reached", name), discordColorRed
+	case "idle_terminated":
+		icon, title, color = "🔴", fmt.Sprintf("%s has terminated — idle timeout reached", name), discordColorRed
+	case "completion":
+		icon, title, color = "✅", fmt.Sprintf("%s has completed", name), discordColorGreen
+	case "spot_interrupt":
+		icon, title, color = "⚠️", fmt.Sprintf("%s received a Spot interruption notice — %s", name, nr.Detail), discordColorYellow
+	case "pre_stop_start":
+		icon, title, color = "🔄", fmt.Sprintf("%s is running its shutdown task before terminating", name), discordColorBlue
+	default:
+		icon, title = "ℹ️", fmt.Sprintf("%s: %s", name, nr.EventType)
+	}
+
+	embed := discordEmbed{
+		Title:     icon + " " + title,
+		Color:     color,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	if nr.DNSName != "" {
+		embed.URL = "https://" + nr.DNSName
+		embed.Fields = append(embed.Fields, discordEmbedField{Name: "URL", Value: "https://" + nr.DNSName, Inline: false})
+	}
+	if nr.InstanceID != "" {
+		embed.Fields = append(embed.Fields, discordEmbedField{Name: "Instance", Value: "`" + nr.InstanceID + "`", Inline: true})
+	}
+	if nr.Region != "" {
+		embed.Fields = append(embed.Fields, discordEmbedField{Name: "Region", Value: nr.Region, Inline: true})
+	}
+	return embed
+}
+
+// postDiscordWebhook POSTs an embed to a Discord channel webhook URL (#2).
+func postDiscordWebhook(webhookURL string, embed discordEmbed) {
+	payload, _ := json.Marshal(map[string]interface{}{
+		"embeds": []discordEmbed{embed},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "POST", webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		logf("discord webhook request error: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		logf("discord webhook call error: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	// Discord returns 204 No Content on success for webhook posts.
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		logf("discord webhook returned %d", resp.StatusCode)
+	}
+}

--- a/lambda/spore-bot/discord_test.go
+++ b/lambda/spore-bot/discord_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDiscordEmbed_ColorAndFields(t *testing.T) {
+	nr := NotifyRequest{
+		Platform:     "discord",
+		EventType:    "ttl_warning",
+		InstanceName: "rstudio",
+		InstanceID:   "i-0abc123",
+		Region:       "us-west-2",
+		DNSName:      "rstudio.5k0zfnmq.spore.host",
+		Detail:       "10m",
+	}
+	e := buildDiscordEmbed(nr)
+
+	if e.Color != discordColorYellow {
+		t.Errorf("ttl_warning color = %#x, want yellow %#x", e.Color, discordColorYellow)
+	}
+	if !strings.Contains(e.Title, "rstudio") || !strings.Contains(e.Title, "10m") {
+		t.Errorf("title = %q, want instance name + detail", e.Title)
+	}
+	if e.URL != "https://rstudio.5k0zfnmq.spore.host" {
+		t.Errorf("url = %q", e.URL)
+	}
+	// Expect URL, Instance, Region fields.
+	var hasInstance, hasRegion bool
+	for _, f := range e.Fields {
+		if f.Name == "Instance" && strings.Contains(f.Value, "i-0abc123") {
+			hasInstance = true
+		}
+		if f.Name == "Region" && f.Value == "us-west-2" {
+			hasRegion = true
+		}
+	}
+	if !hasInstance || !hasRegion {
+		t.Errorf("missing Instance/Region fields: %+v", e.Fields)
+	}
+}
+
+func TestBuildDiscordEmbed_SeverityColors(t *testing.T) {
+	cases := map[string]int{
+		"completion":     discordColorGreen,
+		"ttl_expired":    discordColorRed,
+		"idle_stopped":   discordColorRed,
+		"spot_interrupt": discordColorYellow,
+		"idle_warning":   discordColorYellow,
+		"pre_stop_start": discordColorBlue,
+	}
+	for event, want := range cases {
+		e := buildDiscordEmbed(NotifyRequest{EventType: event, InstanceName: "x"})
+		if e.Color != want {
+			t.Errorf("%s color = %#x, want %#x", event, e.Color, want)
+		}
+	}
+}
+
+func TestBuildDiscordEmbed_UnknownEventDefaultsBlue(t *testing.T) {
+	e := buildDiscordEmbed(NotifyRequest{EventType: "something_new", InstanceName: "x"})
+	if e.Color != discordColorBlue {
+		t.Errorf("unknown event color = %#x, want blue", e.Color)
+	}
+}

--- a/lambda/spore-bot/notify.go
+++ b/lambda/spore-bot/notify.go
@@ -73,6 +73,19 @@ func handleNotify(ctx context.Context, cfg aws.Config, reg *Registry, request ev
 	slackCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	// Discord: post a color-coded embed to the channel webhook (#2). Discord
+	// uses its own embed payload rather than Slack's plain text/blocks; DM-by-bot
+	// is a later addition (interactions phase), so webhook is the delivery path.
+	if nr.Platform == "discord" {
+		embed := buildDiscordEmbed(nr)
+		for i := range workspaces {
+			if ws := &workspaces[i]; ws.IncomingWebhookURL != "" {
+				postDiscordWebhook(ws.IncomingWebhookURL, embed)
+			}
+		}
+		return jsonOK(), nil
+	}
+
 	for i := range workspaces {
 		ws := &workspaces[i]
 		// Pattern A: post to channel via incoming webhook — synchronous so Lambda stays alive

--- a/lambda/spore-bot/registry.go
+++ b/lambda/spore-bot/registry.go
@@ -50,6 +50,10 @@ type WorkspaceConfig struct {
 	AppID         string `dynamodbav:"app_id,omitempty"`
 	BotToken      string `dynamodbav:"bot_token"`
 	SigningSecret string `dynamodbav:"signing_secret"`
+	// PublicKey is the Discord application's Ed25519 public key (hex), used to
+	// verify inbound Discord interaction requests. Discord has no signing secret;
+	// set via `spawn notify workspace-add --platform discord --public-key` (#2).
+	PublicKey     string `dynamodbav:"public_key,omitempty"`
 	Platform      string `dynamodbav:"platform"`
 	WorkspaceName string `dynamodbav:"workspace_name"`
 	InstalledBy   string `dynamodbav:"installed_by"`


### PR DESCRIPTION
Phase 1 of spore-host/spawn#2 (Discord support), umbrella half. Pairs with spore-host/spawn#169 (the CLI + spored wiring).

## What

Adds Discord delivery to the spore-bot `/notify` path. When a notification arrives with `platform: discord`, the handler builds a **color-coded Discord embed** and posts it to the workspace's channel webhook.

- **`discord.go`** — `buildDiscordEmbed` maps each lifecycle event to an embed (severity color: green=completion, red=terminated/stopped, yellow=warnings/spot, blue=info; fields for instance ID, region, URL). `postDiscordWebhook` POSTs it (handles Discord's 204 success).
- **`notify.go`** — branch on `nr.Platform == "discord"` before the Slack/Teams delivery; posts the embed to each workspace's `IncomingWebhookURL`.
- **`registry.go`** — `PublicKey` field on `WorkspaceConfig` (Discord's Ed25519 interaction key; additive, back-compat). Used by Phase 2 slash commands.
- **`docs/guides/discord-setup.md`** — webhook creation, `workspace-add --platform discord`, `launch --notify-platform discord`.

## Scope

Notifications only (Phase 1). The interactions endpoint — `/discord` route, Ed25519 verification, PING/PONG, `/spore list|status|extend|stop` — is Phase 2 (tracked on spawn#2). spored stays platform-agnostic; it just POSTs `platform: discord`.

## Tests

`discord_test.go`: embed color-by-severity, fields (instance/region/URL), unknown-event default. `go test ./...` + `go vet` green.