### PR TITLE
feat(spore-bot): Discord slash commands — Phase 2 of spawn#2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ own changelogs for CLI releases.
   instance/region/URL fields) to the workspace's channel webhook. Adds a
   `PublicKey` field to the workspace registry for Discord's Ed25519 interaction
   verification (used by Phase 2 slash commands). New `docs/guides/discord-setup.md`.
+- **spore-bot** Discord slash commands (Phase 2 of spore-host/spawn#2): a
+  `/discord` interactions endpoint verifies Discord's Ed25519 request signature
+  (per-application public key), answers the PING/PONG handshake, and dispatches
+  `/spore list|status|start|stop|hibernate|url|extend|connect` through the same
+  async action machinery as Slack/Teams — replying with a deferred ack and
+  editing in the result (meeting Discord's 3-second deadline). Multi-tenant: any
+  guild installs the published app and registers via `spawn notify workspace-add
+  --platform discord`. New `scripts/register-discord-commands.sh` registers the
+  global slash command; setup guide extended with the Phase 2 install flow.
 - **spore-bot** honors the friendly account-name DNS segment: it displays
   `{name}.{account-name}.spore.host` when the instance has a `spawn:account-name`
   tag (falling back to base36) and matches a user-typed target against either

--- a/docs/guides/discord-setup.md
+++ b/docs/guides/discord-setup.md
@@ -77,3 +77,52 @@ posts the embed to your channel webhook.
 
 That's it — you'll see embeds in the channel as the instance warns, stops, or
 completes.
+
+## Phase 2: Slash commands (`/spore` in your own server)
+
+Add the spore-bot **application** to your guild so members can run
+`/spore list|status|start|stop|hibernate|url|extend|connect` — your instances,
+your server. This is separate from the community spore.host server; you install
+the app wherever you want to control spores.
+
+### 1. Configure the application
+
+In your Discord application (from Step 2 above):
+
+1. **General Information → Interactions Endpoint URL**: set it to the spore-bot
+   service URL with a `/discord` suffix, e.g.
+   `https://<spore-bot-function-url>/discord`. Discord sends a signed PING;
+   spore-bot answers the PONG, so save succeeds only once the endpoint is live
+   and your application **Public Key** is registered (Step 3 below).
+2. **Installation / OAuth2**: add an install link with the `applications.commands`
+   (and `bot`, if you want notifications via the bot) scopes, then add the app to
+   your server.
+
+### 2. Register the slash command (one-time)
+
+```bash
+DISCORD_APP_ID=<application-id> DISCORD_BOT_TOKEN=<bot-token> \
+  ./scripts/register-discord-commands.sh
+# fast testing in a single guild (instant vs ~1h global propagation):
+DISCORD_APP_ID=… DISCORD_BOT_TOKEN=… DISCORD_TEST_GUILD_ID=<guild> \
+  ./scripts/register-discord-commands.sh
+```
+
+### 3. Register your guild + its public key
+
+So spore-bot can verify your guild's interactions and map commands to your
+instances:
+
+```bash
+spawn notify workspace-add --platform discord \
+  --workspace-id <YOUR_GUILD_ID> \
+  --public-key <APPLICATION_PUBLIC_KEY>
+spawn notify register --platform discord \
+  --workspace-id <YOUR_GUILD_ID> --user-id <YOUR_DISCORD_USER_ID> \
+  --instance i-0abc… --nickname rstudio --allow status,stop,extend
+```
+
+Now `/spore status rstudio` in your server returns your instance's state, TTL,
+and URL; `/spore extend rstudio 4h` extends its deadline — all verified against
+your application's Ed25519 key. The bot replies "thinking…" and edits in the
+result (Discord's 3-second deadline is met by a deferred response).

--- a/lambda/spore-bot/discord.go
+++ b/lambda/spore-bot/discord.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -107,4 +109,122 @@ func postDiscordWebhook(webhookURL string, embed discordEmbed) {
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
 		logf("discord webhook returned %d", resp.StatusCode)
 	}
+}
+
+// ── Discord interactions (slash commands) — Phase 2 (#2) ─────────────────────
+//
+// Discord posts every interaction to a single application-wide HTTPS endpoint,
+// signed with the application's Ed25519 key (no per-guild secret). The flow:
+//   1. verify the Ed25519 signature over (timestamp + raw body) using the app's
+//      public key (stored per workspace; one app → one key);
+//   2. reply to PING (type 1) with PONG (type 2) — Discord's endpoint handshake;
+//   3. for an APPLICATION_COMMAND (type 2), parse it into a SlashCommand, ACK
+//      with a DEFERRED response (type 5) within 3s, and post the real result via
+//      the interaction follow-up webhook (executeAction → postDiscordResponse).
+
+// Discord interaction + response type constants.
+const (
+	discordInteractionPing               = 1
+	discordInteractionApplicationCommand = 2
+
+	discordResponsePong               = 1
+	discordResponseDeferredChannelMsg = 5 // "thinking…" ack; result posted via follow-up
+)
+
+// discordInteraction is the subset of Discord's interaction payload we read.
+type discordInteraction struct {
+	Type    int    `json:"type"`
+	ID      string `json:"id"`
+	Token   string `json:"token"`
+	AppID   string `json:"application_id"`
+	GuildID string `json:"guild_id"`
+	Data    struct {
+		Name    string `json:"name"` // the command, e.g. "spore"
+		Options []struct {
+			Name  string          `json:"name"`
+			Value json.RawMessage `json:"value"`
+		} `json:"options"`
+	} `json:"data"`
+	Member struct {
+		User struct {
+			ID string `json:"id"`
+		} `json:"user"`
+	} `json:"member"`
+	User struct {
+		ID string `json:"id"`
+	} `json:"user"`
+}
+
+// verifyDiscordSignature checks the Ed25519 signature Discord puts on every
+// interaction request: sig is over (timestamp || body), verified with the
+// application's public key (hex). All three inputs come from the request.
+func verifyDiscordSignature(publicKeyHex, signatureHex, timestamp string, body []byte) error {
+	if publicKeyHex == "" {
+		return fmt.Errorf("no Discord public key configured for this application")
+	}
+	pubKey, err := hex.DecodeString(publicKeyHex)
+	if err != nil || len(pubKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid Discord public key")
+	}
+	sig, err := hex.DecodeString(signatureHex)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("invalid Discord signature")
+	}
+	msg := append([]byte(timestamp), body...)
+	if !ed25519.Verify(ed25519.PublicKey(pubKey), msg, sig) {
+		return fmt.Errorf("Discord signature verification failed")
+	}
+	return nil
+}
+
+// discordUserID returns the invoking user's ID from either the guild (member) or
+// DM (user) shape of an interaction.
+func (i *discordInteraction) discordUserID() string {
+	if i.Member.User.ID != "" {
+		return i.Member.User.ID
+	}
+	return i.User.ID
+}
+
+// discordOptionValue returns the string value of a named subcommand option.
+func (i *discordInteraction) optionString(name string) string {
+	for _, o := range i.Data.Options {
+		if o.Name == name {
+			var s string
+			if json.Unmarshal(o.Value, &s) == nil {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// discordFollowupURL is the webhook URL for posting the deferred result of an
+// interaction (PATCH/POST the original response). Editing the original message
+// uses .../messages/@original; a fresh follow-up POSTs to the base URL.
+func discordFollowupURL(appID, token string) string {
+	return fmt.Sprintf("https://discord.com/api/v10/webhooks/%s/%s/messages/@original", appID, token)
+}
+
+// postDiscordResponse delivers an async command result to a Discord interaction
+// by editing the deferred ("thinking…") message via the follow-up webhook. Used
+// by postResponse's "discord" case (#2).
+func postDiscordResponse(followupURL, text string) error {
+	payload, _ := json.Marshal(map[string]string{"content": text})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "PATCH", followupURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("discord follow-up request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("discord follow-up call: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("discord follow-up returned %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/lambda/spore-bot/discord_test.go
+++ b/lambda/spore-bot/discord_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -62,5 +65,80 @@ func TestBuildDiscordEmbed_UnknownEventDefaultsBlue(t *testing.T) {
 	e := buildDiscordEmbed(NotifyRequest{EventType: "something_new", InstanceName: "x"})
 	if e.Color != discordColorBlue {
 		t.Errorf("unknown event color = %#x, want blue", e.Color)
+	}
+}
+
+func TestVerifyDiscordSignature_Valid(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	ts := "1700000000"
+	body := []byte(`{"type":1}`)
+	sig := ed25519.Sign(priv, append([]byte(ts), body...))
+	err := verifyDiscordSignature(hex.EncodeToString(pub), hex.EncodeToString(sig), ts, body)
+	if err != nil {
+		t.Errorf("valid signature rejected: %v", err)
+	}
+}
+
+func TestVerifyDiscordSignature_Tampered(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	ts := "1700000000"
+	sig := ed25519.Sign(priv, append([]byte(ts), []byte(`{"type":1}`)...))
+	// Verify against a DIFFERENT body — must fail.
+	err := verifyDiscordSignature(hex.EncodeToString(pub), hex.EncodeToString(sig), ts, []byte(`{"type":2}`))
+	if err == nil {
+		t.Error("tampered body passed verification")
+	}
+}
+
+func TestVerifyDiscordSignature_WrongKey(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	otherPub, _, _ := ed25519.GenerateKey(nil)
+	ts := "1700000000"
+	body := []byte(`{"type":1}`)
+	sig := ed25519.Sign(priv, append([]byte(ts), body...))
+	if err := verifyDiscordSignature(hex.EncodeToString(otherPub), hex.EncodeToString(sig), ts, body); err == nil {
+		t.Error("signature verified against the wrong public key")
+	}
+}
+
+func TestVerifyDiscordSignature_BadInputs(t *testing.T) {
+	if err := verifyDiscordSignature("", "aa", "1", []byte("x")); err == nil {
+		t.Error("empty public key should error")
+	}
+	if err := verifyDiscordSignature("zzzz", "aa", "1", []byte("x")); err == nil {
+		t.Error("non-hex public key should error")
+	}
+}
+
+func TestDiscordInteraction_ParseOptions(t *testing.T) {
+	raw := `{
+	  "type": 2, "guild_id": "g1", "application_id": "app1", "token": "tok1",
+	  "member": {"user": {"id": "u123"}},
+	  "data": {"name": "spore", "options": [
+	    {"name": "command", "value": "status"},
+	    {"name": "name", "value": "rstudio"},
+	    {"name": "arg", "value": "4h"}
+	  ]}
+	}`
+	var it discordInteraction
+	if err := json.Unmarshal([]byte(raw), &it); err != nil {
+		t.Fatal(err)
+	}
+	if it.discordUserID() != "u123" {
+		t.Errorf("user id = %q, want u123", it.discordUserID())
+	}
+	if it.optionString("command") != "status" || it.optionString("name") != "rstudio" || it.optionString("arg") != "4h" {
+		t.Errorf("options parsed wrong: cmd=%q name=%q arg=%q", it.optionString("command"), it.optionString("name"), it.optionString("arg"))
+	}
+	if it.optionString("missing") != "" {
+		t.Error("missing option should be empty")
+	}
+}
+
+func TestDiscordFollowupURL(t *testing.T) {
+	got := discordFollowupURL("app1", "tok1")
+	want := "https://discord.com/api/v10/webhooks/app1/tok1/messages/@original"
+	if got != want {
+		t.Errorf("followup url = %q, want %q", got, want)
 	}
 }

--- a/lambda/spore-bot/executor.go
+++ b/lambda/spore-bot/executor.go
@@ -693,6 +693,8 @@ func postResponse(platform, responseURL, text string) error {
 		return postSlackResponse(responseURL, text, false)
 	case "teams":
 		return postTeamsResponse(responseURL, text)
+	case "discord":
+		return postDiscordResponse(responseURL, text)
 	default:
 		return fmt.Errorf("unknown platform: %s", platform)
 	}

--- a/lambda/spore-bot/handler.go
+++ b/lambda/spore-bot/handler.go
@@ -19,6 +19,13 @@ func handleWebhook(ctx context.Context, cfg aws.Config, reg *Registry, request e
 	var platform string
 	var err error
 
+	// Discord interactions are their own flow: a single app-wide endpoint, Ed25519
+	// verification, a PING/PONG handshake, and a synchronous DEFERRED ack with the
+	// real result delivered via follow-up. Handle it before the Slack/Teams path (#2).
+	if strings.HasSuffix(path, "/discord") {
+		return handleDiscordWebhook(ctx, cfg, reg, request)
+	}
+
 	// Handle Slack URL verification challenge before any signature checking.
 	// Slack sends this once when a slash command endpoint is configured.
 	if strings.HasSuffix(path, "/slack") {
@@ -96,6 +103,78 @@ func handleWebhook(ctx context.Context, cfg aws.Config, reg *Registry, request e
 		go executeAction(context.Background(), cfg, reg, action)
 	}
 	return jsonResp(200, fmt.Sprintf(`{"text":%q}`, ackMessage(command, nickname))), nil
+}
+
+// handleDiscordWebhook verifies a Discord interaction (Ed25519), answers the
+// PING handshake, and for a slash command ACKs with a DEFERRED response while
+// the real result is computed async and delivered via the interaction follow-up
+// webhook (#2). Discord's 3-second deadline is met by the deferred ack.
+func handleDiscordWebhook(ctx context.Context, cfg aws.Config, reg *Registry, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	sig := headerLookup(request.Headers, "X-Signature-Ed25519")
+	ts := headerLookup(request.Headers, "X-Signature-Timestamp")
+	body := []byte(request.Body)
+
+	// Parse first to learn the guild, so we can fetch its app public key. (We
+	// verify before acting on anything; an unparseable body fails closed.)
+	var it discordInteraction
+	if err := json.Unmarshal(body, &it); err != nil {
+		return errorResp(400, "invalid interaction body"), nil
+	}
+
+	ws, err := reg.GetWorkspace(ctx, "discord", it.GuildID)
+	if err != nil || ws == nil {
+		logf("discord: no workspace for guild %s", it.GuildID)
+		return errorResp(401, "unknown guild"), nil
+	}
+	if err := verifyDiscordSignature(ws.PublicKey, sig, ts, body); err != nil {
+		logf("discord signature verification failed (guild %s): %v", it.GuildID, err)
+		return errorResp(401, "invalid request signature"), nil
+	}
+
+	// PING → PONG handshake (Discord verifies the endpoint this way).
+	if it.Type == discordInteractionPing {
+		return jsonResp(200, fmt.Sprintf(`{"type":%d}`, discordResponsePong)), nil
+	}
+
+	if it.Type != discordInteractionApplicationCommand {
+		// Components/autocomplete/etc. aren't used yet — ack harmlessly.
+		return jsonResp(200, fmt.Sprintf(`{"type":%d}`, discordResponsePong)), nil
+	}
+
+	// Map the slash command. We model `/spore <command> <nickname> [arg]` as
+	// subcommand options so it mirrors the Slack/Teams text parse.
+	command := it.optionString("command")
+	if command == "" {
+		command = "help"
+	}
+	action := &BotAction{
+		Platform:     "discord",
+		WorkspaceID:  it.GuildID,
+		UserID:       it.discordUserID(),
+		ResponseURL:  discordFollowupURL(it.AppID, it.Token),
+		Command:      command,
+		Nickname:     it.optionString("name"),
+		Arg:          it.optionString("arg"),
+		SlashCommand: "/" + it.Data.Name,
+	}
+
+	// Kick off the real work async; the deferred ack below buys >3s.
+	if err := invokeAsync(ctx, action); err != nil {
+		logf("discord async invoke failed: %v", err)
+		go executeAction(context.Background(), cfg, reg, action)
+	}
+	// DEFERRED ack: shows "spore-bot is thinking…"; executeAction edits it with
+	// the result via postDiscordResponse.
+	return jsonResp(200, fmt.Sprintf(`{"type":%d}`, discordResponseDeferredChannelMsg)), nil
+}
+
+// headerLookup returns a header value, tolerating canonical and lowercased keys
+// (API Gateway / Function URL casing varies).
+func headerLookup(headers map[string]string, key string) string {
+	if v := headers[key]; v != "" {
+		return v
+	}
+	return headers[strings.ToLower(key)]
 }
 
 // handleSlackWebhook verifies the Slack signature and parses the slash command.

--- a/scripts/register-discord-commands.sh
+++ b/scripts/register-discord-commands.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Register spore-bot's global Discord slash commands (one-time, per application).
+#
+# Discord application commands are registered once on the application; they then
+# appear in every guild that installs the app. Re-run after changing the command
+# shape. Globals can take up to ~1h to propagate (guild-scoped is instant — see
+# below for testing).
+#
+# Usage:
+#   DISCORD_APP_ID=...  DISCORD_BOT_TOKEN=...  ./register-discord-commands.sh
+#   # fast iteration in ONE test guild (instant propagation):
+#   DISCORD_APP_ID=...  DISCORD_BOT_TOKEN=...  DISCORD_TEST_GUILD_ID=...  ./register-discord-commands.sh
+#
+# Models `/spore <command> [name] [arg]` as a single command with options, so it
+# maps onto the same {command,nickname,arg} the handler parses for Slack/Teams.
+set -euo pipefail
+
+: "${DISCORD_APP_ID:?set DISCORD_APP_ID (Application ID)}"
+: "${DISCORD_BOT_TOKEN:?set DISCORD_BOT_TOKEN (Bot token)}"
+CMD_NAME="${SPORE_COMMAND_NAME:-spore}"
+
+if [[ -n "${DISCORD_TEST_GUILD_ID:-}" ]]; then
+  URL="https://discord.com/api/v10/applications/${DISCORD_APP_ID}/guilds/${DISCORD_TEST_GUILD_ID}/commands"
+  echo "Registering /${CMD_NAME} in test guild ${DISCORD_TEST_GUILD_ID} (instant)…"
+else
+  URL="https://discord.com/api/v10/applications/${DISCORD_APP_ID}/commands"
+  echo "Registering GLOBAL /${CMD_NAME} (may take up to ~1h to appear everywhere)…"
+fi
+
+# Option type 3 = STRING. `command` is required; name/arg optional.
+read -r -d '' PAYLOAD <<JSON || true
+{
+  "name": "${CMD_NAME}",
+  "type": 1,
+  "description": "Control your spore.host instances",
+  "options": [
+    { "name": "command", "description": "list, status, start, stop, hibernate, url, extend, connect, help", "type": 3, "required": true },
+    { "name": "name", "description": "instance nickname (e.g. rstudio)", "type": 3, "required": false },
+    { "name": "arg", "description": "extra argument (e.g. a duration for extend)", "type": 3, "required": false }
+  ]
+}
+JSON
+
+curl -sS -X POST "$URL" \
+  -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" | { command -v jq >/dev/null 2>&1 && jq . || cat; }
+
+echo
+echo "Done. Set the application's Interactions Endpoint URL to the spore-bot Function URL + /discord."


### PR DESCRIPTION
Phase 2 of spore-host/spawn#2 — the inbound `/spore` Discord slash commands. Multi-tenant: a published spore-bot app that **any user installs into their own guild** to control their instances (distinct from the community spore.host server). Phase 1 (notifications) shipped earlier.

## What

A single application-wide `/discord` interactions endpoint, slotted into the existing Lambda Function URL alongside `/slack` and `/teams`:

- **`discord.go`** — `verifyDiscordSignature` (Ed25519 over `timestamp+body`, per-**application** public key; Discord has no signing secret), interaction parsing (options → `{command, name, arg}`, user/guild extraction), and `postDiscordResponse` (edits the deferred message via the interaction follow-up webhook).
- **`handler.go`** — `/discord` route: look up the guild's workspace → **verify Ed25519** → answer the **PING/PONG** handshake → for an application command, build the same `BotAction` the Slack/Teams paths use, **ACK with a DEFERRED response (type 5)** within Discord's 3-second window, and invoke async. The result is edited in via the follow-up webhook.
- **`executor.go`** — `postResponse` gains a `discord` case → `postDiscordResponse`.
- **`scripts/register-discord-commands.sh`** — one-time global slash-command registration (`/spore <command> [name] [arg]` modeled as options so it maps onto the existing parse), with a test-guild fast path.
- **`docs/guides/discord-setup.md`** — extended with the Phase 2 install/registration flow.

## Multi-tenant by design

Reuses the existing registry keyed by `{platform}#{workspace-id}` — a guild is just a workspace. `spawn notify workspace-add --platform discord --workspace-id <guild> --public-key <app-key>` (shipped in Phase 1) is how each guild registers. One app, one global command, one Ed25519 key; every installing guild verified against it.

## Tests

`discord_test.go` adds: Ed25519 verify (valid / tampered body / wrong key / bad inputs), interaction option+user parsing, follow-up URL. `go test ./...` + `go vet` green.

## Manual validation (post-deploy)

Discord's endpoint-verification PING and a real `/spore status` require the deployed Function URL + a registered application public key — to be exercised once deployed, the same way Phase 1's notifications were validated against a live webhook. Closes the two-phase #2 once verified.