### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Report something in spore-host that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug in **spore-host** (spore.host umbrella / infrastructure).
+        Please search existing issues first to avoid duplicates.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, and what went wrong?
+      placeholder: Describe the bug and the steps to reproduce it.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Output / logs
+      description: Relevant command output, error messages, or logs. Redact credentials, webhook URLs, and private resource IDs.
+      render: shell
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of the tool's `version` command, or the release tag.
+      placeholder: "e.g. spore-host v0.52.0"
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      placeholder: "OS / arch / AWS region, e.g. macOS arm64, us-west-2"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Community chat (Discord)
+    url: https://discord.gg/2deGRFCW
+    about: Questions, help, and discussion — faster than an issue for usage questions.
+  - name: 📖 Documentation
+    url: https://spore.host/docs
+    about: Guides and reference for the spore.host tools.
+  - name: 🔒 Security issue
+    url: https://github.com/spore-host/spore-host/security/advisories/new
+    about: Report a vulnerability privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest an enhancement for spore-host
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea for **spore-host** (spore.host umbrella / infrastructure).
+        Search existing issues first — someone may have proposed it already.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case or pain point motivating the request.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to happen. Sketch the CLI/flag/behavior if you can.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered


### PR DESCRIPTION
Adds GitHub issue forms (bug report + feature request) and a chooser for the umbrella repo, consistent with the per-tool repos. Chooser routes usage questions to the spore.host Discord (discord.gg/2deGRFCW), docs to spore.host/docs, and security to a private advisory. Template-only.