### PR TITLE
fix(spore-bot): verify Discord interactions against the app public key (#2)

### DIFF
--- a/lambda/spore-bot/handler.go
+++ b/lambda/spore-bot/handler.go
@@ -114,24 +114,23 @@ func handleDiscordWebhook(ctx context.Context, cfg aws.Config, reg *Registry, re
 	ts := headerLookup(request.Headers, "X-Signature-Timestamp")
 	body := []byte(request.Body)
 
-	// Parse first to learn the guild, so we can fetch its app public key. (We
-	// verify before acting on anything; an unparseable body fails closed.)
+	// Verify against the APPLICATION public key — Discord signs every interaction
+	// with the app's single Ed25519 key (one per application, not per guild), and
+	// the endpoint-verification PING carries no guild at all. So verification must
+	// use the app key (DISCORD_PUBLIC_KEY) independent of guild; the per-guild
+	// workspace lookup happens later, only to authorize the command (#2).
+	if err := verifyDiscordSignature(discordPublicKey, sig, ts, body); err != nil {
+		logf("discord signature verification failed: %v", err)
+		return errorResp(401, "invalid request signature"), nil
+	}
+
 	var it discordInteraction
 	if err := json.Unmarshal(body, &it); err != nil {
 		return errorResp(400, "invalid interaction body"), nil
 	}
 
-	ws, err := reg.GetWorkspace(ctx, "discord", it.GuildID)
-	if err != nil || ws == nil {
-		logf("discord: no workspace for guild %s", it.GuildID)
-		return errorResp(401, "unknown guild"), nil
-	}
-	if err := verifyDiscordSignature(ws.PublicKey, sig, ts, body); err != nil {
-		logf("discord signature verification failed (guild %s): %v", it.GuildID, err)
-		return errorResp(401, "invalid request signature"), nil
-	}
-
-	// PING → PONG handshake (Discord verifies the endpoint this way).
+	// PING → PONG handshake (Discord verifies the endpoint this way). This must
+	// work with no workspace registered — it's an app-level health check.
 	if it.Type == discordInteractionPing {
 		return jsonResp(200, fmt.Sprintf(`{"type":%d}`, discordResponsePong)), nil
 	}
@@ -139,6 +138,13 @@ func handleDiscordWebhook(ctx context.Context, cfg aws.Config, reg *Registry, re
 	if it.Type != discordInteractionApplicationCommand {
 		// Components/autocomplete/etc. aren't used yet — ack harmlessly.
 		return jsonResp(200, fmt.Sprintf(`{"type":%d}`, discordResponsePong)), nil
+	}
+
+	// Authorize: the guild must be a registered workspace before we act on a
+	// command (verification above already proved the request is genuinely Discord).
+	if ws, err := reg.GetWorkspace(ctx, "discord", it.GuildID); err != nil || ws == nil {
+		logf("discord: command from unregistered guild %s", it.GuildID)
+		return jsonResp(200, `{"type":4,"data":{"content":"This server isn't set up with spore-bot yet. An admin can run: spawn notify workspace-add --platform discord --workspace-id <guild> --public-key <key>"}}`), nil
 	}
 
 	// Map the slash command. We model `/spore <command> <nickname> [arg]` as

--- a/lambda/spore-bot/main.go
+++ b/lambda/spore-bot/main.go
@@ -26,7 +26,11 @@ var (
 	auditor      *Auditor
 	lambdaClient *lambdasvc.Client
 	functionName string
-	httpClient   = &http.Client{Timeout: 15 * time.Second}
+	// discordPublicKey is the spore-bot Discord application's Ed25519 public key
+	// (hex), used to verify all inbound Discord interactions. One per application
+	// (#2). Set via the DISCORD_PUBLIC_KEY env var.
+	discordPublicKey string
+	httpClient       = &http.Client{Timeout: 15 * time.Second}
 )
 
 func init() {
@@ -40,6 +44,7 @@ func init() {
 	auditor = NewAuditor(cfg)
 	lambdaClient = lambdasvc.NewFromConfig(cfg)
 	functionName = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+	discordPublicKey = os.Getenv("DISCORD_PUBLIC_KEY")
 }
 
 // handler routes between webhook (Phase 1), admin API, and async action (Phase 2).


### PR DESCRIPTION
Fixes the Phase 2 endpoint verification — caught during live setup ("interactions_endpoint_url could not be verified").

## Bug

The handler verified the Ed25519 signature against a **per-guild** workspace's stored public key, and returned 401 "unknown guild" when none was registered. But:
- Discord signs every interaction with the **application's single** Ed25519 key (one per app, not per guild).
- The endpoint-verification PING carries **no guild** at all.

So the Interactions Endpoint URL could never verify (no workspace → 401 on the PING), and any guild that hadn't run `workspace-add` would have valid interactions rejected.

## Fix

- Verify against `DISCORD_PUBLIC_KEY` (the **app** key, from env) **before** anything else.
- Answer **PING/PONG with no workspace required** (it's an app-level health check).
- Do the per-guild workspace lookup **after** verification, only to **authorize** a command — an unregistered guild now gets a friendly setup hint (interaction type 4) instead of a 401.

## Verified live

Deployed to the production `spore-bot` Lambda (direct `update-function-code` — the function isn't stack-managed; see infra-debt note below) with `DISCORD_PUBLIC_KEY` set. The Discord developer portal **successfully verified** the Interactions Endpoint URL (signed PING → PONG). A bad-signature POST returns 401, not a crash.

## Note

The `spore-bot` function is hand-deployed (no CloudFormation; its stack is stuck empty in REVIEW_IN_PROGRESS). Reconciling it under IaC is tracked separately.