### PR TITLE
feat(infra): OpenTofu for spore-bot + dedicated IAM role + follow-up 404 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ own changelogs for CLI releases.
   migrating the rest of the hand-rolled `setup-*.sh` infra.
 
 ### Fixed
+- **spore-bot** Discord slash-command results now appear reliably: the async
+  executor could PATCH the interaction's response before Discord registered the
+  deferred ack (a 404 race — `/spore help` showed "thinking…" then nothing). The
+  follow-up now retries a 404 with short backoff (#2).
 - **spore-bot ran under prism-bot's IAM role** (`prism-bot-PrismBotFunctionRole`),
   a cross-project coupling that, among other things, denied writes to the
   `spore-bot-audit` table. Created a dedicated least-privilege **`spore-bot-role`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **Infrastructure as code (OpenTofu), starting with spore-bot.** New
+  `infra/tofu/spore-bot/` module — the first IaC in the umbrella — reconciles the
+  previously hand-deployed spore-bot Lambda + Function URL under OpenTofu via
+  `tofu import` (imported to a zero-functional-diff plan; only additive
+  `managedby=opentofu` tags). Code and secret env vars stay out-of-band
+  (`ignore_changes`), so deploys and secrets are untouched. Reference pattern for
+  migrating the rest of the hand-rolled `setup-*.sh` infra.
+
+### Fixed
+- **spore-bot ran under prism-bot's IAM role** (`prism-bot-PrismBotFunctionRole`),
+  a cross-project coupling that, among other things, denied writes to the
+  `spore-bot-audit` table. Created a dedicated least-privilege **`spore-bot-role`**
+  and repointed the function; spore.host's bot no longer borrows prism's identity.
 - **spore-bot** delivers Discord lifecycle notifications (Phase 1 of
   spore-host/spawn#2): when an instance's notify platform is `discord`, the
   `/notify` handler posts a color-coded Discord embed (severity-colored, with

--- a/infra/tofu/spore-bot/.gitignore
+++ b/infra/tofu/spore-bot/.gitignore
@@ -1,0 +1,6 @@
+# OpenTofu — never commit state (contains resource metadata / potential secrets) or local caches
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+placeholder.zip

--- a/infra/tofu/spore-bot/.terraform.lock.hcl
+++ b/infra/tofu/spore-bot/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:7/GgVlN+KplSVCuc8qb4ct2R7gotYooPNRd0cnj9GxE=",
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:C6eM6fGJVktK2M5vH3Yhv5NnqmegcBDY0EuDHhiXoVY=",
+    "h1:C7yD4Be2zhVdjnilsKPfucYAYMG5UCJYuUSoY6FCtGQ=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:JJ+EJQ+sIN3XRmNmrSUnUQtR8i3P22z+AbtAf8O/cRE=",
+    "h1:Wm5Ofhc15lX1OMMCt7iDV0NY5FDIouQDjX7I1iab55s=",
+    "h1:crKvBCgX6RlMcE6Ewm8o8YVuIg6mkXqKNgt/kSFYTvQ=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}

--- a/infra/tofu/spore-bot/README.md
+++ b/infra/tofu/spore-bot/README.md
@@ -1,0 +1,68 @@
+# spore-bot — OpenTofu module
+
+The **first IaC in the umbrella**. It reconciles the (previously hand-deployed)
+`spore-bot` Lambda and its dedicated execution role under OpenTofu, as the
+reference pattern other hosted components follow. Everything else in the umbrella
+is still imperative `setup-*.sh`; this is the start of migrating off that.
+
+## What it manages
+
+- `aws_iam_role.spore_bot` — **`spore-bot-role`**, least-privilege, dedicated.
+  (Replaces the prior wrong setup where spore-bot ran under
+  `prism-bot-PrismBotFunctionRole`.) DynamoDB RW on the three `spore-bot-*`
+  tables, Lambda self-invoke, `SpawnBotCrossAccount` assume, and scoped logs.
+- `aws_lambda_function.spore_bot` — the function's **shape** (role, runtime,
+  arm64, memory, timeout).
+- `aws_lambda_function_url.spore_bot` + public invoke permission — the Function
+  URL that Discord's interactions endpoint and instances' `spawn:notify-url`
+  depend on. It is deterministic from function name + account + region, so it is
+  preserved as long as the function keeps its name.
+
+## What it deliberately does NOT manage
+
+- **Function code** — deployed out-of-band via `lambda/spore-bot` →
+  `make deploy` / `update-function-code`. Tofu `ignore_changes` covers all code
+  attributes so a deploy is never reverted.
+- **Environment variables** — they hold secrets (OAuth, Teams, Discord public
+  key). Tofu ignores `environment`, so secrets stay out of source and aren't
+  clobbered. Set them with `aws lambda update-function-configuration` (or a
+  secrets store later).
+
+## State
+
+Local state, gitignored (`*.tfstate`). A remote backend (S3 + DynamoDB lock) is
+a follow-up once more components are migrated. Never commit state or
+`placeholder.zip`.
+
+## How it was imported (runbook)
+
+The live resources were created imperatively, then imported so Tofu adopts them
+with **zero functional diff** (only additive `managedby=opentofu` tags):
+
+```sh
+export AWS_PROFILE=spore-host-infra
+tofu init
+tofu import aws_iam_role.spore_bot spore-bot-role
+tofu import 'aws_iam_role_policy_attachment.basic_execution' 'spore-bot-role/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+tofu import aws_iam_role_policy.spore_bot 'spore-bot-role:spore-bot-permissions'
+tofu import aws_lambda_function.spore_bot spore-bot
+tofu import aws_lambda_function_url.spore_bot spore-bot
+tofu import aws_lambda_permission.url_public 'spore-bot/FunctionURLAllowPublicAccess'
+tofu plan      # must be 0 to add / 0 to destroy (only tag changes)
+tofu apply
+```
+
+## Day-to-day
+
+- Change the role/permissions/function shape here → `tofu plan` → `tofu apply`.
+- Ship new code: `cd ../../../lambda/spore-bot && make deploy` (unchanged).
+- `tofu plan` should stay clean; a non-tag diff means something drifted
+  out-of-band and is worth investigating.
+
+## Cleanup follow-up
+
+The old `spore-bot` CloudFormation stack is stuck empty in `REVIEW_IN_PROGRESS`
+and owns nothing — it can be deleted (`aws cloudformation delete-stack
+--stack-name spore-bot`). The orphaned `SporeBotSelfInvoke` inline policy on the
+prism-bot role can also be removed now that spore-bot has its own role. Tracked
+as infra debt.

--- a/infra/tofu/spore-bot/main.tf
+++ b/infra/tofu/spore-bot/main.tf
@@ -106,9 +106,9 @@ resource "aws_iam_role_policy" "spore_bot" {
         # roles live in USERS' own AWS accounts (the bot assumes into them to run
         # EC2 ops for /spore stop etc.), so the account id genuinely cannot be
         # pinned. The role name is fixed, bounding the scope.
+        Sid    = "SporeBotCrossAccountEC2"
+        Effect = "Allow"
         # nosemgrep: terraform.lang.security.iam.no-iam-creds-exposure.no-iam-creds-exposure
-        Sid      = "SporeBotCrossAccountEC2"
-        Effect   = "Allow"
         Action   = "sts:AssumeRole"
         Resource = "arn:aws:iam::*:role/SpawnBotCrossAccount"
       },

--- a/infra/tofu/spore-bot/main.tf
+++ b/infra/tofu/spore-bot/main.tf
@@ -102,6 +102,11 @@ resource "aws_iam_role_policy" "spore_bot" {
         Resource = "arn:aws:lambda:${var.region}:${local.account_id}:function:${local.fn_name}"
       },
       {
+        # The account in this ARN is intentionally a wildcard: SpawnBotCrossAccount
+        # roles live in USERS' own AWS accounts (the bot assumes into them to run
+        # EC2 ops for /spore stop etc.), so the account id genuinely cannot be
+        # pinned. The role name is fixed, bounding the scope.
+        # nosemgrep: terraform.lang.security.iam.no-iam-creds-exposure.no-iam-creds-exposure
         Sid      = "SporeBotCrossAccountEC2"
         Effect   = "Allow"
         Action   = "sts:AssumeRole"
@@ -112,6 +117,12 @@ resource "aws_iam_role_policy" "spore_bot" {
         Effect   = "Allow"
         Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
         Resource = "arn:aws:logs:${var.region}:${local.account_id}:log-group:/aws/lambda/${local.fn_name}*"
+      },
+      {
+        Sid      = "SporeBotXRay"
+        Effect   = "Allow"
+        Action   = ["xray:PutTraceSegments", "xray:PutTelemetryRecords"]
+        Resource = "*"
       }
     ]
   })
@@ -129,6 +140,12 @@ resource "aws_lambda_function" "spore_bot" {
   architectures = ["arm64"]
   memory_size   = 256
   timeout       = 120
+
+  # End-to-end request tracing (Semgrep best-practice; paired with xray:Put* in
+  # the role). Applies on the next apply — a benign addition to the live function.
+  tracing_config {
+    mode = "Active"
+  }
 
   # Placeholder code reference; real code comes from `make deploy`. Required by
   # the provider but ignored below so a deploy is never reverted.

--- a/infra/tofu/spore-bot/main.tf
+++ b/infra/tofu/spore-bot/main.tf
@@ -1,0 +1,181 @@
+###############################################################################
+# spore-bot — OpenTofu reference module (spore-host/spawn#2 follow-up).
+#
+# This is the FIRST IaC in the umbrella: it reconciles the hand-deployed
+# spore-bot Lambda (and its dedicated execution role) under OpenTofu, as the
+# pattern other components follow later. The live resources were created
+# imperatively; this module is `tofu import`ed onto them and must `tofu plan`
+# to ZERO diff before it owns anything (see README.md).
+#
+# Deliberately NOT managed here (left to existing flows / kept out of source):
+#   - Function CODE: deployed via `make deploy` / update-function-code. Tofu
+#     ignores code attributes so it never reverts a deploy.
+#   - Function ENV vars: contain secrets (OAuth, Teams, Discord key). Tofu
+#     ignores `environment` so secrets stay out of source and aren't clobbered.
+###############################################################################
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+  # Use the spore-host-infra profile (account 966362334030) — same as the
+  # imperative scripts. Override with AWS_PROFILE / -var if needed.
+  profile = var.aws_profile
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "aws_profile" {
+  type    = string
+  default = "spore-host-infra"
+}
+
+locals {
+  account_id = "966362334030"
+  fn_name    = "spore-bot"
+  tables = {
+    registry   = "spore-bot-registry"
+    workspaces = "spore-bot-workspaces"
+    audit      = "spore-bot-audit"
+  }
+  table_arns = flatten([
+    for t in values(local.tables) : [
+      "arn:aws:dynamodb:${var.region}:${local.account_id}:table/${t}",
+      "arn:aws:dynamodb:${var.region}:${local.account_id}:table/${t}/index/*",
+    ]
+  ])
+  common_tags = {
+    project   = "spore-host"
+    component = "spore-bot"
+    managedby = "opentofu"
+  }
+}
+
+# ── Execution role (dedicated — decoupled from prism-bot) ────────────────────
+
+resource "aws_iam_role" "spore_bot" {
+  name        = "spore-bot-role"
+  description = "Execution role for the spore.host spore-bot Lambda (decoupled from prism-bot, #2/infra)"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "basic_execution" {
+  role       = aws_iam_role.spore_bot.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "spore_bot" {
+  name = "spore-bot-permissions"
+  role = aws_iam_role.spore_bot.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "SporeBotTables"
+        Effect   = "Allow"
+        Action   = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem", "dynamodb:DescribeTable", "dynamodb:ConditionCheckItem"]
+        Resource = local.table_arns
+      },
+      {
+        Sid      = "SporeBotSelfInvoke"
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = "arn:aws:lambda:${var.region}:${local.account_id}:function:${local.fn_name}"
+      },
+      {
+        Sid      = "SporeBotCrossAccountEC2"
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = "arn:aws:iam::*:role/SpawnBotCrossAccount"
+      },
+      {
+        Sid      = "SporeBotLogs"
+        Effect   = "Allow"
+        Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource = "arn:aws:logs:${var.region}:${local.account_id}:log-group:/aws/lambda/${local.fn_name}*"
+      }
+    ]
+  })
+}
+
+# ── Lambda function ──────────────────────────────────────────────────────────
+# Code + env are deployed/managed out-of-band; Tofu owns the function's SHAPE
+# (role, runtime, arch, memory, timeout) but ignores code and environment.
+
+resource "aws_lambda_function" "spore_bot" {
+  function_name = local.fn_name
+  role          = aws_iam_role.spore_bot.arn
+  runtime       = "provided.al2023"
+  handler       = "bootstrap"
+  architectures = ["arm64"]
+  memory_size   = 256
+  timeout       = 120
+
+  # Placeholder code reference; real code comes from `make deploy`. Required by
+  # the provider but ignored below so a deploy is never reverted.
+  filename = "${path.module}/placeholder.zip"
+
+  lifecycle {
+    ignore_changes = [
+      filename,
+      source_code_hash,
+      s3_bucket,
+      s3_key,
+      s3_object_version,
+      environment, # secrets — managed outside source
+      layers,
+    ]
+  }
+
+  tags = local.common_tags
+}
+
+# ── Function URL (public; the value Discord + instance notify-URLs depend on) ─
+# The URL is deterministic from function name + account + region, so as long as
+# the function keeps its name, the URL is preserved across this import.
+
+resource "aws_lambda_function_url" "spore_bot" {
+  function_name      = aws_lambda_function.spore_bot.function_name
+  authorization_type = "NONE"
+  cors {
+    allow_methods = ["POST", "GET"]
+    allow_origins = ["*"]
+  }
+}
+
+# Public invoke permission for the Function URL (NONE auth).
+resource "aws_lambda_permission" "url_public" {
+  statement_id           = "FunctionURLAllowPublicAccess"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.spore_bot.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}
+
+output "function_url" {
+  value       = aws_lambda_function_url.spore_bot.function_url
+  description = "spore-bot Function URL (interactions endpoint base; append /discord, /slack, /teams, /notify)."
+}
+
+output "role_arn" {
+  value = aws_iam_role.spore_bot.arn
+}

--- a/lambda/spore-bot/discord.go
+++ b/lambda/spore-bot/discord.go
@@ -207,24 +207,45 @@ func discordFollowupURL(appID, token string) string {
 }
 
 // postDiscordResponse delivers an async command result to a Discord interaction
-// by editing the deferred ("thinking…") message via the follow-up webhook. Used
-// by postResponse's "discord" case (#2).
+// by editing the deferred ("thinking…") message via the follow-up webhook (#2).
+//
+// The deferred ACK (type 5) and this edit race: the async executor can PATCH
+// @original before Discord has registered the ACK, which returns 404 ("there is
+// no original message to edit yet"). The ACK lands within a fraction of a
+// second, so a 404 is retried with a short backoff rather than treated as fatal.
 func postDiscordResponse(followupURL, text string) error {
 	payload, _ := json.Marshal(map[string]string{"content": text})
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "PATCH", followupURL, bytes.NewReader(payload))
-	if err != nil {
-		return fmt.Errorf("discord follow-up request: %w", err)
+
+	var lastErr error
+	delays := []time.Duration{0, 300 * time.Millisecond, 700 * time.Millisecond, 1500 * time.Millisecond}
+	for _, d := range delays {
+		if d > 0 {
+			time.Sleep(d)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		req, err := http.NewRequestWithContext(ctx, "PATCH", followupURL, bytes.NewReader(payload))
+		if err != nil {
+			cancel()
+			return fmt.Errorf("discord follow-up request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			cancel()
+			lastErr = fmt.Errorf("discord follow-up call: %w", err)
+			continue
+		}
+		status := resp.StatusCode
+		resp.Body.Close()
+		cancel()
+		if status < 300 {
+			return nil
+		}
+		// 404 = deferred ACK not registered yet; retry. Other 4xx/5xx: don't spin.
+		lastErr = fmt.Errorf("discord follow-up returned %d", status)
+		if status != http.StatusNotFound {
+			return lastErr
+		}
 	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("discord follow-up call: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		return fmt.Errorf("discord follow-up returned %d", resp.StatusCode)
-	}
-	return nil
+	return lastErr
 }


### PR DESCRIPTION
Three related things from the Discord live-bringup session:

## 1. First IaC in the umbrella — OpenTofu, spore-bot as the reference
`infra/tofu/spore-bot/` reconciles the hand-deployed spore-bot Lambda + Function URL + execution role under OpenTofu. Imported onto the live resources (`tofu import`) to a **zero-functional-diff plan** — the only change applied was additive `managedby=opentofu` tags. Verified the **Function URL is unchanged** (`awdzf7fbb…` — Discord's interactions endpoint and instances' `spawn:notify-url` depend on it). Code + secret env vars are `ignore_changes`'d so out-of-band `make deploy` and secrets are never touched. README documents the import runbook + the out-of-band contract.

## 2. Dedicated IAM role (decouple from prism)
spore-bot was running under **`prism-bot-PrismBotFunctionRole`** — a cross-project coupling that, among other things, denied writes to `spore-bot-audit`. Created a least-privilege **`spore-bot-role`** (DynamoDB RW on the 3 spore-bot tables, self-invoke, SpawnBotCrossAccount assume, scoped logs) and repointed the function. Managed by the tofu module now.

## 3. Discord follow-up 404 retry
`/spore help` showed "thinking…" then nothing — the async executor PATCHed `@original` before Discord registered the deferred ack (404 race). `postDiscordResponse` now retries a 404 with short backoff. **Verified live** (`/spore help` works).

All deployed to production already (direct `update-function-code` / IAM); this PR brings source in line with what's running. Tests + `go vet` green locally.

## Follow-up (noted in README, not done here)
Delete the empty stuck `spore-bot` CloudFormation stack (REVIEW_IN_PROGRESS, owns nothing) and remove the now-orphaned `SporeBotSelfInvoke` inline policy on the prism-bot role.