### PR TITLE
ci(security): scan all Go modules + add gitleaks + Trivy secrets

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,8 +26,37 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
-      - name: govulncheck - rest-api Lambda
-        run: cd lambda/rest-api && go mod tidy && govulncheck ./...
+      - name: Scan all Go modules
+        run: |
+          # Per-module scan: every nested go.mod (spore-bot, rest-api, …), not
+          # just rest-api as before.
+          set -e
+          fail=0
+          for mod in $(find . -name go.mod -not -path '*/vendor/*' | sort); do
+            dir=$(dirname "$mod")
+            echo "::group::govulncheck $dir"
+            ( cd "$dir" && go mod tidy && govulncheck ./... ) || fail=1
+            echo "::endgroup::"
+          done
+          exit $fail
+
+  gitleaks:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      # gitleaks BINARY (MIT, free for orgs); the action wrapper needs a paid
+      # org license. Allowlist in .gitleaks.toml covers doc examples + fixtures.
+      - name: Install gitleaks
+        run: |
+          VER=8.21.2
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: gitleaks detect
+        run: gitleaks detect --source . --redact --verbose --exit-code 1
 
   trivy:
     name: Trivy Security Scan
@@ -35,11 +64,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Trivy filesystem scan
+      - name: Trivy filesystem scan (vulns + secrets)
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: fs
           scan-ref: .
+          scanners: vuln,secret
           severity: HIGH,CRITICAL
           exit-code: 1
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+# gitleaks configuration for spawn.
+# Extends the built-in default ruleset; adds an allowlist for known
+# false positives — documentation examples and security-test fixtures that
+# contain illustrative (fake) keys, not real credentials.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Docs examples and test fixtures contain placeholder secrets, not real ones"
+paths = [
+  '''SECURITY\.md''',
+  '''docs/.*\.md''',
+  '''.*_test\.go''',
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Security
+- Security CI hardened to a consistent gate across the suite: govulncheck now
+  scans **all** Go modules (added `spore-bot` — previously only `rest-api`),
+  added **gitleaks** secret scanning (MIT binary; org-license-free; allowlist for
+  doc examples + test fixtures), and Trivy's filesystem scan now includes the
+  **secret** scanner. The same Security workflow (govulncheck/gitleaks/Trivy/
+  Semgrep) was added to the previously-unscanned tool repos (spawn, truffle,
+  lagotto, nf-spawn, spore-host-mcp).
+
 ### Added
 - **Infrastructure as code (OpenTofu), starting with spore-bot.** New
   `infra/tofu/spore-bot/` module — the first IaC in the umbrella — reconciles the


### PR DESCRIPTION
Brings the umbrella's Security workflow to the consistent suite-wide bar:

- **govulncheck** now scans **all** Go modules (adds `spore-bot` — was `rest-api` only).
- New **gitleaks** secret-scan job (MIT binary, org-license-free; `.gitleaks.toml` allowlist for doc examples + test fixtures).
- Trivy filesystem scan now includes the **secret** scanner.
- Semgrep + Trivy IaC unchanged (already present).

Completes the rollout (spawn pilot #172 + truffle/lagotto/nf-spawn/mcp) so every spore.host repo has the same security gate. First-run findings triaged here.