### PR TITLE
fix(spore-bot): gate /notify DM+SMS on instance registration (audit C2, #370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Security
+- **spore-bot `/notify` now gates per-user DM and SMS fan-out on instance
+  registration** (audit C2, spore-host/spawn#369-370 class). Previously the
+  endpoint only checked that `workspace_id`/`instance_id` were non-empty, so
+  anyone who learned an instance_id + workspace_id could trigger DMs to
+  registered users and platform-billed SMS for an instance that wasn't theirs.
+  DM/SMS now require the instance to be registered in the workspace
+  (`InstanceRegisteredInWorkspace`); the channel-webhook path is left open (the
+  workspace owner opted in, no per-user targeting or SMS cost). PKCS#7 identity
+  verification is wired in as log-only for now (the embedded-cert path is
+  unreliable cross-region; #294) and will flip to hard-reject once certs are fixed.
+
+### Security
 - Security CI hardened to a consistent gate across the suite: govulncheck now
   scans **all** Go modules (added `spore-bot` — previously only `rest-api`),
   added **gitleaks** secret scanning (MIT binary; org-license-free; allowlist for

--- a/lambda/spore-bot/notify.go
+++ b/lambda/spore-bot/notify.go
@@ -41,12 +41,29 @@ func handleNotify(ctx context.Context, cfg aws.Config, reg *Registry, request ev
 		return errorResp(400, "Invalid request body"), nil
 	}
 
-	// Auth: verify the instance_id is registered in this workspace.
-	// Cryptographic PKCS#7 verification was unreliable across AWS regions and
-	// cert rotations. Registry membership is the effective gate — an unregistered
-	// instance can't trigger DMs regardless of what it sends.
 	if nr.WorkspaceID == "" || nr.InstanceID == "" {
 		return errorResp(400, "workspace_id and instance_id are required"), nil
+	}
+
+	// AuthZ (spore-host/spawn#2 audit, C2): only fan out to per-user DMs / SMS
+	// when this instance is actually REGISTERED in the workspace. Without this,
+	// anyone who learns an instance_id + workspace_id could DM registered users
+	// and trigger platform-billed SMS for an instance that isn't theirs. The
+	// channel WEBHOOK path is left ungated: the workspace owner opted in by
+	// configuring the webhook, and it carries no per-user targeting or SMS cost.
+	registered, err := reg.InstanceRegisteredInWorkspace(ctx, nr.Platform, nr.WorkspaceID, nr.InstanceID)
+	if err != nil {
+		logf("notify: registration check failed for %s in %s#%s: %v", nr.InstanceID, nr.Platform, nr.WorkspaceID, err)
+		return errorResp(500, "registration check failed"), nil
+	}
+
+	// Cryptographic identity verification (PKCS#7). Log-only for now: the
+	// embedded-cert path has been unreliable across regions/rotations (see
+	// dns-updater #294), so failing hard here risks dropping legitimate
+	// notifications. The registry-membership gate above is the enforced control;
+	// flip this to a hard reject once cert reliability is resolved.
+	if err := verifyNotifyAuth(nr); err != nil {
+		logf("notify: identity verification did not pass for %s (membership-gated, allowing): %v", nr.InstanceID, err)
 	}
 
 	msg := formatNotification(nr)
@@ -88,21 +105,26 @@ func handleNotify(ctx context.Context, cfg aws.Config, reg *Registry, request ev
 
 	for i := range workspaces {
 		ws := &workspaces[i]
-		// Pattern A: post to channel via incoming webhook — synchronous so Lambda stays alive
+		// Pattern A: channel webhook — ungated (workspace opted in; no per-user
+		// targeting or SMS cost).
 		if ws.IncomingWebhookURL != "" {
 			postIncomingWebhook(ws.IncomingWebhookURL, msg)
 		}
-		// Pattern B: DM each registered Slack user
-		sendUserDMs(slackCtx, cfg, reg, ws, nr.InstanceID, msg)
+		// Pattern B: per-user DMs — only for a registered instance (C2).
+		if registered {
+			sendUserDMs(slackCtx, cfg, reg, ws, nr.InstanceID, msg)
+		}
 	}
 
-	// Teams DMs via Bot Framework proactive messaging
-	if nr.Platform == "slack" || nr.Platform == "" {
-		sendTeamsDMs(slackCtx, reg, nil, nr.InstanceID, msg)
+	// Per-user DM/SMS fan-out (Teams + SMS) — gated on registration like Slack DMs.
+	if registered {
+		if nr.Platform == "slack" || nr.Platform == "" {
+			sendTeamsDMs(slackCtx, reg, nil, nr.InstanceID, msg)
+		}
+		go sendUserSMS(context.Background(), reg, nr)
+	} else {
+		logf("notify: instance %s not registered in %s#%s — channel webhook only, skipping DM/SMS", nr.InstanceID, nr.Platform, nr.WorkspaceID)
 	}
-
-	// SMS notifications for users who have registered a phone number
-	go sendUserSMS(context.Background(), reg, nr)
 
 	return jsonOK(), nil
 }

--- a/lambda/spore-bot/registry.go
+++ b/lambda/spore-bot/registry.go
@@ -223,6 +223,38 @@ func (r *Registry) ListUserInstances(ctx context.Context, platform, workspaceID,
 	return regs, nil
 }
 
+// InstanceRegisteredInWorkspace reports whether instanceID has at least one
+// registration scoped to platform#workspaceID. This is the authorization gate
+// for inbound /notify: a notification may only fan out to a workspace that has
+// actually registered the instance, so a caller can't spoof notifications for an
+// arbitrary instance_id (spore-host/spawn#2 audit, C2). Uses the instance_id-index
+// GSI and filters by the user_key prefix.
+func (r *Registry) InstanceRegisteredInWorkspace(ctx context.Context, platform, workspaceID, instanceID string) (bool, error) {
+	if instanceID == "" || workspaceID == "" {
+		return false, nil
+	}
+	result, err := r.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(r.registryTable),
+		IndexName:              aws.String("instance_id-index"),
+		KeyConditionExpression: aws.String("instance_id = :iid"),
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":iid": &dynamodbtypes.AttributeValueMemberS{Value: instanceID},
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("query instance registrations: %w", err)
+	}
+	prefix := platform + "#" + workspaceID + "#"
+	for _, item := range result.Items {
+		if uk, ok := item["user_key"].(*dynamodbtypes.AttributeValueMemberS); ok {
+			if strings.HasPrefix(uk.Value, prefix) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // GetInstance retrieves a specific registered instance by nickname.
 func (r *Registry) GetInstance(ctx context.Context, platform, workspaceID, userID, nickname string) (*BotRegistration, error) {
 	key := userKey(platform, workspaceID, userID)


### PR DESCRIPTION
Closes #370 (audit Critical C2).

## Problem
`/notify` only checked `workspace_id`/`instance_id` were non-empty, then fanned out channel webhooks + per-user DMs + SMS. The PKCS#7 verification (`verifyNotifyAuth`) existed but was **never called** — effectively unauthenticated. Anyone who learned an `instance_id` + `workspace_id` could DM registered users and trigger platform-billed SMS for an instance that wasn't theirs.

## Fix (scoped to avoid regressing legitimate channel notifications)
- New `Registry.InstanceRegisteredInWorkspace` (instance_id-index GSI + workspace prefix).
- **Per-user DM + SMS fan-out** (Slack DMs, Teams DMs, SMS) now requires the instance to be **registered in the workspace** — that's the real spoofing/billing risk.
- **Channel webhook** path stays open: the workspace owner opted in by configuring the webhook, and it has no per-user targeting or SMS cost. (This deliberately keeps the Discord Phase 1 + Slack channel-notification use cases working — gating those would have been a regression.)
- `verifyNotifyAuth` is now actually invoked (PKCS#7), **log-only** for now: the embedded-cert path is unreliable cross-region (same root as dns-updater #294), so hard-failing would risk dropping real notifications. Flip to hard-reject once cert reliability is fixed.

## Tests
Build + vet + existing suite green. (A registration-gate unit test wants a DynamoDB fake — noted for the MCP/coverage follow-up; the GSI query mirrors the existing `sendUserDMs` path.)

Deploys via the manual `update-function-code` path like the other spore-bot changes; I'll deploy after merge.