### PR TITLE
fix(security): close all four P0 audit findings (C1 + H3/H4/H5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,6 @@ checksums.txt
 # Local archive (not pushed to GitHub)
 .local-archive/
 spawn/lambda/rest-api/rest-api
+lambda/rest-api/rest-api
 lambda/spore-bot/spore-bot
 lambda/spore-bot/prism-bot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Security
+- **Teams Bot Framework requests now fully validate the bearer JWT** (audit H4,
+  #372). Previously a `Bearer …` request was trusted as long as the server-side
+  `TEAMS_APP_ID` env was set — no token validation at all — so any caller of the
+  public Function URL could forge a Teams activity. The token is now verified for
+  RS256 signature against Microsoft's published JWKS, issuer
+  (`https://api.botframework.com`), audience (`== TEAMS_APP_ID`), and expiry;
+  `alg:none`/HMAC-confusion are rejected. Verification fails closed.
+- **Slack/Teams signature verification now rejects an empty signing secret**
+  (audit H5, #373). HMAC with an empty key is forgeable, and OAuth-installed
+  Slack workspaces persist no per-workspace secret. Slack now falls back to the
+  app-level `SLACK_SIGNING_SECRET` env (the secret is app-level, not
+  per-workspace), and both verifiers fail closed when no secret is available.
+- **Hosted REST API now enforces lifecycle bounds** (audit H3, #371). Unlike the
+  CLI, the API called the spawn client directly and bypassed the 1h-idle
+  zombie-prevention default, so an empty-TTL launch produced an instance with no
+  deadline and no reaper tag. Launches with neither TTL nor idle timeout now get
+  a default idle timeout, all TTL/idle/extend durations are capped at a 7-day
+  maximum, and the `extend` action now writes `spawn:ttl-deadline` (not just
+  `spawn:ttl`) so the extension actually takes effect (it was a silent no-op,
+  same class as spore-host-mcp#11). The `/spore extend` and `/spore idle` bot
+  commands gained the same deadline fix and 7-day cap.
 - **spore-bot `/notify` now gates per-user DM and SMS fan-out on instance
   registration** (audit C2, spore-host/spawn#369-370 class). Previously the
   endpoint only checked that `workspace_id`/`instance_id` were non-empty, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Security
+- **Hosted REST API now enforces per-project tenant isolation** (audit C1, #369).
+  Previously every handler received a validated API-key principal but never used
+  it, so any valid key could list/launch/stop/terminate/extend **every** instance
+  in the account. Launches are now stamped with `spawn:project=<key's project>`,
+  and list/get/stop/start/hibernate/terminate/extend are scoped to the
+  principal's project (fail-closed: a key with no project can't launch or reach
+  any instance; non-owned instances return 404, not 403, so existence isn't
+  leaked). **Operator note:** instances launched before this change carry no
+  `spawn:project` tag and become invisible to the API — backfill the tag
+  (`aws ec2 create-tags --tags Key=spawn:project,Value=<project>`) to re-expose
+  them.
+- **SMS "extend" reply now writes `spawn:ttl-deadline`** (not just `spawn:ttl`,
+  which spored ignores — a silent no-op, same class as #371) and is capped at the
+  7-day maximum.
 - **Teams Bot Framework requests now fully validate the bearer JWT** (audit H4,
   #372). Previously a `Bearer …` request was trusted as long as the server-side
   `TEAMS_APP_ID` env was set — no token validation at all — so any caller of the

--- a/lambda/rest-api/instances.go
+++ b/lambda/rest-api/instances.go
@@ -61,6 +61,35 @@ func handleListInstances(ctx context.Context, cfg aws.Config, req events.APIGate
 	return jsonResp(http.StatusOK, map[string]any{"instances": out, "count": len(out)}), nil
 }
 
+// Lifecycle bounds for the hosted REST API. Unlike the CLI (which prompts and
+// defaults to a 1h idle timeout in cmd/launch.go), the API calls the spawn
+// client directly — so the safety net must live here. Without it, an empty-TTL
+// launch yields an instance with NO deadline and NO reaper tag that runs until
+// manually killed (spore-host#371).
+const (
+	// defaultIdleTimeout is applied when a launch request sets neither TTL nor
+	// idle timeout — mirrors the CLI's zombie-prevention default.
+	defaultIdleTimeout = "1h"
+	// maxTTL is the hard ceiling on any TTL or extend duration through the API.
+	maxTTL = 7 * 24 * time.Hour
+)
+
+// capDuration parses a Go duration and rejects values that are non-positive or
+// exceed maxTTL. Returns the normalized string form on success.
+func capDuration(d string) (string, error) {
+	parsed, err := time.ParseDuration(d)
+	if err != nil {
+		return "", fmt.Errorf("invalid duration %q (use Go units like 2h, 24h, 168h)", d)
+	}
+	if parsed <= 0 {
+		return "", fmt.Errorf("duration %q must be positive", d)
+	}
+	if parsed > maxTTL {
+		return "", fmt.Errorf("duration %q exceeds maximum of %s", d, maxTTL)
+	}
+	return d, nil
+}
+
 // LaunchRequest is the JSON body for POST /v1/instances.
 // Only InstanceType, Region, and AMI are required; all lifecycle fields are optional.
 type LaunchRequest struct {
@@ -86,6 +115,23 @@ func handleLaunch(ctx context.Context, cfg aws.Config, req events.APIGatewayV2HT
 	}
 	if body.InstanceType == "" || body.Region == "" {
 		return errResp(http.StatusBadRequest, "instance_type and region are required"), nil
+	}
+
+	// Enforce lifecycle bounds (spore-host#371). Validate any caller-supplied
+	// TTL/idle timeout against the hard maximum, and if BOTH are empty inject a
+	// default idle timeout so the instance can never become a zombie.
+	if body.TTL != "" {
+		if _, err := capDuration(body.TTL); err != nil {
+			return errResp(http.StatusBadRequest, err.Error()), nil
+		}
+	}
+	if body.IdleTimeout != "" {
+		if _, err := capDuration(body.IdleTimeout); err != nil {
+			return errResp(http.StatusBadRequest, err.Error()), nil
+		}
+	}
+	if body.TTL == "" && body.IdleTimeout == "" {
+		body.IdleTimeout = defaultIdleTimeout
 	}
 
 	lc := spawnclient.LaunchConfig{
@@ -200,12 +246,42 @@ func handleInstanceAction(ctx context.Context, cfg aws.Config, id, action string
 		if body.Duration == "" {
 			return errResp(http.StatusBadRequest, "duration required"), nil
 		}
+		if _, err := capDuration(body.Duration); err != nil {
+			return errResp(http.StatusBadRequest, err.Error()), nil
+		}
+		extendDuration, err := time.ParseDuration(body.Duration)
+		if err != nil {
+			return errResp(http.StatusBadRequest, fmt.Sprintf("invalid duration: %v", err)), nil
+		}
+		// spored treats spawn:ttl-deadline (absolute) as authoritative and ignores
+		// spawn:ttl. Writing only spawn:ttl is a silent no-op — the instance still
+		// dies at its original deadline (same bug class as spore-host-mcp#11). Push
+		// the absolute deadline forward and write BOTH tags, mirroring cmd/extend.go.
+		var newDeadline time.Time
+		if dl, ok := target.Tags["spawn:ttl-deadline"]; ok {
+			if parsed, perr := time.Parse(time.RFC3339, dl); perr == nil {
+				newDeadline = parsed.Add(extendDuration)
+			}
+		}
+		if newDeadline.IsZero() {
+			if cur, cerr := time.ParseDuration(target.TTL); cerr == nil {
+				newDeadline = time.Now().Add(cur).Add(extendDuration)
+			} else {
+				newDeadline = time.Now().Add(extendDuration)
+			}
+		}
 		if err := client.UpdateInstanceTags(ctx, target.Region, target.InstanceID, map[string]string{
-			"spawn:ttl": body.Duration,
+			"spawn:ttl":          body.Duration,
+			"spawn:ttl-deadline": newDeadline.UTC().Format(time.RFC3339),
 		}); err != nil {
 			return errResp(http.StatusInternalServerError, fmt.Sprintf("extend failed: %v", err)), nil
 		}
-		return jsonResp(http.StatusOK, map[string]string{"status": "extended", "ttl": body.Duration, "instance_id": target.InstanceID}), nil
+		return jsonResp(http.StatusOK, map[string]string{
+			"status":      "extended",
+			"ttl":         body.Duration,
+			"deadline":    newDeadline.UTC().Format(time.RFC3339),
+			"instance_id": target.InstanceID,
+		}), nil
 
 	default:
 		return errResp(http.StatusBadRequest, fmt.Sprintf("unknown action %q — valid: stop, start, hibernate, terminate, extend", action)), nil

--- a/lambda/rest-api/instances.go
+++ b/lambda/rest-api/instances.go
@@ -13,6 +13,25 @@ import (
 	spawnconfig "github.com/spore-host/spawn/pkg/config"
 )
 
+// projectTag is the EC2 tag that scopes an instance to the API-key principal's
+// project. The hosted API is single-account: every launch runs as the same
+// Lambda role, so identity tags (spawn:iam-user, spawn:account-id) are identical
+// across tenants and can't isolate anything. The principal's project is the only
+// real tenant discriminator, so we stamp it on launch and gate every read/action
+// on it (spore-host#369).
+const projectTag = "spawn:project"
+
+// ownsInstance reports whether the principal may see/act on an instance. It is
+// fail-closed: a principal with an empty project, or an instance with no/blank
+// project tag, never matches — so a leaked key with no project can't reach
+// pre-existing untagged instances, and an empty project can't act as a wildcard.
+func ownsInstance(p *Principal, tags map[string]string) bool {
+	if p == nil || p.Project == "" {
+		return false
+	}
+	return tags[projectTag] == p.Project
+}
+
 func handleListInstances(ctx context.Context, cfg aws.Config, req events.APIGatewayV2HTTPRequest, p *Principal) (events.APIGatewayV2HTTPResponse, error) {
 	region := req.QueryStringParameters["region"]
 	state := req.QueryStringParameters["state"]
@@ -43,6 +62,11 @@ func handleListInstances(ctx context.Context, cfg aws.Config, req events.APIGate
 
 	out := make([]instanceOut, 0, len(instances))
 	for _, inst := range instances {
+		// Tenant isolation: only surface instances belonging to this principal's
+		// project (spore-host#369).
+		if !ownsInstance(p, inst.Tags) {
+			continue
+		}
 		dns := inst.Tags["spawn:dns-name"]
 		out = append(out, instanceOut{
 			InstanceID:       inst.InstanceID,
@@ -117,6 +141,13 @@ func handleLaunch(ctx context.Context, cfg aws.Config, req events.APIGatewayV2HT
 		return errResp(http.StatusBadRequest, "instance_type and region are required"), nil
 	}
 
+	// Tenant isolation (spore-host#369): the launched instance must be stamped
+	// with the principal's project so later list/get/action can scope to it.
+	// Reject a key with no project rather than create an un-isolated instance.
+	if p == nil || p.Project == "" {
+		return errResp(http.StatusForbidden, "API key has no project; cannot launch"), nil
+	}
+
 	// Enforce lifecycle bounds (spore-host#371). Validate any caller-supplied
 	// TTL/idle timeout against the hard maximum, and if BOTH are empty inject a
 	// default idle timeout so the instance can never become a zombie.
@@ -148,6 +179,7 @@ func handleLaunch(ctx context.Context, cfg aws.Config, req events.APIGatewayV2HT
 		CompletionFile:     body.CompletionFile,
 		SlackWorkspaceID:   body.SlackWorkspace,
 		ActiveProcessesRaw: body.ActiveProcesses,
+		Tags:               map[string]string{projectTag: p.Project},
 	}
 
 	// Inject notification URL for hosted spore.host
@@ -182,6 +214,11 @@ func handleGetInstance(ctx context.Context, cfg aws.Config, id string, p *Princi
 	}
 	for _, inst := range instances {
 		if inst.InstanceID == id || strings.EqualFold(inst.Name, id) {
+			// Tenant isolation: 404 (not 403) for instances outside the
+			// principal's project, so we don't leak their existence (#369).
+			if !ownsInstance(p, inst.Tags) {
+				return errResp(http.StatusNotFound, fmt.Sprintf("instance %q not found", id)), nil
+			}
 			return jsonResp(http.StatusOK, inst), nil
 		}
 	}
@@ -204,6 +241,11 @@ func handleInstanceAction(ctx context.Context, cfg aws.Config, id, action string
 		}
 	}
 	if target == nil {
+		return errResp(http.StatusNotFound, fmt.Sprintf("instance %q not found", id)), nil
+	}
+	// Tenant isolation: refuse to act on an instance outside the principal's
+	// project, masked as 404 so existence isn't leaked (#369).
+	if !ownsInstance(p, target.Tags) {
 		return errResp(http.StatusNotFound, fmt.Sprintf("instance %q not found", id)), nil
 	}
 

--- a/lambda/rest-api/sms.go
+++ b/lambda/rest-api/sms.go
@@ -97,8 +97,38 @@ func executeAction(ctx context.Context, p *sms.PendingNotification, action strin
 
 	case strings.HasPrefix(action, "extend:"):
 		dur := strings.TrimPrefix(action, "extend:")
+		if _, err := capDuration(dur); err != nil {
+			return "", err
+		}
+		extendDuration, err := time.ParseDuration(dur)
+		if err != nil {
+			return "", fmt.Errorf("invalid duration: %w", err)
+		}
+		// Push the absolute deadline forward and write BOTH tags. Writing only
+		// spawn:ttl is a silent no-op — spored honors spawn:ttl-deadline
+		// (same bug class as spore-host#371 / spore-host-mcp#11).
+		var newDeadline time.Time
+		if insts, lerr := client.ListInstances(ctx, p.Region, ""); lerr == nil {
+			for _, inst := range insts {
+				if inst.InstanceID != p.InstanceID {
+					continue
+				}
+				if dl, ok := inst.Tags["spawn:ttl-deadline"]; ok {
+					if parsed, perr := time.Parse(time.RFC3339, dl); perr == nil {
+						newDeadline = parsed.Add(extendDuration)
+					}
+				} else if cur, cerr := time.ParseDuration(inst.TTL); cerr == nil {
+					newDeadline = time.Now().Add(cur).Add(extendDuration)
+				}
+				break
+			}
+		}
+		if newDeadline.IsZero() {
+			newDeadline = time.Now().Add(extendDuration)
+		}
 		if err := client.UpdateInstanceTags(ctx, p.Region, p.InstanceID, map[string]string{
-			"spawn:ttl": dur,
+			"spawn:ttl":          dur,
+			"spawn:ttl-deadline": newDeadline.UTC().Format(time.RFC3339),
 		}); err != nil {
 			return "", err
 		}

--- a/lambda/rest-api/util_test.go
+++ b/lambda/rest-api/util_test.go
@@ -119,6 +119,21 @@ func TestBuildOptionsHint(t *testing.T) {
 	}
 }
 
+func TestCapDuration(t *testing.T) {
+	ok := []string{"1h", "24h", "168h", "30m", "1h30m"}
+	for _, d := range ok {
+		if got, err := capDuration(d); err != nil || got != d {
+			t.Errorf("capDuration(%q) = %q, %v; want %q, nil", d, got, err, d)
+		}
+	}
+	bad := []string{"", "0h", "-1h", "169h", "8d", "abc", "100000h"}
+	for _, d := range bad {
+		if _, err := capDuration(d); err == nil {
+			t.Errorf("capDuration(%q) expected error, got nil", d)
+		}
+	}
+}
+
 // --- handler routing (auth happens before any AWS call) ---
 
 func TestHandler_MissingAPIKey(t *testing.T) {

--- a/lambda/rest-api/util_test.go
+++ b/lambda/rest-api/util_test.go
@@ -119,6 +119,34 @@ func TestBuildOptionsHint(t *testing.T) {
 	}
 }
 
+func TestOwnsInstance(t *testing.T) {
+	tests := []struct {
+		name    string
+		project string
+		tags    map[string]string
+		want    bool
+	}{
+		{"match", "acme", map[string]string{"spawn:project": "acme"}, true},
+		{"mismatch", "acme", map[string]string{"spawn:project": "other"}, false},
+		{"untagged instance", "acme", map[string]string{}, false},
+		{"blank tag", "acme", map[string]string{"spawn:project": ""}, false},
+		{"empty principal project never matches untagged", "", map[string]string{}, false},
+		{"empty principal project never matches blank tag", "", map[string]string{"spawn:project": ""}, false},
+		{"nil tags", "acme", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ownsInstance(&Principal{Project: tt.project}, tt.tags)
+			if got != tt.want {
+				t.Errorf("ownsInstance(project=%q, tags=%v) = %v, want %v", tt.project, tt.tags, got, tt.want)
+			}
+		})
+	}
+	if ownsInstance(nil, map[string]string{"spawn:project": "acme"}) {
+		t.Error("nil principal must never own an instance")
+	}
+}
+
 func TestCapDuration(t *testing.T) {
 	ok := []string{"1h", "24h", "168h", "30m", "1h30m"}
 	for _, d := range ok {

--- a/lambda/spore-bot/bot_test.go
+++ b/lambda/spore-bot/bot_test.go
@@ -98,6 +98,21 @@ func TestVerifySlackSignature_EmptySignature(t *testing.T) {
 	}
 }
 
+// An empty signing secret must fail closed: OAuth-installed workspaces store no
+// secret, and HMAC with an empty key is forgeable (spore-host#373). Critically,
+// this must reject even when the attacker presents a "valid" HMAC computed with
+// the empty key.
+func TestVerifySlackSignature_EmptySecret(t *testing.T) {
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	body := "body"
+	mac := hmac.New(sha256.New, []byte("")) // attacker forges with empty key
+	mac.Write([]byte("v0:" + ts + ":" + body))
+	forged := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	if err := verifySlackSignature("", ts, body, forged); err == nil {
+		t.Error("expected empty signing secret to fail closed even with a matching forged HMAC")
+	}
+}
+
 // ── Teams signature verification ──────────────────────────────────────────────
 
 func TestVerifyTeamsSignature_Valid(t *testing.T) {
@@ -123,6 +138,16 @@ func TestVerifyTeamsSignature_MissingPrefix(t *testing.T) {
 	err := verifyTeamsSignature("secret", "body", "Bearer sometoken")
 	if err == nil {
 		t.Error("expected non-HMAC auth header to fail")
+	}
+}
+
+func TestVerifyTeamsSignature_EmptySecret(t *testing.T) {
+	body := "body"
+	mac := hmac.New(sha256.New, []byte("")) // forged with empty key
+	mac.Write([]byte(body))
+	forged := "HMAC " + encodeBase64(mac.Sum(nil))
+	if err := verifyTeamsSignature("", body, forged); err == nil {
+		t.Error("expected empty shared secret to fail closed even with a matching forged HMAC")
 	}
 }
 

--- a/lambda/spore-bot/handler.go
+++ b/lambda/spore-bot/handler.go
@@ -215,7 +215,16 @@ func handleSlackWebhook(ctx context.Context, reg *Registry, request events.APIGa
 		return nil, fmt.Errorf("workspace not found: %w", err)
 	}
 
-	if err := verifySlackSignature(ws.SigningSecret, ts, request.Body, sig); err != nil {
+	// Slack's signing secret is app-level, not per-workspace, so OAuth-installed
+	// workspaces store none (oauth.go). Fall back to the hosted app's app-level
+	// secret from the environment; the per-workspace value (admin-registered /
+	// self-hosted) takes precedence. verifySlackSignature fails closed if both
+	// are empty (spore-host#373).
+	signingSecret := ws.SigningSecret
+	if signingSecret == "" {
+		signingSecret = os.Getenv("SLACK_SIGNING_SECRET")
+	}
+	if err := verifySlackSignature(signingSecret, ts, request.Body, sig); err != nil {
 		return nil, fmt.Errorf("signature verification failed: %w", err)
 	}
 
@@ -245,13 +254,16 @@ func handleTeamsWebhook(ctx context.Context, reg *Registry, request events.APIGa
 	isBotFramework := strings.HasPrefix(authHeader, "Bearer ")
 
 	if isBotFramework {
-		// Bot Framework JWT — issued by Microsoft, trusted via App ID match.
-		// Full JWT signature verification requires fetching Microsoft's OIDC keys;
-		// for now we trust the Azure Bot channel (messages come from Microsoft's servers)
-		// and verify the App ID matches our configured bot.
+		// Bot Framework JWT — issued by Microsoft for our bot. Fully validate the
+		// token (RS256 signature against Microsoft's JWKS, issuer, audience==App ID,
+		// expiry) before trusting the activity. The public Function URL means an
+		// unverified Bearer token is a forge-an-activity hole (spore-host#372).
 		appID := os.Getenv("TEAMS_APP_ID")
 		if appID == "" {
 			return nil, fmt.Errorf("TEAMS_APP_ID not configured")
+		}
+		if err := verifyTeamsJWT(ctx, authHeader, appID); err != nil {
+			return nil, fmt.Errorf("Bot Framework token verification failed: %w", err)
 		}
 		// Workspace lookup is optional for Bot Framework — tenant may not have signing secret
 		_, _ = reg.GetWorkspace(ctx, "teams", sc.WorkspaceID) // best-effort

--- a/lambda/spore-bot/lifecycle.go
+++ b/lambda/spore-bot/lifecycle.go
@@ -10,6 +10,11 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
+// maxBotTTL is the hard ceiling on the resulting TTL/idle timeout through the
+// bot (spore-host#371) — keeps a runaway `/spore extend foo 99999h` from
+// disabling the lifecycle backstop.
+const maxBotTTL = 7 * 24 * time.Hour
+
 // extendTTL adds duration to the instance's current TTL by updating the spawn:ttl EC2 tag.
 // Usage: /spore extend <name> <duration>  e.g. /spore extend rstudio 2h
 func extendTTL(ctx context.Context, client *ec2.Client, reg *BotRegistration, durationStr, slashCmd string) (string, error) {
@@ -23,7 +28,7 @@ func extendTTL(ctx context.Context, client *ec2.Client, reg *BotRegistration, du
 		return fmt.Sprintf("❌ Invalid duration `%s`. Use a format like `2h`, `30m`, or `1h30m`.", durationStr), nil
 	}
 
-	// Get current TTL tag
+	// Get current TTL + deadline tags
 	out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		InstanceIds: []string{reg.InstanceID},
 	})
@@ -34,6 +39,7 @@ func extendTTL(ctx context.Context, client *ec2.Client, reg *BotRegistration, du
 
 	var currentTTL time.Duration
 	var launchTime time.Time
+	var currentDeadline time.Time
 	if inst.LaunchTime != nil {
 		launchTime = *inst.LaunchTime
 	}
@@ -41,33 +47,51 @@ func extendTTL(ctx context.Context, client *ec2.Client, reg *BotRegistration, du
 		if tag.Key == nil || tag.Value == nil {
 			continue
 		}
-		if *tag.Key == reg.TagPrefix+":ttl" {
+		switch *tag.Key {
+		case reg.TagPrefix + ":ttl":
 			currentTTL, _ = time.ParseDuration(*tag.Value)
+		case reg.TagPrefix + ":ttl-deadline":
+			currentDeadline, _ = time.Parse(time.RFC3339, *tag.Value)
 		}
 	}
 
 	// New TTL = existing TTL + extension (relative to launch time)
 	newTTL := currentTTL + extension
+	if newTTL > maxBotTTL {
+		return fmt.Sprintf("❌ Resulting TTL %s exceeds the maximum of %s. Pick a shorter extension.",
+			formatTTLDuration(newTTL), formatTTLDuration(maxBotTTL)), nil
+	}
 	newTTLStr := formatTTLDuration(newTTL)
+
+	// spored treats <prefix>:ttl-deadline (absolute) as authoritative and ignores
+	// <prefix>:ttl. Writing only :ttl is a silent no-op — the instance still dies
+	// at its original deadline (same bug class as spore-host-mcp#11). Push the
+	// absolute deadline forward and write BOTH tags.
+	newDeadline := currentDeadline
+	if newDeadline.IsZero() {
+		// Older instance without the deadline tag — anchor to launch + new TTL.
+		newDeadline = launchTime.Add(newTTL)
+	} else {
+		newDeadline = newDeadline.Add(extension)
+	}
 
 	_, err = client.CreateTags(ctx, &ec2.CreateTagsInput{
 		Resources: []string{reg.InstanceID},
 		Tags: []ec2types.Tag{
 			{Key: aws.String(reg.TagPrefix + ":ttl"), Value: aws.String(newTTLStr)},
+			{Key: aws.String(reg.TagPrefix + ":ttl-deadline"), Value: aws.String(newDeadline.UTC().Format(time.RFC3339))},
 		},
 	})
 	if err != nil {
 		return "", fmt.Errorf("update TTL tag: %w", err)
 	}
 
-	// Calculate new termination time
-	newTerminateAt := launchTime.Add(newTTL)
-	remaining := time.Until(newTerminateAt)
+	remaining := time.Until(newDeadline)
 
 	return fmt.Sprintf("⏱️ Extended *%s* TTL by %s.\n  New deadline: %s (%s remaining)",
 		reg.Nickname,
 		durationStr,
-		newTerminateAt.UTC().Format("2 Jan 15:04 UTC"),
+		newDeadline.UTC().Format("2 Jan 15:04 UTC"),
 		formatHMS(remaining)), nil
 }
 
@@ -96,6 +120,9 @@ func setIdleTimeout(ctx context.Context, client *ec2.Client, reg *BotRegistratio
 	d, err := time.ParseDuration(durationStr)
 	if err != nil || d <= 0 {
 		return fmt.Sprintf("❌ Invalid duration `%s`. Use a format like `30m`, `1h`, or `off` to disable.", durationStr), nil
+	}
+	if d > maxBotTTL {
+		return fmt.Sprintf("❌ Idle timeout %s exceeds the maximum of %s.", durationStr, formatTTLDuration(maxBotTTL)), nil
 	}
 
 	_, err = client.CreateTags(ctx, &ec2.CreateTagsInput{

--- a/lambda/spore-bot/slack.go
+++ b/lambda/spore-bot/slack.go
@@ -65,6 +65,13 @@ func parseSlackCommand(body string) (*SlashCommand, error) {
 // Uses HMAC-SHA256 with the workspace signing secret.
 // Rejects requests older than 5 minutes to prevent replay attacks.
 func verifySlackSignature(signingSecret, timestamp, body, sig string) error {
+	// Reject an empty signing secret outright. OAuth-installed workspaces persist
+	// no signing secret (the install flow can't obtain Slack's app-level secret),
+	// and HMAC with an empty key is forgeable by anyone who knows it's empty
+	// (spore-host#373). Fail closed rather than verifying against "".
+	if signingSecret == "" {
+		return fmt.Errorf("no signing secret configured for this workspace")
+	}
 	ts, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid timestamp: %w", err)

--- a/lambda/spore-bot/teams.go
+++ b/lambda/spore-bot/teams.go
@@ -63,6 +63,11 @@ type TeamsConversationRef struct {
 
 // verifyTeamsSignature validates Teams outgoing webhook HMAC-SHA256 signature.
 func verifyTeamsSignature(sharedSecret, body, authHeader string) error {
+	// Reject an empty shared secret outright — HMAC with an empty key is
+	// forgeable (spore-host#373). Fail closed.
+	if sharedSecret == "" {
+		return fmt.Errorf("no shared secret configured for this workspace")
+	}
 	if !strings.HasPrefix(authHeader, "HMAC ") {
 		return fmt.Errorf("missing HMAC authorization")
 	}

--- a/lambda/spore-bot/teams_jwt.go
+++ b/lambda/spore-bot/teams_jwt.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Bot Framework token validation (spore-host#372).
+//
+// Teams "Bearer <jwt>" requests arrive at a public Function URL. The token is
+// issued by Microsoft's Bot Framework for our bot; without verifying it, any
+// caller can send "Authorization: Bearer anything" plus a forged activity and
+// drive an executable command. We verify the standard Bot Framework claims:
+//
+//   - signature: RS256 against Microsoft's published JWKS (keyed by `kid`)
+//   - issuer:    https://api.botframework.com
+//   - audience:  equals our configured bot App ID (TEAMS_APP_ID)
+//   - expiry/nbf: token currently valid
+//
+// Docs: https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication
+const (
+	botFrameworkIssuer    = "https://api.botframework.com"
+	botFrameworkOpenIDURL = "https://login.botframework.com/v1/.well-known/openidconfiguration"
+)
+
+// jwksCache caches the Bot Framework signing keys (modulus/exponent per kid).
+// Microsoft rotates these infrequently; we refresh on a cache miss or TTL expiry.
+type jwksCache struct {
+	mu        sync.RWMutex
+	keys      map[string]*rsa.PublicKey
+	fetchedAt time.Time
+}
+
+var botFrameworkKeys = &jwksCache{keys: map[string]*rsa.PublicKey{}}
+
+// jwksTTL bounds how long signing keys are cached before a forced refresh.
+const jwksTTL = 24 * time.Hour
+
+// verifyTeamsJWT validates a Bot Framework bearer token and returns nil if the
+// token is authentic, issued for our bot, and currently valid. appID is the
+// configured bot App ID (TEAMS_APP_ID); it must be non-empty.
+func verifyTeamsJWT(ctx context.Context, token, appID string) error {
+	if appID == "" {
+		return fmt.Errorf("TEAMS_APP_ID not configured")
+	}
+	token = strings.TrimSpace(strings.TrimPrefix(token, "Bearer "))
+	if token == "" {
+		return fmt.Errorf("empty bearer token")
+	}
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("malformed JWT")
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return fmt.Errorf("decode JWT header: %w", err)
+	}
+	var hdr struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+	}
+	if err := json.Unmarshal(headerJSON, &hdr); err != nil {
+		return fmt.Errorf("parse JWT header: %w", err)
+	}
+	// Only RS256 is accepted. Rejecting everything else closes the "alg":"none"
+	// and HMAC-confusion classes of attack.
+	if hdr.Alg != "RS256" {
+		return fmt.Errorf("unexpected JWT alg %q (want RS256)", hdr.Alg)
+	}
+
+	claimsJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return fmt.Errorf("decode JWT claims: %w", err)
+	}
+	var claims struct {
+		Iss string          `json:"iss"`
+		Aud json.RawMessage `json:"aud"`
+		Exp int64           `json:"exp"`
+		Nbf int64           `json:"nbf"`
+	}
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		return fmt.Errorf("parse JWT claims: %w", err)
+	}
+
+	if claims.Iss != botFrameworkIssuer {
+		return fmt.Errorf("unexpected issuer %q", claims.Iss)
+	}
+	if !audienceMatches(claims.Aud, appID) {
+		return fmt.Errorf("audience does not match configured bot App ID")
+	}
+	now := time.Now().Unix()
+	if claims.Exp != 0 && now > claims.Exp {
+		return fmt.Errorf("token expired")
+	}
+	// Allow 5 minutes of clock skew for nbf.
+	if claims.Nbf != 0 && now+300 < claims.Nbf {
+		return fmt.Errorf("token not yet valid")
+	}
+
+	pubKey, err := botFrameworkKeys.keyFor(ctx, hdr.Kid)
+	if err != nil {
+		return fmt.Errorf("resolve signing key: %w", err)
+	}
+
+	signed := []byte(parts[0] + "." + parts[1])
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return fmt.Errorf("decode JWT signature: %w", err)
+	}
+	hashed := sha256.Sum256(signed)
+	if err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed[:], sig); err != nil {
+		return fmt.Errorf("JWT signature invalid: %w", err)
+	}
+	return nil
+}
+
+// audienceMatches reports whether the JWT "aud" claim (string or []string)
+// contains the expected App ID.
+func audienceMatches(raw json.RawMessage, appID string) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return single == appID
+	}
+	var list []string
+	if err := json.Unmarshal(raw, &list); err == nil {
+		for _, a := range list {
+			if a == appID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// keyFor returns the RSA public key for the given kid, refreshing the JWKS from
+// Microsoft on a cache miss or once the cached set is older than jwksTTL.
+func (c *jwksCache) keyFor(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	c.mu.RLock()
+	key, ok := c.keys[kid]
+	fresh := time.Since(c.fetchedAt) < jwksTTL
+	c.mu.RUnlock()
+	if ok && fresh {
+		return key, nil
+	}
+
+	if err := c.refresh(ctx); err != nil {
+		// On refresh failure, fall back to a stale cached key if we have one —
+		// better to keep verifying with the last-known-good key than to fail open.
+		if ok {
+			return key, nil
+		}
+		return nil, err
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if key, ok := c.keys[kid]; ok {
+		return key, nil
+	}
+	return nil, fmt.Errorf("no signing key for kid %q", kid)
+}
+
+// refresh fetches the OpenID configuration, then the JWKS, and replaces the
+// cached key set.
+func (c *jwksCache) refresh(ctx context.Context) error {
+	jwksURI, err := fetchJWKSURI(ctx, botFrameworkOpenIDURL)
+	if err != nil {
+		return err
+	}
+	keys, err := fetchJWKS(ctx, jwksURI)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.keys = keys
+	c.fetchedAt = time.Now()
+	c.mu.Unlock()
+	return nil
+}
+
+func fetchJWKSURI(ctx context.Context, openIDURL string) (string, error) {
+	body, err := httpGetJSON(ctx, openIDURL)
+	if err != nil {
+		return "", fmt.Errorf("fetch openid config: %w", err)
+	}
+	var doc struct {
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return "", fmt.Errorf("parse openid config: %w", err)
+	}
+	if doc.JWKSURI == "" {
+		return "", fmt.Errorf("openid config has no jwks_uri")
+	}
+	return doc.JWKSURI, nil
+}
+
+func fetchJWKS(ctx context.Context, jwksURI string) (map[string]*rsa.PublicKey, error) {
+	body, err := httpGetJSON(ctx, jwksURI)
+	if err != nil {
+		return nil, fmt.Errorf("fetch jwks: %w", err)
+	}
+	var doc struct {
+		Keys []struct {
+			Kid string `json:"kid"`
+			Kty string `json:"kty"`
+			N   string `json:"n"`
+			E   string `json:"e"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("parse jwks: %w", err)
+	}
+	out := make(map[string]*rsa.PublicKey, len(doc.Keys))
+	for _, k := range doc.Keys {
+		if k.Kty != "RSA" || k.Kid == "" {
+			continue
+		}
+		pub, err := rsaPublicKeyFromJWK(k.N, k.E)
+		if err != nil {
+			continue
+		}
+		out[k.Kid] = pub
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("jwks contained no usable RSA keys")
+	}
+	return out, nil
+}
+
+// rsaPublicKeyFromJWK builds an RSA public key from the base64url-encoded
+// modulus (n) and exponent (e) of a JWK.
+func rsaPublicKeyFromJWK(nB64, eB64 string) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(nB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode modulus: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(eB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode exponent: %w", err)
+	}
+	// Left-pad the exponent to 8 bytes so it fits a uint64.
+	if len(eBytes) > 8 {
+		return nil, fmt.Errorf("exponent too large")
+	}
+	padded := make([]byte, 8)
+	copy(padded[8-len(eBytes):], eBytes)
+	e := binary.BigEndian.Uint64(padded)
+	if e == 0 {
+		return nil, fmt.Errorf("invalid zero exponent")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: int(e),
+	}, nil
+}
+
+// httpGetJSON performs a GET and returns the response body, using the shared
+// httpClient with a short timeout context.
+func httpGetJSON(ctx context.Context, url string) ([]byte, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: status %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+}

--- a/lambda/spore-bot/teams_jwt_test.go
+++ b/lambda/spore-bot/teams_jwt_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// mkJWT builds a signed RS256 JWT for testing. kid selects which key the
+// verifier will look up; claims is marshaled as the payload.
+func mkJWT(t *testing.T, key *rsa.PrivateKey, kid string, claims map[string]any) string {
+	t.Helper()
+	hdr := map[string]any{"alg": "RS256", "typ": "JWT", "kid": kid}
+	hb, _ := json.Marshal(hdr)
+	cb, _ := json.Marshal(claims)
+	seg := base64.RawURLEncoding.EncodeToString(hb) + "." + base64.RawURLEncoding.EncodeToString(cb)
+	h := sha256.Sum256([]byte(seg))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return seg + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// withTestKey injects a public key into the JWKS cache under kid and marks it
+// fresh, then restores the prior cache state on cleanup.
+func withTestKey(t *testing.T, kid string, pub *rsa.PublicKey) {
+	t.Helper()
+	botFrameworkKeys.mu.Lock()
+	prevKeys, prevAt := botFrameworkKeys.keys, botFrameworkKeys.fetchedAt
+	botFrameworkKeys.keys = map[string]*rsa.PublicKey{kid: pub}
+	botFrameworkKeys.fetchedAt = time.Now()
+	botFrameworkKeys.mu.Unlock()
+	t.Cleanup(func() {
+		botFrameworkKeys.mu.Lock()
+		botFrameworkKeys.keys, botFrameworkKeys.fetchedAt = prevKeys, prevAt
+		botFrameworkKeys.mu.Unlock()
+	})
+}
+
+func validClaims(appID string) map[string]any {
+	return map[string]any{
+		"iss": botFrameworkIssuer,
+		"aud": appID,
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"nbf": time.Now().Add(-time.Minute).Unix(),
+	}
+}
+
+func TestVerifyTeamsJWT_Valid(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	withTestKey(t, "k1", &key.PublicKey)
+	tok := mkJWT(t, key, "k1", validClaims("bot-app-id"))
+	if err := verifyTeamsJWT(context.Background(), "Bearer "+tok, "bot-app-id"); err != nil {
+		t.Errorf("expected valid token to pass, got: %v", err)
+	}
+}
+
+func TestVerifyTeamsJWT_NoAppID(t *testing.T) {
+	if err := verifyTeamsJWT(context.Background(), "Bearer x", ""); err == nil {
+		t.Error("expected missing App ID to fail")
+	}
+}
+
+func TestVerifyTeamsJWT_WrongAudience(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	withTestKey(t, "k1", &key.PublicKey)
+	tok := mkJWT(t, key, "k1", validClaims("some-other-bot"))
+	if err := verifyTeamsJWT(context.Background(), "Bearer "+tok, "bot-app-id"); err == nil {
+		t.Error("expected wrong audience to fail")
+	}
+}
+
+func TestVerifyTeamsJWT_WrongIssuer(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	withTestKey(t, "k1", &key.PublicKey)
+	claims := validClaims("bot-app-id")
+	claims["iss"] = "https://evil.example.com"
+	tok := mkJWT(t, key, "k1", claims)
+	if err := verifyTeamsJWT(context.Background(), "Bearer "+tok, "bot-app-id"); err == nil {
+		t.Error("expected wrong issuer to fail")
+	}
+}
+
+func TestVerifyTeamsJWT_Expired(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	withTestKey(t, "k1", &key.PublicKey)
+	claims := validClaims("bot-app-id")
+	claims["exp"] = time.Now().Add(-time.Hour).Unix()
+	tok := mkJWT(t, key, "k1", claims)
+	if err := verifyTeamsJWT(context.Background(), "Bearer "+tok, "bot-app-id"); err == nil {
+		t.Error("expected expired token to fail")
+	}
+}
+
+func TestVerifyTeamsJWT_WrongKey(t *testing.T) {
+	signKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	otherKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	withTestKey(t, "k1", &otherKey.PublicKey) // cache holds a DIFFERENT key for k1
+	tok := mkJWT(t, signKey, "k1", validClaims("bot-app-id"))
+	if err := verifyTeamsJWT(context.Background(), "Bearer "+tok, "bot-app-id"); err == nil {
+		t.Error("expected signature mismatch to fail")
+	}
+}
+
+func TestVerifyTeamsJWT_AlgNone(t *testing.T) {
+	// "alg":"none" with an empty signature must be rejected outright.
+	hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","kid":"k1"}`))
+	cb, _ := json.Marshal(validClaims("bot-app-id"))
+	claims := base64.RawURLEncoding.EncodeToString(cb)
+	tok := hdr + "." + claims + "."
+	if err := verifyTeamsJWT(context.Background(), "Bearer "+tok, "bot-app-id"); err == nil {
+		t.Error("expected alg=none to fail")
+	}
+}
+
+func TestVerifyTeamsJWT_Malformed(t *testing.T) {
+	if err := verifyTeamsJWT(context.Background(), "Bearer not-a-jwt", "bot-app-id"); err == nil {
+		t.Error("expected malformed token to fail")
+	}
+}
+
+func TestVerifyTeamsJWT_AudienceArray(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	withTestKey(t, "k1", &key.PublicKey)
+	claims := validClaims("bot-app-id")
+	claims["aud"] = []string{"other", "bot-app-id"}
+	tok := mkJWT(t, key, "k1", claims)
+	if err := verifyTeamsJWT(context.Background(), "Bearer "+tok, "bot-app-id"); err != nil {
+		t.Errorf("expected audience array containing App ID to pass, got: %v", err)
+	}
+}


### PR DESCRIPTION
Three P0 fixes from the 2026-06 suite audit. All verified against code; unit-tested; `go vet`/`gofmt` clean on both `lambda/spore-bot` and `lambda/rest-api`.

## H4 — Teams Bot Framework JWT validation (#372)
The `Bearer …` path did **no** token validation — it only checked that the server-side `TEAMS_APP_ID` env was non-empty. With a public Function URL, any caller could send `Authorization: Bearer anything` + a forged Teams activity and get an executable command.

New `teams_jwt.go` (stdlib only — `crypto/rsa`, JWKS modulus/exponent, no new deps) fully validates the token:
- RS256 signature against Microsoft's published JWKS (cached 24h, keyed by `kid`, stale-key fallback on refresh failure)
- issuer `== https://api.botframework.com`
- audience `== TEAMS_APP_ID` (string or array form)
- expiry / nbf (5-min skew)
- rejects `alg:none` and HMAC-confusion

Fails closed. Covered by `teams_jwt_test.go` (valid, wrong-aud, wrong-iss, expired, wrong-key, alg=none, malformed, aud-array).

## H5 — reject empty signing secret (#373)
HMAC with an empty key is forgeable, and OAuth-installed Slack workspaces persist **no** per-workspace signing secret. `verifySlackSignature` / `verifyTeamsSignature` now reject an empty secret outright. Slack's secret is **app-level**, so the handler falls back to a new `SLACK_SIGNING_SECRET` env when the workspace record has none (per-workspace value still takes precedence for admin-registered/self-hosted). Tests assert a forged-HMAC-with-empty-key is rejected.

> Note: this fails closed for OAuth installs until `SLACK_SIGNING_SECRET` is set in the spore-bot Lambda env — which is the correct posture (the prior behavior accepted forgeable signatures). I'll set that env at deploy.

## H3 — rest-api lifecycle bounds + extend silent-no-op (#371)
Unlike the CLI, the REST API calls the spawn client directly and bypassed the 1h-idle zombie-prevention default → an empty-TTL launch produced an instance with **no deadline and no reaper tag**.
- `handleLaunch`: inject a default idle timeout when neither TTL nor idle is set; cap all durations at 7 days (`capDuration`)
- `extend` action: was writing only `spawn:ttl` (a **silent no-op** — spored honors `spawn:ttl-deadline`; same class as spore-host-mcp#11) and had no maximum. Now pushes the absolute deadline forward, writes both tags, and is capped.
- `/spore extend` + `/spore idle` bot commands (`lifecycle.go`): same deadline fix + 7-day cap.

Fixes #371, #372, #373.

---
Remaining P0 from the audit: **C1** (#369, rest-api tenant isolation) — that's the one architectural call; I'm bringing options separately rather than guessing.