### PR TITLE
fix(security): med/low audit hardening — spore-bot + rest-api (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Security
+- **Medium/Low audit hardening** (#374): the OAuth state HMAC now fails closed
+  when `BOT_OAUTH_SECRET` is unset or still `change-me` (the old default let a
+  forged state complete the flow); Twilio webhook signature verification is
+  **required in production** (`SPORE_ENV=production`) and the
+  `SKIP_TWILIO_SIGNATURE` escape hatch is ignored there; connect codes are now
+  generated with `crypto/rand` (8 hex chars, ~4.3B) instead of a time-seeded
+  value; and `MarkTerminated`'s DynamoDB retention now matches its documented
+  7 days (was 24h).
 - **Hosted REST API now enforces per-project tenant isolation** (audit C1, #369).
   Previously every handler received a validated API-key principal but never used
   it, so any valid key could list/launch/stop/terminate/extend **every** instance

--- a/lambda/rest-api/sms.go
+++ b/lambda/rest-api/sms.go
@@ -25,8 +25,17 @@ import (
 // handleSMSIncoming processes a Twilio webhook for an inbound SMS reply.
 // The To field identifies the project; the From field identifies the user.
 func handleSMSIncoming(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	// Twilio signature enforcement (2026-06 audit, M-sec). In production the auth
+	// token is REQUIRED and the skip flag is ignored — otherwise an unset token or
+	// a stray SKIP_TWILIO_SIGNATURE=true would silently accept forged webhooks
+	// (which can start instances and reset idle timers). The skip escape hatch is
+	// honored only outside production.
 	authToken := os.Getenv("TWILIO_AUTH_TOKEN")
-	skipSig := os.Getenv("SKIP_TWILIO_SIGNATURE") == "true"
+	prod := isProd()
+	if prod && authToken == "" {
+		return errResp(http.StatusServiceUnavailable, "SMS not configured"), nil
+	}
+	skipSig := !prod && os.Getenv("SKIP_TWILIO_SIGNATURE") == "true"
 	if authToken != "" && !skipSig && !validateTwilioSignature(req, authToken) {
 		return errResp(http.StatusForbidden, "invalid Twilio signature"), nil
 	}

--- a/lambda/rest-api/util.go
+++ b/lambda/rest-api/util.go
@@ -2,11 +2,25 @@ package main
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 )
 
 func parseJSON(body string, v any) error {
 	return json.Unmarshal([]byte(body), v)
+}
+
+// isProd reports whether the Lambda is running in the production environment,
+// per the SPORE_ENV var (set at deploy: "integ" for staging, "production"/"prod"
+// for prod). Used to fail closed on security gates that have non-prod escape
+// hatches.
+func isProd() bool {
+	switch strings.ToLower(os.Getenv("SPORE_ENV")) {
+	case "production", "prod":
+		return true
+	default:
+		return false
+	}
 }
 
 func trim(s string) string               { return strings.TrimSpace(s) }

--- a/lambda/rest-api/util_test.go
+++ b/lambda/rest-api/util_test.go
@@ -119,6 +119,23 @@ func TestBuildOptionsHint(t *testing.T) {
 	}
 }
 
+func TestIsProd(t *testing.T) {
+	cases := map[string]bool{
+		"production": true,
+		"PROD":       true,
+		"prod":       true,
+		"integ":      false,
+		"":           false,
+		"dev":        false,
+	}
+	for val, want := range cases {
+		t.Setenv("SPORE_ENV", val)
+		if got := isProd(); got != want {
+			t.Errorf("isProd() with SPORE_ENV=%q = %v, want %v", val, got, want)
+		}
+	}
+}
+
 func TestOwnsInstance(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/lambda/spore-bot/executor.go
+++ b/lambda/spore-bot/executor.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -606,6 +608,16 @@ func platformConnectTTL() time.Duration {
 	return 24 * time.Hour
 }
 
+// generateConnectCode returns an unguessable 8-char uppercase hex connect code
+// (4 bytes of crypto/rand entropy).
+func generateConnectCode() (string, error) {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return strings.ToUpper(hex.EncodeToString(b)), nil
+}
+
 // cmdConnect generates a connect code for self-registration.
 // Usage: /<cmd> connect [duration]   e.g. /spore connect 4h
 // Duration cannot exceed the workspace or platform maximum.
@@ -639,8 +651,13 @@ func cmdConnect(ctx context.Context, reg *Registry, action *BotAction) (string, 
 		ttl = requested
 	}
 
-	// Generate a human-friendly 6-character uppercase hex code
-	code := strings.ToUpper(fmt.Sprintf("%06x", time.Now().UnixNano()%0xFFFFFF))
+	// Generate an unguessable connect code. The old scheme was time-seeded
+	// (UnixNano % 0xFFFFFF → ~16.7M, predictable from the request time); use
+	// crypto/rand → 8 uppercase hex chars (~4.3B) instead (2026-06 audit L-sec).
+	code, err := generateConnectCode()
+	if err != nil {
+		return "", fmt.Errorf("generate connect code: %w", err)
+	}
 
 	cc := ConnectCode{
 		CodeKey:     "connect#" + code,

--- a/lambda/spore-bot/oauth.go
+++ b/lambda/spore-bot/oauth.go
@@ -40,7 +40,11 @@ func handleOAuthRedirect(platform string, request events.APIGatewayProxyRequest)
 		return oauthError(500, "Failed to generate PKCE verifier"), nil
 	}
 	challenge := oauthSHA256B64URL(verifier)
-	state := oauthSignedState(platform, verifier)
+	state, err := oauthSignedState(platform, verifier)
+	if err != nil {
+		logf("oauth: %v", err)
+		return oauthError(500, "OAuth is not configured"), nil
+	}
 
 	redirectURI := oauthRedirectURI(platform, request)
 	authURL := fmt.Sprintf("%s?client_id=%s&scope=%s&redirect_uri=%s&code_challenge=%s&code_challenge_method=S256&state=%s",
@@ -230,11 +234,14 @@ func oauthSHA256B64URL(s string) string {
 
 // oauthSignedState embeds platform + code_verifier in an HMAC-signed state parameter.
 // Signed with BOT_OAUTH_SECRET env var (shared across platforms).
-func oauthSignedState(platform, verifier string) string {
+func oauthSignedState(platform, verifier string) (string, error) {
 	ts := strconv.FormatInt(time.Now().Unix(), 10)
 	payload := base64.RawURLEncoding.EncodeToString([]byte(platform + ":" + verifier + ":" + ts))
-	sig := oauthHMAC(payload)
-	return payload + "." + sig
+	sig, err := oauthHMAC(payload)
+	if err != nil {
+		return "", err
+	}
+	return payload + "." + sig, nil
 }
 
 func oauthExtractVerifier(platform, state string) (string, error) {
@@ -246,7 +253,11 @@ func oauthExtractVerifier(platform, state string) (string, error) {
 		return "", fmt.Errorf("malformed state")
 	}
 	payload, sig := parts[0], parts[1]
-	if expected := oauthHMAC(payload); !hmac.Equal([]byte(expected), []byte(sig)) {
+	expected, err := oauthHMAC(payload)
+	if err != nil {
+		return "", err
+	}
+	if !hmac.Equal([]byte(expected), []byte(sig)) {
 		return "", fmt.Errorf("state signature invalid")
 	}
 	raw, err := base64.RawURLEncoding.DecodeString(payload)
@@ -283,11 +294,29 @@ func oauthExtractVerifier(platform, state string) (string, error) {
 	return verifier, nil
 }
 
-func oauthHMAC(data string) string {
-	secret := getEnv("BOT_OAUTH_SECRET", "change-me")
+// errOAuthSecretUnset signals a misconfigured BOT_OAUTH_SECRET. The OAuth state
+// HMAC must never fall back to a known constant (the old "change-me" default
+// let anyone forge a valid state and complete the CSRF-protected flow).
+var errOAuthSecretUnset = fmt.Errorf("BOT_OAUTH_SECRET is not configured")
+
+// oauthSecret returns the configured OAuth signing secret, or an error if it is
+// empty or still the placeholder. Fail closed (2026-06 audit, M-sec).
+func oauthSecret() (string, error) {
+	secret := os.Getenv("BOT_OAUTH_SECRET")
+	if secret == "" || secret == "change-me" {
+		return "", errOAuthSecretUnset
+	}
+	return secret, nil
+}
+
+func oauthHMAC(data string) (string, error) {
+	secret, err := oauthSecret()
+	if err != nil {
+		return "", err
+	}
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(data))
-	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 }
 
 func oauthRedirectResult(successURL, params string) events.APIGatewayProxyResponse {

--- a/lambda/spore-bot/oauth_test.go
+++ b/lambda/spore-bot/oauth_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOAuthSecret_FailClosed(t *testing.T) {
+	cases := []struct {
+		name   string
+		val    string
+		setEnv bool
+		wantOK bool
+	}{
+		{"unset", "", false, false},
+		{"empty", "", true, false},
+		{"placeholder", "change-me", true, false},
+		{"real", "s3cr3t-value", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv("BOT_OAUTH_SECRET", tc.val)
+			} else {
+				t.Setenv("BOT_OAUTH_SECRET", "") // ensure clean
+			}
+			_, err := oauthSecret()
+			if (err == nil) != tc.wantOK {
+				t.Errorf("oauthSecret() err=%v, wantOK=%v", err, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestOAuthSignedState_RoundTrip(t *testing.T) {
+	t.Setenv("BOT_OAUTH_SECRET", "round-trip-secret")
+	state, err := oauthSignedState("slack", "verifier-123")
+	if err != nil {
+		t.Fatalf("oauthSignedState: %v", err)
+	}
+	got, err := oauthExtractVerifier("slack", state)
+	if err != nil {
+		t.Fatalf("oauthExtractVerifier: %v", err)
+	}
+	if got != "verifier-123" {
+		t.Errorf("verifier = %q, want verifier-123", got)
+	}
+}
+
+func TestOAuthExtractVerifier_ForgedWithPlaceholder(t *testing.T) {
+	// A state forged with the old "change-me" default must not validate once a
+	// real secret is configured.
+	t.Setenv("BOT_OAUTH_SECRET", "change-me")
+	forged, err := oauthSignedState("slack", "attacker")
+	if err == nil {
+		// With the fix, signing under "change-me" itself fails closed.
+		t.Fatalf("expected signing under placeholder to fail, got state %q", forged)
+	}
+}
+
+func TestGenerateConnectCode(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		c, err := generateConnectCode()
+		if err != nil {
+			t.Fatalf("generateConnectCode: %v", err)
+		}
+		if len(c) != 8 {
+			t.Errorf("code %q length = %d, want 8", c, len(c))
+		}
+		if c != strings.ToUpper(c) {
+			t.Errorf("code %q not uppercase", c)
+		}
+		if seen[c] {
+			t.Errorf("duplicate code %q within 100 draws", c)
+		}
+		seen[c] = true
+	}
+}

--- a/lambda/spore-bot/registry.go
+++ b/lambda/spore-bot/registry.go
@@ -513,7 +513,7 @@ func (r *Registry) RedeemConnectCode(ctx context.Context, code string) (*Connect
 // Called by /spore list when EC2 reports the instance as terminated.
 func (r *Registry) MarkTerminated(ctx context.Context, reg *BotRegistration) error {
 	now := time.Now().UTC()
-	expiry := now.Add(24 * time.Hour).Unix()
+	expiry := now.Add(7 * 24 * time.Hour).Unix() // 7-day retention (matches doc comment; 2026-06 audit M-corr)
 	_, err := r.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: &r.registryTable,
 		Key: map[string]dynamodbtypes.AttributeValue{


### PR DESCRIPTION
Knocks out four self-contained items from the Medium/Low audit tracker (#374). Unit-tested; `go vet`/`gofmt` clean on both `lambda/spore-bot` and `lambda/rest-api`.

| Item | Sev | Fix |
|---|---|---|
| OAuth state HMAC fell back to hardcoded `change-me` | M-sec | `oauthSecret()` fails closed when `BOT_OAUTH_SECRET` is unset or `change-me`; `oauthHMAC`/`oauthSignedState` now return errors and the authorize handler 500s rather than signing with a known key. A state forged under the placeholder no longer validates. |
| Twilio signature globally disableable / skipped when token unset | M-sec | In production (`SPORE_ENV=production`/`prod`) the auth token is **required** and `SKIP_TWILIO_SIGNATURE` is **ignored**; the skip escape hatch is honored only outside prod. New `isProd()` helper. |
| Connect codes time-seeded (~16.7M, predictable) | L-sec | `generateConnectCode()` uses `crypto/rand` → 8 uppercase hex chars (~4.3B). Redeem path unaffected (trims `SPORE-` prefix, no hardcoded length). |
| `MarkTerminated` comment says 7-day retention, code used 24h | M-corr | Aligned to 7 days. |

Tests added: oauth fail-closed (unset/empty/placeholder/real) + round-trip, connect-code format/uniqueness, `isProd`.

Refs #374. Remaining tracker items (cross-account ExternalId entropy, GSI for the Scan paths, hashed API keys, dead-code cleanup of the verifyNotifyAuth/RedeemConnectCode chain) left for follow-up — noted there.

> Note: deploy-time — set `SPORE_ENV=production` on the prod rest-api Lambda for the Twilio gate to enforce. Verified `BOT_OAUTH_SECRET` is already set (not `change-me`) on the live spore-bot, so the OAuth fail-closed change is a no-op there.