### PR TITLE
fix: floor extend deadline at now+duration — prevent premature reaping (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Fixed
+- **`extend` can no longer prematurely reap an instance** (audit M-corr, #374).
+  The bot `/spore extend`, the REST API `extend` action, and the SMS `extend`
+  reply now floor the new TTL deadline at `now + requested-duration`. Previously,
+  if the instance had a missing/unparseable `spawn:ttl` (deadline anchored to a
+  long-past launch time) or an already-expired `spawn:ttl-deadline`, the
+  recomputed deadline could land in the past — terminating the instance at the
+  moment the user asked to keep it alive. An extend now always grants at least
+  the requested duration from the current moment.
+
 ### Security
 - **Medium/Low audit hardening** (#374): the OAuth state HMAC now fails closed
   when `BOT_OAUTH_SECRET` is unset or still `change-me` (the old default let a

--- a/lambda/rest-api/instances.go
+++ b/lambda/rest-api/instances.go
@@ -312,6 +312,13 @@ func handleInstanceAction(ctx context.Context, cfg aws.Config, id, action string
 				newDeadline = time.Now().Add(extendDuration)
 			}
 		}
+		// Safety floor (2026-06 audit, M-corr): an extend must never produce a
+		// deadline earlier than the requested duration from now — otherwise a
+		// past/expired existing deadline would reap the instance the moment the
+		// caller asked to keep it.
+		if floor := time.Now().Add(extendDuration); newDeadline.Before(floor) {
+			newDeadline = floor
+		}
 		if err := client.UpdateInstanceTags(ctx, target.Region, target.InstanceID, map[string]string{
 			"spawn:ttl":          body.Duration,
 			"spawn:ttl-deadline": newDeadline.UTC().Format(time.RFC3339),

--- a/lambda/rest-api/sms.go
+++ b/lambda/rest-api/sms.go
@@ -135,6 +135,12 @@ func executeAction(ctx context.Context, p *sms.PendingNotification, action strin
 		if newDeadline.IsZero() {
 			newDeadline = time.Now().Add(extendDuration)
 		}
+		// Safety floor (2026-06 audit, M-corr): never set a deadline earlier than
+		// the requested duration from now — a past/expired existing deadline must
+		// not reap the instance the moment the user replies to keep it.
+		if floor := time.Now().Add(extendDuration); newDeadline.Before(floor) {
+			newDeadline = floor
+		}
 		if err := client.UpdateInstanceTags(ctx, p.Region, p.InstanceID, map[string]string{
 			"spawn:ttl":          dur,
 			"spawn:ttl-deadline": newDeadline.UTC().Format(time.RFC3339),

--- a/lambda/spore-bot/lifecycle.go
+++ b/lambda/spore-bot/lifecycle.go
@@ -15,6 +15,26 @@ import (
 // disabling the lifecycle backstop.
 const maxBotTTL = 7 * 24 * time.Hour
 
+// computeExtendedDeadline returns the new absolute TTL deadline for an extend.
+// It pushes the existing deadline forward by extension; if there is no deadline
+// tag it anchors to launchTime+newTTL. A safety floor (2026-06 audit, M-corr)
+// guarantees the result is never earlier than now+extension — so a missing or
+// already-expired prior deadline (or a stale launch anchor) can never set a
+// deadline in the past and reap the instance the moment the user asks to keep
+// it. An extend always grants at least `extension` from the current moment.
+func computeExtendedDeadline(now, currentDeadline, launchTime time.Time, newTTL, extension time.Duration) time.Time {
+	var d time.Time
+	if currentDeadline.IsZero() {
+		d = launchTime.Add(newTTL)
+	} else {
+		d = currentDeadline.Add(extension)
+	}
+	if floor := now.Add(extension); d.Before(floor) {
+		d = floor
+	}
+	return d
+}
+
 // extendTTL adds duration to the instance's current TTL by updating the spawn:ttl EC2 tag.
 // Usage: /spore extend <name> <duration>  e.g. /spore extend rstudio 2h
 func extendTTL(ctx context.Context, client *ec2.Client, reg *BotRegistration, durationStr, slashCmd string) (string, error) {
@@ -67,13 +87,7 @@ func extendTTL(ctx context.Context, client *ec2.Client, reg *BotRegistration, du
 	// <prefix>:ttl. Writing only :ttl is a silent no-op — the instance still dies
 	// at its original deadline (same bug class as spore-host-mcp#11). Push the
 	// absolute deadline forward and write BOTH tags.
-	newDeadline := currentDeadline
-	if newDeadline.IsZero() {
-		// Older instance without the deadline tag — anchor to launch + new TTL.
-		newDeadline = launchTime.Add(newTTL)
-	} else {
-		newDeadline = newDeadline.Add(extension)
-	}
+	newDeadline := computeExtendedDeadline(time.Now(), currentDeadline, launchTime, newTTL, extension)
 
 	_, err = client.CreateTags(ctx, &ec2.CreateTagsInput{
 		Resources: []string{reg.InstanceID},

--- a/lambda/spore-bot/lifecycle_test.go
+++ b/lambda/spore-bot/lifecycle_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestComputeExtendedDeadline(t *testing.T) {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	hour := time.Hour
+
+	cases := []struct {
+		name            string
+		currentDeadline time.Time
+		launchTime      time.Time
+		newTTL          time.Duration
+		extension       time.Duration
+		want            time.Time
+	}{
+		{
+			name:            "future deadline pushed forward",
+			currentDeadline: now.Add(3 * hour),
+			extension:       2 * hour,
+			want:            now.Add(5 * hour),
+		},
+		{
+			name:            "expired deadline floored to now+extension",
+			currentDeadline: now.Add(-10 * hour), // already past — would reap immediately
+			extension:       2 * hour,
+			want:            now.Add(2 * hour),
+		},
+		{
+			name:       "no deadline tag, stale launch + zero TTL floored",
+			launchTime: now.Add(-30 * hour), // missing/unparseable ttl → newTTL==extension
+			newTTL:     2 * hour,
+			extension:  2 * hour,
+			want:       now.Add(2 * hour), // launch+2h is in the past → floored
+		},
+		{
+			name:       "no deadline tag, launch + ttl in future kept",
+			launchTime: now.Add(-1 * hour),
+			newTTL:     5 * hour, // launch+5h = now+4h
+			extension:  2 * hour,
+			want:       now.Add(4 * hour),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeExtendedDeadline(now, tc.currentDeadline, tc.launchTime, tc.newTTL, tc.extension)
+			if !got.Equal(tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+			// Invariant: never earlier than now+extension.
+			if got.Before(now.Add(tc.extension)) {
+				t.Errorf("result %v is earlier than floor now+extension %v", got, now.Add(tc.extension))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes the **[M corr] `extendTTL` premature-reaping** item from the audit tracker (#374).

## The bug
An `extend` recomputes the absolute `spawn:ttl-deadline`. In two cases the result could land **in the past**, so spored reaps the instance at the very moment the user asked to keep it:
1. **Missing/unparseable `spawn:ttl`** → the no-deadline-tag fallback anchors to `launchTime + newTTL`; for an instance launched long ago with `newTTL≈extension`, that's already past.
2. **Already-expired `spawn:ttl-deadline`** (instance overdue but not yet reaped) → `parsed.Add(extension)` can still be `< now`.

## Fix
All three extend paths floor the new deadline at `now + requested-duration` — an extend always grants **at least** the requested duration from the current moment:
- **spore-bot `/spore extend`** (`lifecycle.go`) — logic extracted to a pure `computeExtendedDeadline(now, currentDeadline, launchTime, newTTL, extension)`, unit-tested (future-deadline, expired-deadline, stale-launch+zero-TTL, future-launch).
- **rest-api `extend` action** (`instances.go`)
- **rest-api SMS `extend:` reply** (`sms.go`)

`go test`/`vet`/`gofmt` clean on both `lambda/spore-bot` and `lambda/rest-api`.

## Follow-up (separate repos, same root cause)
`spawn` `cmd/extend.go` and `spore-host-mcp` `handleSpawnExtend` have the identical pattern (a past `spawn:ttl-deadline` → `parsed+extension` can be `< now`). I'll fix those in their own repos' PRs and update #374.

Refs #374.