### PR TITLE
chore: remove dead Registry.RedeemConnectCode (audit L-health, #374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Removed
+- Dead `Registry.RedeemConnectCode` in spore-bot (audit L-health, #374). Connect
+  codes are redeemed on the spawn side (`spawn bot register --connect-code`,
+  which atomically deletes the shared-table item); the Lambda only issues them.
+  The duplicate, never-called Lambda-side redeem method is removed to avoid
+  misrepresenting the flow.
+
 ### Fixed
 - **`extend` can no longer prematurely reap an instance** (audit M-corr, #374).
   The bot `/spore extend`, the REST API `extend` action, and the SMS `extend`

--- a/lambda/spore-bot/registry.go
+++ b/lambda/spore-bot/registry.go
@@ -482,32 +482,10 @@ func (r *Registry) PutConnectCode(ctx context.Context, code ConnectCode) error {
 	return err
 }
 
-// RedeemConnectCode atomically deletes a connect code and returns it.
-// Returns nil if the code does not exist or has expired (DynamoDB TTL is eventual
-// so we also check the TTL field explicitly).
-func (r *Registry) RedeemConnectCode(ctx context.Context, code string) (*ConnectCode, error) {
-	result, err := r.client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
-		TableName: &r.workspacesTable,
-		Key: map[string]dynamodbtypes.AttributeValue{
-			"workspace_key": &dynamodbtypes.AttributeValueMemberS{Value: "connect#" + code},
-		},
-		ReturnValues: dynamodbtypes.ReturnValueAllOld,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("redeem connect code: %w", err)
-	}
-	if result.Attributes == nil {
-		return nil, nil
-	}
-	var cc ConnectCode
-	if err := attributevalue.UnmarshalMap(result.Attributes, &cc); err != nil {
-		return nil, fmt.Errorf("unmarshal connect code: %w", err)
-	}
-	if time.Now().Unix() > cc.TTL {
-		return nil, nil // expired
-	}
-	return &cc, nil
-}
+// Connect codes are redeemed on the spawn side (spawn `bot register
+// --connect-code`, which atomically DeleteItems the shared table); the Lambda
+// only issues them via PutConnectCode. A duplicate Lambda-side redeem method was
+// removed as dead code (2026-06 audit, L-health, #374).
 
 // MarkTerminated stamps terminated_at and sets a 7-day DynamoDB TTL on a registration.
 // Called by /spore list when EC2 reports the instance as terminated.


### PR DESCRIPTION
Addresses the **[L health]** item in the audit tracker (#374): dead trust/connect code that misrepresents posture.

**Investigated the whole flagged set; only one piece was actually dead:**

- **`Registry.RedeemConnectCode`** — **zero callers**, removed. Connect codes are redeemed on the **spawn side** (`spawn bot register --connect-code` → `redeemConnectCode` in `spawn/cmd/bot.go`, which does its own atomic `DeleteItem` on the shared DynamoDB table). The Lambda only *issues* codes (`PutConnectCode`). The Lambda-side redeem method was a duplicate implementation that never ran.

- **`verifyNotifyAuth` trust chain** (`verifyInstanceIdentitySignature`, `verifyPKCS7`) — **NOT dead.** The audit item predates the C2 fix (#370, now **closed**), which wired `verifyNotifyAuth` into `/notify` log-only. Enforcement is intentionally gated on EC2 identity-cert reliability (#294, open), and the code comment says so. Posture is correctly represented — left as-is.

Net: one orphaned method deleted; `go build`/`test`/`vet`/`gofmt` clean.

Refs #374.