### PR TITLE
feat(spore-bot): format pre_stop_failed / pre_stop_timeout events (spawn#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Added
+- spore-bot formats the new `pre_stop_failed` / `pre_stop_timeout` lifecycle
+  events (spawn#186): a failed or timed-out `--pre-stop` hook now shows as a
+  loud orange/red Slack/Teams/Discord message (and SMS) carrying the hook's
+  error/output tail, instead of being indistinguishable from a clean shutdown.
+  Surfaces the spawn#184 data-loss shape (a pre-stop that "succeeded" saving
+  nothing).
+
 ### Removed
 - Dead `Registry.RedeemConnectCode` in spore-bot (audit L-health, #374). Connect
   codes are redeemed on the spawn side (`spawn bot register --connect-code`,

--- a/lambda/spore-bot/discord.go
+++ b/lambda/spore-bot/discord.go
@@ -64,6 +64,10 @@ func buildDiscordEmbed(nr NotifyRequest) discordEmbed {
 		icon, title, color = "⚠️", fmt.Sprintf("%s received a Spot interruption notice — %s", name, nr.Detail), discordColorYellow
 	case "pre_stop_start":
 		icon, title, color = "🔄", fmt.Sprintf("%s is running its shutdown task before terminating", name), discordColorBlue
+	case "pre_stop_failed":
+		icon, title, color = "🟠", fmt.Sprintf("%s shutdown task FAILED — output may NOT have been saved", name), discordColorRed
+	case "pre_stop_timeout":
+		icon, title, color = "🟠", fmt.Sprintf("%s shutdown task TIMED OUT — output may be incomplete", name), discordColorRed
 	default:
 		icon, title = "ℹ️", fmt.Sprintf("%s: %s", name, nr.EventType)
 	}
@@ -77,6 +81,10 @@ func buildDiscordEmbed(nr NotifyRequest) discordEmbed {
 		embed.URL = "https://" + nr.DNSName
 		embed.Fields = append(embed.Fields, discordEmbedField{Name: "URL", Value: "https://" + nr.DNSName, Inline: false})
 	}
+	// Surface the hook's error/output tail for failed/timed-out pre-stop (#186).
+	if (nr.EventType == "pre_stop_failed" || nr.EventType == "pre_stop_timeout") && nr.Detail != "" {
+		embed.Fields = append(embed.Fields, discordEmbedField{Name: "Details", Value: "```" + truncateDetail(nr.Detail, 1000) + "```", Inline: false})
+	}
 	if nr.InstanceID != "" {
 		embed.Fields = append(embed.Fields, discordEmbedField{Name: "Instance", Value: "`" + nr.InstanceID + "`", Inline: true})
 	}
@@ -84,6 +92,16 @@ func buildDiscordEmbed(nr NotifyRequest) discordEmbed {
 		embed.Fields = append(embed.Fields, discordEmbedField{Name: "Region", Value: nr.Region, Inline: true})
 	}
 	return embed
+}
+
+// truncateDetail trims a detail string to max runes (Discord embed field values
+// are capped at 1024 chars; we leave headroom for the code fences).
+func truncateDetail(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
 }
 
 // postDiscordWebhook POSTs an embed to a Discord channel webhook URL (#2).

--- a/lambda/spore-bot/discord_test.go
+++ b/lambda/spore-bot/discord_test.go
@@ -46,18 +46,37 @@ func TestBuildDiscordEmbed_ColorAndFields(t *testing.T) {
 
 func TestBuildDiscordEmbed_SeverityColors(t *testing.T) {
 	cases := map[string]int{
-		"completion":     discordColorGreen,
-		"ttl_expired":    discordColorRed,
-		"idle_stopped":   discordColorRed,
-		"spot_interrupt": discordColorYellow,
-		"idle_warning":   discordColorYellow,
-		"pre_stop_start": discordColorBlue,
+		"completion":       discordColorGreen,
+		"ttl_expired":      discordColorRed,
+		"idle_stopped":     discordColorRed,
+		"spot_interrupt":   discordColorYellow,
+		"idle_warning":     discordColorYellow,
+		"pre_stop_start":   discordColorBlue,
+		"pre_stop_failed":  discordColorRed,
+		"pre_stop_timeout": discordColorRed,
 	}
 	for event, want := range cases {
 		e := buildDiscordEmbed(NotifyRequest{EventType: event, InstanceName: "x"})
 		if e.Color != want {
 			t.Errorf("%s color = %#x, want %#x", event, e.Color, want)
 		}
+	}
+}
+
+func TestBuildDiscordEmbed_PreStopFailureCarriesDetail(t *testing.T) {
+	e := buildDiscordEmbed(NotifyRequest{
+		EventType:    "pre_stop_failed",
+		InstanceName: "gpu1",
+		Detail:       "exit 1 — fatal error: Unable to locate credentials",
+	})
+	var hasDetail bool
+	for _, f := range e.Fields {
+		if f.Name == "Details" && strings.Contains(f.Value, "Unable to locate credentials") {
+			hasDetail = true
+		}
+	}
+	if !hasDetail {
+		t.Errorf("pre_stop_failed embed should carry a Details field with the hook output: %+v", e.Fields)
 	}
 }
 

--- a/lambda/spore-bot/notify.go
+++ b/lambda/spore-bot/notify.go
@@ -253,6 +253,16 @@ func formatNotification(nr NotifyRequest) string {
 		icon, verb = "⚠️", fmt.Sprintf("*%s* received a Spot interruption notice — %s", name, nr.Detail)
 	case "pre_stop_start":
 		icon, verb = "🔄", fmt.Sprintf("*%s* is running its shutdown task before terminating", name)
+	case "pre_stop_failed":
+		icon, verb = "🟠", fmt.Sprintf("*%s* shutdown task FAILED — output may NOT have been saved", name)
+		if nr.Detail != "" {
+			verb += fmt.Sprintf("\n  ```%s```", nr.Detail)
+		}
+	case "pre_stop_timeout":
+		icon, verb = "🟠", fmt.Sprintf("*%s* shutdown task TIMED OUT — output may be incomplete", name)
+		if nr.Detail != "" {
+			verb += fmt.Sprintf("\n  ```%s```", nr.Detail)
+		}
 	default:
 		icon, verb = "ℹ️", fmt.Sprintf("*%s*: %s", name, nr.EventType)
 	}
@@ -308,6 +318,7 @@ func sendUserSMS(ctx context.Context, reg *Registry, nr NotifyRequest) {
 	if nr.Detail != "" {
 		extra["remaining"] = nr.Detail
 		extra["idle_duration"] = nr.Detail
+		extra["detail"] = nr.Detail // pre_stop_failed/timeout carry the hook's error/output tail (#186)
 	}
 	msgText, options := twilioMessage(nr.InstanceName, nr.EventType, extra)
 


### PR DESCRIPTION
Paired with spawn#189. spored now emits `pre_stop_failed` / `pre_stop_timeout` when a `--pre-stop` hook fails or is killed at its timeout (spawn#186); this formats them across the spore-bot notifier so the failure is loud instead of silent (the spawn#184 data-loss shape).

- **`formatNotification`** (Slack/Teams): 🟠 header, "output may NOT have been saved", with the hook's error/output tail in a code block.
- **`buildDiscordEmbed`**: red embed + a **Details** field carrying the (truncated to 1000 chars) tail.
- **`BuildMessage`** (SMS): "shutdown task FAILED / TIMED OUT" + detail.
- **`notify.go`**: threads `nr.Detail` into the SMS `extra` map as `detail`.

Tests: severity-color map covers both events; new `TestBuildDiscordEmbed_PreStopFailureCarriesDetail` asserts the Details field carries the hook output. `go test ./...` green; vet/fmt clean.

Refs spawn#186, spawn#184.