### PR TITLE
fix(web): hold demo video on final frame for 10s before restart

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -314,9 +314,21 @@ tar -xzf truffle_*_$(uname -s)_$(uname -m).tar.gz</code></pre>
         fit: 'width',
         idleTimeLimit: 2    // compress idle gaps in the cast to max 2s
       });
-      // Pause 10 seconds at the end so viewers can see the final state, then restart
+      // Hold on the final frame for 10s so viewers can read the end state, then
+      // restart from the top. Explicitly pause() (the prior code only re-played,
+      // which restarted immediately with no visible hold), then seek(0)+play()
+      // after the delay. Guarded so a repeated 'ended' can't stack timers.
+      var PAUSE_MS = 10000;
+      var looping = false;
       p.addEventListener('ended', function() {
-        setTimeout(function() { p.play(); }, 10000);
+        if (looping) return;
+        looping = true;
+        p.pause();
+        setTimeout(function() {
+          p.seek(0);
+          p.play();
+          looping = false;
+        }, PAUSE_MS);
       });
     };
     document.head.appendChild(script);


### PR DESCRIPTION
## Problem
The landing-page asciinema demo restarted **immediately** at the end instead of pausing — there was no visible hold on the final frame for viewers to read the end state.

## Cause
The prior `ended` handler only scheduled `p.play()` after a timeout. With nothing pausing/holding the player, it restarted right away (the delayed `play()` was effectively a no-op on an already-restarting player).

## Fix
On `ended`: explicitly `p.pause()`, then after **10s** `p.seek(0)` + `p.play()` — using the player's documented `pause()`/`seek()`/`play()` API and the `ended` event (asciinema-player v3.14.0). Guarded with a `looping` flag so a repeated `ended` can't stack timers.

```js
p.addEventListener('ended', function() {
  if (looping) return;
  looping = true;
  p.pause();
  setTimeout(function() { p.seek(0); p.play(); looping = false; }, 10000);
});
```

Single-file change to `web/index.html`. Verify by loading the page, letting the demo finish, and confirming it holds on the last frame ~10s before replaying from the top.