### PR TITLE
docs: lagotto launch + poll scoping, and the Capacity Block flow

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -50,6 +50,8 @@ lagotto list   # see active watches
 
 Lagotto is useful when you have a job queued but can't launch it yet — you want to be notified the moment capacity opens up, or you want the launch to happen automatically.
 
+It triggers on two things: **capacity** (`lagotto watch`) and **time** (`lagotto launch --at/--after/--cron`). The time-based mode exists so you can launch into an EC2 Capacity Block for ML at its reserved start time — the block becomes usable at a fixed hour, and the launch fires automatically with no one awake to run it.
+
 ### <span class="tool-badge bot">Spore-bot</span> — Control from anywhere
 
 Once an instance is running, you might not want to open a terminal to manage it. Spore-bot connects your Slack or Teams workspace to your running instances. Any team member you've authorized can type `/spore status`, `/spore stop`, or `/spore extend 4h` and it just works — from any device, any location.

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -94,15 +94,43 @@ spawn notify list --platform slack --workspace-id T0...
 ## lagotto
 
 ```sh
+# Watch for capacity, act when it appears
 lagotto watch "p5.48xlarge" --action notify
 lagotto watch "p5.48xlarge" --regions us-east-1 --action notify \
   --notify email:you@example.com
 lagotto watch "g5.xlarge" --action spawn --spawn-config job.yaml
+lagotto watch "g5.xlarge" --action spawn --spawn-config job.yaml --project fieldwork
 lagotto list
 lagotto status <watch-id>
 lagotto cancel <watch-id>
 lagotto extend <watch-id> --ttl 7d
 lagotto history
+
+# Schedule a launch by time (requires `lagotto deploy` first)
+lagotto launch --at 2026-07-01T08:00:00Z --az us-east-1a --spawn-config block.yaml
+lagotto launch --after 6h --spawn-config job.yaml
+lagotto launch --cron "0 9 ? * MON-FRI *" --spawn-config nightly.yaml
+
+# Poll: one cycle, or an infra-free daemon (scope it in a shared account)
+lagotto poll
+lagotto poll --daemon --interval 5m --project fieldwork
+lagotto poll --daemon --mine
+
+# Deploy / remove the hosted poller stack in your account
+lagotto deploy
+lagotto deploy --teardown
+```
+
+## Capacity Blocks for ML (truffle → spawn → lagotto)
+
+```sh
+# 1. Find a purchasable offering (read-only)
+truffle capacity-blocks --instance-type p5.48xlarge --count 1 --duration-hours 24
+# 2. Purchase it (up-front, non-refundable; three typed confirmations, interactive only)
+spawn capacity-block purchase <offering-id> --instance-type p5.48xlarge \
+  --count 1 --duration-hours 24 --region us-east-1 --dry-run   # preview; drop --dry-run to buy
+# 3. Launch into it at the reserved start time (block.yaml sets reservation_id + capacity_block)
+lagotto launch --at <block-start> --az <block-az> --spawn-config block.yaml
 ```
 
 ## Environment variables

--- a/docs/tools/lagotto.md
+++ b/docs/tools/lagotto.md
@@ -95,11 +95,39 @@ lagotto history --watch-id <watch-id>  # one watch
 
 ### `lagotto poll`
 
-Manually trigger one polling cycle (useful for testing):
+Manually trigger one polling cycle (useful for testing), or loop in the foreground with `--daemon`:
 
 ```sh
-lagotto poll
+lagotto poll                                 # one cycle
+lagotto poll --daemon --interval 5m          # loop, infra-free (no Lambda needed)
 ```
+
+In a **shared account**, scope a daemon to your own watches so it doesn't drive another project's:
+
+```sh
+lagotto poll --daemon --project fieldwork    # only that project (or $LAGOTTO_PROJECT)
+lagotto poll --daemon --mine                 # only watches you created
+lagotto poll --daemon --watch w-aaa,w-bbb    # only these watch IDs
+```
+
+A scoped daemon exits when **its** watches drain. Before acting on a match a poller claims a short **lease** on the watch, so two daemons — or a daemon racing the hosted Lambda — can't both launch it (`--no-lease` opts out). Tag a watch for scoping with `lagotto watch --project NAME` (or `$LAGOTTO_PROJECT`).
+
+### `lagotto launch`
+
+Schedule a launch by **time** rather than capacity — fire once at a clock time (`--at`), after a delay (`--after`), or on a recurring cron (`--cron`):
+
+```sh
+# Launch into a Capacity Block at its reserved start time
+lagotto launch --at 2026-07-01T08:00:00Z --az us-east-1a --spawn-config block.yaml
+
+# Launch 6 hours from now
+lagotto launch --after 6h --spawn-config job.yaml
+
+# Recurring: every weekday at 09:00 UTC
+lagotto launch --cron "0 9 ? * MON-FRI *" --spawn-config nightly.yaml
+```
+
+The motivating case is launching into an **EC2 Capacity Block for ML** at its reserved start time — see [Capacity Blocks](#capacity-blocks-for-ml) below. Scheduled launches run on EventBridge Scheduler in the hosted poller stack, so they require `lagotto deploy` first; the launched instance always carries a TTL. If an instance with the same `Name` tag already exists at fire time, `--if-exists skip|launch|replace` decides what happens (default: `skip` for one-shots so a Capacity Block can't double-book, `launch` for cron).
 
 ## Actions
 
@@ -143,9 +171,26 @@ drop out of the active set as they launch, fail, or expire. When **zero** active
 watches remain, the Lambda disables its own schedule — no watches, no Lambda.
 Creating a new watch re-arms it.
 
+## Capacity Blocks for ML
+
+Lagotto is the last step of the end-to-end Capacity Block flow across the three tools:
+
+1. **Discover** a purchasable offering — `truffle capacity-blocks --instance-type p5.48xlarge --count 1 --duration-hours 24` (read-only).
+2. **Purchase** it — `spawn capacity-block purchase <offering-id> ...` (billed up front, non-refundable; three typed confirmations, interactive-only).
+3. **Launch into it at the reserved start time** — `lagotto launch --at <block-start> --az <block-az> --spawn-config block.yaml`, where `block.yaml` sets `reservation_id` + `capacity_block: true` (forwarded to `spawn launch --reservation-id … --capacity-block`).
+
+Step 3 is why `lagotto launch --at` exists: the block becomes usable at its start time, and a scheduled launch brings the instance up automatically — no one awake at 08:00 to run it.
+
 ## Deploy
 
-Lagotto is deployed via CloudFormation — not through the CLI. See the [deployment guide](https://github.com/spore-host/spore-host/blob/main/lagotto/DEPLOYMENT.md) for the full setup: Lambda, EventBridge schedule, DynamoDB tables, and IAM role. Once deployed, the `lagotto` CLI manages watches in that infrastructure.
+Deploy the hosted poller stack **into your own account** with one command:
+
+```sh
+lagotto deploy                 # stand up Lambda + EventBridge + DynamoDB + IAM
+lagotto deploy --teardown      # remove it
+```
+
+`lagotto deploy` downloads the published poller Lambda artifact, uploads it to a bucket in your account, and deploys the embedded CloudFormation template. The poller schedule deploys disabled and the first `lagotto watch` arms it; the stack self-tears-down when no watches or pending scheduled launches remain. See the [deployment guide](https://github.com/spore-host/spore-host/blob/main/lagotto/DEPLOYMENT.md) for the manual CloudFormation path and details. Once deployed, the `lagotto` CLI manages watches and scheduled launches in that infrastructure.
 
 ## Full command reference
 

--- a/docs/tools/reference/lagotto.md
+++ b/docs/tools/reference/lagotto.md
@@ -79,6 +79,58 @@ lagotto watch "ml.g5.2xlarge" --service sagemaker --notify email:you@example.com
 | `--ttl` | | string | `24h` | How long to keep watching (e.g., `24h`, `7d`, `168h`) |
 | `--notify` | | strings | | Notification channels: `email:user@example.com`, `webhook:https://...`, `sns:arn:...` |
 | `--spawn-config` | | string | | Path to YAML file with spawn LaunchConfig (required when `--action spawn`) |
+| `--project` | | string | (`$LAGOTTO_PROJECT`) | Project label for scoping a local `poll --daemon --project` in a shared account |
+
+---
+
+## lagotto launch
+
+Schedule a future or recurring instance launch — by **time**, as opposed to `watch`, which fires on **capacity**.
+
+```
+lagotto launch (--at <time> | --after <delay> | --cron <expr>) --spawn-config <file>
+```
+
+Where `watch` waits for capacity to appear, `launch` fires at a clock time (`--at`), after a delay (`--after`), or on a recurring cron (`--cron`). The motivating case is launching into an [EC2 Capacity Block for ML](/tools/truffle#capacity-blocks-for-ml) at its reserved start time. The launched instance always carries a TTL.
+
+Scheduled launches are driven by EventBridge Scheduler in the hosted poller stack, so they require **`lagotto deploy`** first (the per-launch schedule targets the poller Lambda in your account with a routing payload). A one-shot's schedule self-deletes after it fires; a cron schedule stays armed.
+
+**Overlap policy (`--if-exists`):** when an instance with the same `Name` tag already exists at fire time:
+
+| `--if-exists` | Behavior | Default for |
+|---------------|----------|-------------|
+| `skip` | Don't launch; treat the existing instance as the fulfillment | `--at` / `--after` (a Capacity Block must not double-book) |
+| `launch` | Launch anyway — each fire is a fresh box | `--cron` |
+| `replace` | Terminate the existing instance, then launch | — |
+
+The dedup key is the instance `Name` tag (`--name`, or the spawn config's `name`).
+
+**Examples:**
+```sh
+# Launch into a Capacity Block at its reserved start time (block.yaml sets
+# reservation_id + capacity_block; --az matches the block's AZ)
+lagotto launch --at 2026-07-01T08:00:00Z --az us-east-1a --spawn-config block.yaml
+
+# Launch 6 hours from now
+lagotto launch --after 6h --spawn-config job.yaml
+
+# Recurring: every weekday at 09:00 UTC
+lagotto launch --cron "0 9 ? * MON-FRI *" --spawn-config nightly.yaml
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--at` | string | | Fire once at this RFC3339 time (e.g. `2026-07-01T08:00:00Z`) |
+| `--after` | string | | Fire once after this delay (e.g. `6h`, `30m`, `2d`) |
+| `--cron` | string | | Fire on this cron schedule (e.g. `0 9 ? * MON-FRI *`) |
+| `--spawn-config` | string | | YAML file with the spawn LaunchConfig (**required**) |
+| `--if-exists` | string | `skip` (one-shot) / `launch` (cron) | Overlap policy: `skip`, `launch`, or `replace` |
+| `--name` | string | (config's name) | Instance Name tag — the overlap dedup key |
+| `--az` | string | | Availability zone (required to match a Capacity Block's AZ) |
+| `--region` | string | (AWS config) | AWS region to launch in |
+| `--stack-name` | string | `lagotto` | Deployed lagotto stack name (provides the poller target) |
 
 ---
 
@@ -200,21 +252,43 @@ lagotto history --output json
 
 ## lagotto poll
 
-Run one polling cycle manually.
+Run one polling cycle, or loop in the foreground with `--daemon`.
 
 ```
-lagotto poll
+lagotto poll [--daemon] [--interval <dur>] [scoping flags]
 ```
 
-Triggers a single poll of all active watches — the same logic the Lambda runs on its schedule. Useful for testing your watches without waiting for the next scheduled poll.
+By default triggers a single poll of all active watches — the same logic the Lambda runs on its schedule. Useful for testing your watches without waiting for the next scheduled poll. With `--daemon` it loops on `--interval` (default 5m), so `lagotto watch --action spawn` works hands-off with **no** Lambda/EventBridge/CloudFormation — the infra-free alternative to the hosted poller.
 
 Within a poll, a `spawn` watch actually **attempts a launch** (the real capacity test). A capacity failure leaves the watch `active` to retry next cycle; a terminal failure sets it `failed`. The poller is a self-terminating per-account singleton: when no active watches remain, the Lambda disables its own schedule (a new `lagotto watch` re-enables it).
+
+**Scoping in a shared account:** by default a daemon services **every** active watch in the account. Scope it to your own so it doesn't drive (and launch) another project's watches:
+
+```sh
+lagotto poll --daemon --project fieldwork   # only that project's watches (or $LAGOTTO_PROJECT)
+lagotto poll --daemon --mine                # only watches you created
+lagotto poll --daemon --watch w-aaa,w-bbb   # only these watch IDs
+```
+
+A scoped daemon exits when **its** watches drain, not the whole account's. Before acting on a match, a poller claims a short **processing lease** on the watch, so two daemons — or a local daemon racing the hosted Lambda — can't both launch the same watch. A crashed poller's lease ages out automatically. Disable with `--no-lease` (not recommended when more than one poller runs).
 
 **Examples:**
 ```sh
 lagotto poll
 lagotto poll --verbose
+lagotto poll --daemon --interval 5m --project fieldwork
 ```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--daemon` | bool | `false` | Loop in the foreground until no active watches in scope remain |
+| `--interval` | duration | `5m` | Polling interval in `--daemon` mode (e.g. `30s`, `5m`) |
+| `--project` | string | (`$LAGOTTO_PROJECT`) | Only poll watches with this project label |
+| `--mine` | bool | `false` | Only poll watches created by the calling identity |
+| `--watch` | strings | | Only poll these watch IDs (comma-separated or repeated) |
+| `--no-lease` | bool | `false` | Disable the per-watch processing lease |
 
 ---
 

--- a/docs/tools/reference/spawn.md
+++ b/docs/tools/reference/spawn.md
@@ -80,7 +80,8 @@ id=$(spawn launch my-job --instance-type c6a.large -y -o json | jq -r '.[0].inst
 | `--spot` | bool | `false` | Launch as Spot instance |
 | `--spot-max-price` | string | | Maximum Spot price (e.g., `0.50`) |
 | `--use-reservation` | bool | `false` | Use On-Demand Capacity Reservation |
-| `--reservation-id` | string | | Specific reservation ID to use |
+| `--reservation-id` | string | | Capacity Reservation / Capacity Block ID to launch into (`cr-…`). The instance must be in the reservation's AZ (set `--az`) |
+| `--capacity-block` | bool | `false` | The `--reservation-id` is a Capacity Block for ML (sets `MarketType=capacity-block`); mutually exclusive with `--spot` |
 
 ### Lifecycle
 
@@ -928,6 +929,43 @@ spawn ami <subcommand>
 | `--tag` | strings | Tags in `key=value` format (repeatable) |
 | `--reboot` | bool | Reboot instance before creating (default: no-reboot) |
 | `--wait` | bool | Wait for AMI to become available |
+
+---
+
+## spawn capacity-block
+
+Purchase EC2 Capacity Blocks for ML from an offering discovered with `truffle capacity-blocks`.
+
+```
+spawn capacity-block purchase <offering-id> [flags]
+```
+
+⚠️ A Capacity Block is billed **up front** and is **non-refundable** — the full block duration is charged at purchase, making this the single most expensive action spawn can take. The purchase requires you to **type three confirmations** (the exact price, `purchase <offering-id>`, and an acknowledgement phrase) and **refuses to run on a non-interactive terminal** — there is no `--yes` bypass. Use `--dry-run` first to preview the price and terms without buying anything.
+
+The offering's instance type, count, and duration must be supplied so the exact offering can be re-validated and its current price re-confirmed immediately before purchase. This is step 2 of the [Capacity Block flow](/tools/truffle#capacity-blocks-for-ml); launch into the reservation afterward with `spawn launch --reservation-id … --capacity-block` or `lagotto launch --at <block-start>`.
+
+**Examples:**
+```sh
+# Preview only — no charge, no write API call
+spawn capacity-block purchase cbo-0abc123 --instance-type p5.48xlarge \
+  --count 1 --duration-hours 24 --region us-east-1 --dry-run
+
+# Real purchase (prompts for the three typed confirmations)
+spawn capacity-block purchase cbo-0abc123 --instance-type p5.48xlarge \
+  --count 1 --duration-hours 24 --region us-east-1
+```
+
+**`spawn capacity-block purchase` flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--instance-type` | string | | Instance type of the offering (**required**, e.g. `p5.48xlarge`) |
+| `--duration-hours` | int | | Capacity Block duration in hours (**required**) |
+| `--count` | int | `1` | Number of instances in the block |
+| `--region` | string | | AWS region of the offering (**required**) |
+| `--platform` | string | `Linux/UNIX` | Instance platform |
+| `--dry-run` | bool | `false` | Preview the price and terms without purchasing |
+| `--tag` | strings | | Tag to apply to the reservation (`key=value`; repeatable) |
 
 ---
 

--- a/docs/tools/reference/truffle.md
+++ b/docs/tools/reference/truffle.md
@@ -162,15 +162,48 @@ truffle az c7i.xlarge --output json
 
 ---
 
+## truffle capacity-blocks
+
+Discover **purchasable** EC2 Capacity Block for ML offerings (read-only).
+
+```
+truffle capacity-blocks --instance-type <type> --duration-hours <n> [--count <n>]
+```
+
+Queries `DescribeCapacityBlockOfferings` — "what can I reserve?" — and lists each offering's id, instance type/count, AZ, start/end, duration, and up-front price. The offering id is what `spawn capacity-block purchase` reserves. For Capacity Blocks you **already own**, use `truffle capacity --blocks` instead.
+
+**Examples:**
+```sh
+truffle capacity-blocks --instance-type p5.48xlarge --count 1 --duration-hours 24
+truffle capacity-blocks --instance-type p5.48xlarge --count 2 --duration-hours 48 \
+  --region us-east-1 --output json
+truffle capacity-blocks --instance-type p5.48xlarge --duration-hours 24 \
+  --start-after 2026-07-01T00:00:00Z
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--instance-type` | string | | Instance type to find offerings for (**required**, e.g. `p5.48xlarge`) |
+| `--duration-hours` | int | | Capacity Block duration in hours (**required**, e.g. `24`) |
+| `--count` | int | `1` | Number of instances in the block |
+| `--start-after` | string | | Only offerings starting after this RFC3339 time |
+| `--start-before` | string | | Only offerings ending before this RFC3339 time |
+| `--regions` | strings | (all enabled) | Filter by specific regions |
+| `--timeout` | duration | `5m` | Timeout for AWS API calls |
+
+---
+
 ## truffle capacity
 
-Show On-Demand Capacity Reservations and Capacity Blocks.
+Show On-Demand Capacity Reservations and Capacity Blocks **you already own**.
 
 ```
 truffle capacity
 ```
 
-Queries your AWS account for existing capacity reservations and capacity blocks. Requires AWS credentials.
+Queries your AWS account for existing capacity reservations and capacity blocks. Requires AWS credentials. To discover **purchasable** Capacity Block offerings, use [`truffle capacity-blocks`](#truffle-capacity-blocks) instead.
 
 **Examples:**
 ```sh
@@ -190,7 +223,7 @@ truffle capacity --blocks
 | `--active-only` | bool | `true` | Only show active reservations |
 | `--min-capacity` | int | `0` | Minimum available capacity |
 | `--gpu-only` | bool | `false` | Only show GPU/ML instance reservations (p, g, inf, trn families) |
-| `--blocks` | bool | `false` | Show Capacity Blocks for ML (training workloads) |
+| `--blocks` | bool | `false` | Show Capacity Blocks for ML **you already own** (to discover purchasable offerings, use `truffle capacity-blocks`) |
 | `--odcr` | bool | `true` | Show On-Demand Capacity Reservations |
 | `--timeout` | duration | `5m` | Timeout for AWS API calls |
 

--- a/docs/tools/spawn.md
+++ b/docs/tools/spawn.md
@@ -148,6 +148,22 @@ spawn notify list ...
 
 See [Slack Setup](/guides/slack-setup) or [Teams Setup](/guides/teams-setup) for the full walkthrough.
 
+### `spawn capacity-block purchase`
+
+Purchase an EC2 Capacity Block for ML from an offering discovered with `truffle capacity-blocks`:
+
+```sh
+# Preview the price and terms (no charge)
+spawn capacity-block purchase <offering-id> --instance-type p5.48xlarge \
+  --count 1 --duration-hours 24 --region us-east-1 --dry-run
+
+# Real purchase — prompts for three typed confirmations
+spawn capacity-block purchase <offering-id> --instance-type p5.48xlarge \
+  --count 1 --duration-hours 24 --region us-east-1
+```
+
+A Capacity Block is billed **up front** and is **non-refundable**, so the purchase requires three typed confirmations (the exact price, `purchase <offering-id>`, and an acknowledgement phrase) and refuses to run non-interactively — no `--yes` bypass. Once purchased, launch into it with `spawn launch --reservation-id <id> --capacity-block --az <block-az>`, or have lagotto launch it automatically at the reserved start time (`lagotto launch --at`). See [Capacity Blocks for ML](/tools/truffle#capacity-blocks-for-ml) for the full three-tool flow.
+
 ## Key concepts
 
 **TTL** — every instance has an absolute termination deadline: `launch_time + TTL`. When it fires, the instance terminates. The deadline is stored in a tag at launch and is **never reset** by stop/wake cycles — it keeps counting even while the instance is stopped. `spawn extend` pushes the deadline forward, not from now.

--- a/docs/tools/truffle.md
+++ b/docs/tools/truffle.md
@@ -83,15 +83,28 @@ truffle quotas --family Standard --request             # generate increase comma
 | `Inf` | inf1, inf2 (Inferentia) |
 | `Trn` | trn1 (Trainium) |
 
-### `truffle capacity` — capacity reservations
+### `truffle capacity` — capacity reservations you own
 
-Check existing On-Demand Capacity Reservations in your account.
+Check existing On-Demand Capacity Reservations and Capacity Blocks **already in your account**.
 
 ```sh
 truffle capacity
 truffle capacity --gpu-only
 truffle capacity --instance-types p5.48xlarge,p4d.24xlarge
+truffle capacity --blocks                              # Capacity Blocks you already own
 ```
+
+### `truffle capacity-blocks` — discover purchasable Capacity Blocks
+
+Find purchasable [EC2 Capacity Block for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks.html) **offerings** — "what can I reserve?" (read-only; queries `DescribeCapacityBlockOfferings`). This is distinct from `truffle capacity --blocks`, which lists blocks you *already* own.
+
+```sh
+truffle capacity-blocks --instance-type p5.48xlarge --count 1 --duration-hours 24
+truffle capacity-blocks --instance-type p5.48xlarge --count 2 --duration-hours 48 \
+  --region us-east-1 --start-after 2026-07-01T00:00:00Z
+```
+
+Each offering shows its **id** (what `spawn capacity-block purchase` reserves), instance type/count, AZ, start/end, duration, and up-front price. `--instance-type` and `--duration-hours` are required. This is step 1 of the Capacity Block flow — see [Capacity Blocks for ML](#capacity-blocks-for-ml) below.
 
 ## Typical workflow: find → search → spot → check quota → launch
 
@@ -121,6 +134,25 @@ spawn launch my-job \
   --instance-type $(truffle search "m8a.*" --min-vcpu 16 --pick-first) \
   --spot --ttl 4h
 ```
+
+## Capacity Blocks for ML
+
+A Capacity Block reserves scarce GPU capacity (e.g. p5.48xlarge) for a future window. The flow spans all three tools — truffle discovers, spawn buys, lagotto launches:
+
+```sh
+# 1. truffle — find a purchasable offering (read-only)
+truffle capacity-blocks --instance-type p5.48xlarge --count 1 --duration-hours 24
+
+# 2. spawn — purchase it (billed up front, NON-REFUNDABLE; three typed
+#    confirmations, interactive only; --dry-run to preview)
+spawn capacity-block purchase <offering-id> --instance-type p5.48xlarge \
+  --count 1 --duration-hours 24 --region us-east-1
+
+# 3. lagotto — launch into it at the reserved start time
+lagotto launch --at <block-start> --az <block-az> --spawn-config block.yaml
+```
+
+Truffle stays read-only throughout — the purchase (a real-money, non-refundable write) lives in spawn behind its confirmation gates.
 
 ## Full command reference
 


### PR DESCRIPTION
Syncs the umbrella docs site with recently-shipped work — surfaced by a full doc sweep. The tool READMEs/DEPLOYMENT (lagotto) were already current; the gap was the umbrella `docs/` site.

## What was stale → fixed

**lagotto v0.46.0 / v0.47.0**
- `lagotto launch --at/--after/--cron` — scheduled/delayed/cron launches with the `--if-exists skip|launch|replace` overlap policy (was entirely undocumented). Added to the guide + command reference + cheatsheet.
- `poll --daemon` scoping — `--project`/`--mine`/`--watch`/`--no-lease` + `$LAGOTTO_PROJECT`, and the per-watch processing lease against double-firing. The `poll` section previously documented only a single manual cycle.
- `lagotto deploy` — the guide claimed lagotto is "deployed via CloudFormation — not through the CLI", stale since v0.45.0. Now documents `lagotto deploy` / `--teardown`.
- `lagotto watch --project` flag.

**Capacity Blocks for ML — the end-to-end three-tool flow** (none of it was on the site):
- `truffle capacity-blocks` (discover purchasable offerings) vs `truffle capacity --blocks` (blocks you already own).
- `spawn capacity-block purchase` (up-front, non-refundable; three typed confirmations; `--dry-run`).
- `spawn launch --capacity-block` flag (the reference Capacity table had `--reservation-id` but not `--capacity-block`).
- The `truffle → spawn → lagotto launch --at` walkthrough, cross-linked from each tool.

## Pages
`tools/{lagotto,truffle,spawn}.md`, `tools/reference/{lagotto,truffle,spawn}.md`, `reference/cheatsheet.md`, `how-it-works.md`.

All flags verified against the actual `--help` output of the shipped binaries. VitePress `build` is clean; cross-links and `#capacity-blocks-for-ml` anchors verified.