### PR TITLE
feat(infra): flip dns-updater to AuthType AWS_IAM — closes Route53 spoofing (spawn#173)

### DIFF
--- a/infra/tofu/dns-updater/README.md
+++ b/infra/tofu/dns-updater/README.md
@@ -79,19 +79,22 @@ Instead, security comes from three layers that need **zero** allow-list upkeep:
 
 Execution order (each step gated; the flip is destructive):
 
-| # | Where | Action | Safe to land alone? |
-|---|-------|--------|---------------------|
-| 0 | here | Import the resource under tofu (this module). | ✅ additive tags only |
-| 1 | here | `enable_iam_invoke = true` → add the `Principal:"*"` AWS_IAM invoke grant. | ✅ additive + inert while AuthType is NONE |
-| 2 | spawn | Client SigV4-signs (PR #242, gated `SPORE_DNS_SIGV4`). | ✅ dormant; signed request still accepted by NONE URL |
-| — | spawn | **Enabler:** set `SPORE_DNS_SIGV4=1` in spored's bootstrap + release; let old instances age out under their TTLs so the fleet is signing. | ✅ |
-| 3 | spawn + here | Deploy the IAM-aware handler (verified-account namespacing), then flip `authorization_type = "AWS_IAM"`. | ❌ **DESTRUCTIVE** — breaks DNS for any instance not yet signing. Do only after the enabler is fielded. |
-| 4 | spawn | Delete the legacy identity-doc parsing / `signature.go` / embedded certs / cross-account default-allow. | ✅ dead code removal post-cutover |
+| # | Where | Action | Status |
+|---|-------|--------|--------|
+| 0 | here | Import the resource under tofu (this module). | ✅ done |
+| 2 | spawn | Client SigV4-signs (PR #242, gated `SPORE_DNS_SIGV4`). | ✅ shipped |
+| — | spawn | **Enabler:** spored sets `SPORE_DNS_SIGV4=1` (v0.67.0+). | ✅ shipped |
+| 3 | spawn | IAM-aware handler (verified-account namespacing), deployed to the live fn. | ✅ deployed |
+| 1+3 | here | `enable_iam_invoke = true` → flip `authorization_type` to `AWS_IAM` (lockstep) + add the `Principal:"*"` invoke grant, remove the NONE public grant. | ✅ **done 2026-06-25** |
+| 4 | spawn | Delete the legacy identity-doc parsing / `signature.go` / embedded certs / cross-account default-allow. | ⏳ post-cutover cleanup (dual-path handler serves both until then) |
 
-**The step-3 flip must be lockstep with a signing fleet.** As of step 0, nothing
-sets `SPORE_DNS_SIGV4`, so *no* instance signs yet — flipping AuthType now would
-break 100% of DNS registration. The enabler must ship and old instances must age
-out first.
+**The flip (now done) was lockstep with a signing fleet:** spored has signed
+since v0.67.0, the IAM-aware handler was deployed, and there were no live
+non-signing instances. `enable_iam_invoke` is now the committed default (`true`).
+Verified post-flip: an unsigned POST returns `403 {"Message":"Forbidden"}` from
+the URL auth layer (the vuln is closed), and a SigV4-signed call reaches the
+handler and is namespaced to the verified caller account. Rollback if ever
+needed: `tofu apply -var enable_iam_invoke=false` (AuthType ← NONE, seconds).
 
 ## Day-to-day
 

--- a/infra/tofu/dns-updater/main.tf
+++ b/infra/tofu/dns-updater/main.tf
@@ -66,8 +66,11 @@ variable "aws_profile" {
 #     spoofing this issue is about, cryptographically, with no allow-list to
 #     maintain and no per-region certs (the reason IAM auth beat PKCS#7).
 variable "enable_iam_invoke" {
-  type    = bool
-  default = false
+  type = bool
+  # Default true since the #173 cutover (2026-06-25): the Function URL runs under
+  # AuthType: AWS_IAM. This is the committed live state — a plain `tofu apply`
+  # must NOT silently revert it to NONE. Set false only for a deliberate rollback.
+  default = true
 }
 
 locals {
@@ -196,12 +199,13 @@ resource "aws_lambda_function" "dns_updater" {
 # ── Function URL ──────────────────────────────────────────────────────────────
 # The endpoint instances POST to (zqonqra6…lambda-url.us-east-1.on.aws). Its value
 # is deterministic from function name + account + region, so it is preserved
-# across this import. AuthType stays NONE until the #173 cutover flips it to
-# AWS_IAM (step 3) — see README; the flip is a one-line change here but MUST be
-# lockstep with fielding SigV4-signing instances or all DNS registration breaks.
+# across this import. AuthType is driven by enable_iam_invoke so the flip to
+# AWS_IAM (#173 step 3, done 2026-06-25) moves in LOCKSTEP with the matching
+# invoke grant below — you cannot enable IAM auth without the grant, or disable
+# the grant while IAM auth is on.
 resource "aws_lambda_function_url" "dns_updater" {
   function_name      = aws_lambda_function.dns_updater.function_name
-  authorization_type = "NONE"
+  authorization_type = var.enable_iam_invoke ? "AWS_IAM" : "NONE"
   cors {
     allow_methods = ["POST"]
     allow_origins = ["*"]
@@ -209,8 +213,12 @@ resource "aws_lambda_function_url" "dns_updater" {
   }
 }
 
-# Public invoke permission for the Function URL (NONE auth) — the live grant.
+# Public invoke permission under NONE auth. Present only while NONE is in effect;
+# the #173 flip (enable_iam_invoke=true) removes it as AuthType switches to
+# AWS_IAM and the AWS_IAM grant below is added — so this permission's auth_type
+# condition always matches the live AuthType.
 resource "aws_lambda_permission" "url_public" {
+  count                  = var.enable_iam_invoke ? 0 : 1
   statement_id           = "FunctionURLAllowPublicAccess"
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = aws_lambda_function.dns_updater.function_name


### PR DESCRIPTION
## Summary

Flips the `spawn-dns-updater` Function URL to **`AuthType: AWS_IAM`**, closing the spawn#173 HIGH vulnerability. Previously the handler trusted an attacker-controllable instance-identity document and default-allowed cross-account callers — so an **unauthenticated** caller could UPSERT/DELETE arbitrary Route53 records.

**Applied to prod and verified before this PR** (the flip is a `tofu apply`; this commits the now-live state to IaC).

## Change

`enable_iam_invoke` (default now **true**) drives both sides in lockstep:
- `authorization_type`: `NONE → AWS_IAM`
- `+ url_iam_invoke` — `Principal:"*"` invoke grant under AWS_IAM ("any SigV4 signer", not anonymous)
- `- url_public` — the old NONE public grant

Default = true means the committed source equals live state; a bare `tofu apply` won't revert it. `tofu plan` is clean (no drift).

## Verified live (2026-06-25)

- **Unsigned** POST → `403 {"Message":"Forbidden"}` from the **URL auth layer** (rejected before the Lambda) — the vuln is closed.
- **SigV4-signed** POST → reaches the handler and is namespaced to the **verified** caller account (a probe signed as `966362334030` resolved to `<record>.cbxv6l3i.spore.host` = base36 of that account). Cross-account spoofing is now cryptographically impossible.

## Why it was safe to flip now

spored has SigV4-signed since spawn **v0.67.0** (the `SPORE_DNS_SIGV4=1` enabler), the IAM-aware **dual-path handler** was deployed to the live function, and there were **no live non-signing instances** (spored registers DNS once at boot, not periodically). Rollback if ever needed: `tofu apply -var enable_iam_invoke=false` (AuthType ← NONE, seconds).

## Follow-up

spawn step 4 (delete the now-dead legacy identity-doc / `signature.go` / embedded certs / cross-account default-allow) ships as a separate spawn PR. The dual-path handler keeps serving both worlds until then. Refs spawn#173.