### PR TITLE
fix(ci): version + durably fix the self-hosted runner fleet (#381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Added
+- **`infra/ci-runners/` — the self-hosted CI runner fleet is now versioned** (it
+  previously lived only on orion.local, so fixes weren't reviewable) (#381). The
+  Dockerfile, self-healing `entrypoint.sh`, compose, boot launchd unit, and a
+  `boot-recreate.sh` recovery/boot script, with a README documenting the failure
+  modes and operations.
+
+### Fixed
+- **CI runner fleet no longer fills its disk and orphans jobs** (#381). The
+  ephemeral runners ran under `restart: always`, which restarts each finished
+  container **in place** — so its writable layer (`_work` + a ~3.5GB Go build
+  cache) grew unbounded across cycles (~7GB × 6) until the colima volume hit 80%+
+  and a job mid-run ran out of space, dying with no recorded steps (a ~10-min
+  GitHub timeout — this is what spuriously failed spawn#258). The entrypoint now
+  self-heals each cycle (clears `_work`, caps the go-build cache, `--replace`
+  re-registers), and a launchd boot unit recreates the fleet (not restart-in-place)
+  after a host reboot, fixing the prior reboot crash-loop too. Recovery on the
+  host reclaimed ~38GB (80%→13%).
+
 ### Fixed
 - Corrected broken GitHub and pkg.go.dev links on the website and docs that
   assumed a monorepo layout: the tools are split repos, so `truffle`, `spawn`,

--- a/infra/ci-runners/.env.example
+++ b/infra/ci-runners/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env on the runner host (orion.local:~/spore-runner-deploy/.env).
+# A GitHub PAT (or `gh auth token`) with the admin:org scope — the entrypoint
+# uses it to mint per-cycle runner registration tokens for the spore-host org.
+# NEVER commit the real .env (gitignored).
+ACCESS_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/infra/ci-runners/.env.example
+++ b/infra/ci-runners/.env.example
@@ -1,5 +1,5 @@
 # Copy to .env on the runner host (orion.local:~/spore-runner-deploy/.env).
 # A GitHub PAT (or `gh auth token`) with the admin:org scope — the entrypoint
 # uses it to mint per-cycle runner registration tokens for the spore-host org.
-# NEVER commit the real .env (gitignored).
-ACCESS_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# NEVER commit the real .env (gitignored). Format: a classic PAT begins "ghp_".
+ACCESS_TOKEN=<YOUR_GITHUB_PAT_WITH_admin_org_SCOPE>

--- a/infra/ci-runners/.gitignore
+++ b/infra/ci-runners/.gitignore
@@ -1,0 +1,2 @@
+# Never commit the runner PAT.
+.env

--- a/infra/ci-runners/Dockerfile
+++ b/infra/ci-runners/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates git sudo jq tar gzip build-essential gnupg \
+    && rm -rf /var/lib/apt/lists/*
+# Go toolchain (arm64 native; can cross-compile to linux/amd64 via GOARCH)
+RUN curl -fsSL https://go.dev/dl/go1.26.2.linux-arm64.tar.gz | tar -C /usr/local -xz
+ENV PATH=/usr/local/go/bin:/home/runner/.local/bin:$PATH
+RUN useradd -m runner && echo 'runner ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/runner
+WORKDIR /home/runner
+RUN RUNNER_VERSION=2.334.0 && \
+    curl -fsSL -o actions-runner.tar.gz "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz" && \
+    tar xzf actions-runner.tar.gz && rm actions-runner.tar.gz && \
+    ./bin/installdependencies.sh && \
+    rm -rf /var/lib/apt/lists/* && \
+    chown -R runner:runner /home/runner
+COPY --chown=runner:runner entrypoint.sh /home/runner/entrypoint.sh
+USER runner
+ENTRYPOINT ["/home/runner/entrypoint.sh"]

--- a/infra/ci-runners/README.md
+++ b/infra/ci-runners/README.md
@@ -1,0 +1,84 @@
+# spore.host CI runner fleet (orion.local)
+
+The self-hosted GitHub Actions runner fleet that the suite's `Test` and
+`E2E Tier 0 (Substrate)` jobs are pinned to (`runs-on: [self-hosted, linux,
+orion]`). Six **org-level, ephemeral** runners as a Docker Compose project on
+`orion.local` (colima/Docker backend). Versioned here (spore-host#381) — it
+previously lived only on the host, so fixes weren't reviewable.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | the `spore-runner:latest` image (Ubuntu 24.04 + Go + the actions runner) |
+| `entrypoint.sh` | per-cycle: mint a registration token, **self-heal** (`--replace` + clear `_work`/cap go-build cache), register ephemeral, run one job |
+| `docker-compose.yml` | the 6-replica fleet (`restart: always`, locally built image) |
+| `.env.example` | the one secret: `ACCESS_TOKEN` (PAT with `admin:org`). Real `.env` is host-only, gitignored |
+| `boot-recreate.sh` | recreate the fleet (used at boot + manual recovery) |
+| `host.spore-ci-runners.plist` | launchd unit that runs `boot-recreate.sh` at host boot |
+
+The live host copy is `orion.local:~/spore-runner-deploy` (compose + `.env`) with
+the image build context at `~/spore-runner`. Keep them in sync with this dir.
+
+## Why it kept breaking (spore-host#381)
+
+The runners are ephemeral (one job, then exit) but the compose uses
+`restart: always`, which **restarts the same container in place** rather than
+recreating it. Two failure modes resulted:
+
+1. **Disk fill → jobs orphaned mid-run.** Each reused container's writable layer
+   accumulated `_work` + the Go build cache (~3.5GB) + modules across 45-58
+   cycles → ~7GB/container × 6 → the colima volume hit 80%+ → a job mid-run ran
+   out of space and the runner died, leaving the GitHub job to time out after
+   ~10 min with **no recorded steps** (the signature: it never logged "Set up
+   job"). This is what failed spawn#258.
+2. **Reboot crash-loop.** After a host reboot, the reused containers' baked
+   `.runner` config made `config.sh` refuse ("already configured") and
+   `restart: always` looped them forever → all runners offline.
+
+## The durable fix (in this dir)
+
+- **`entrypoint.sh` self-heals:** clears `_work/_temp` + `_work/_actions` and caps
+  the go-build cache (wipes if >4GB) at the start of every cycle, so a reused
+  container can't grow unbounded; `--replace` re-registers cleanly so a baked
+  `.runner` no longer crash-loops.
+- **`boot-recreate.sh` + launchd:** at boot, wait for colima then `down
+  --remove-orphans && up -d` (recreate, not restart-in-place) and prune offline
+  ghost registrations.
+
+## Operations
+
+**Recover now (jobs stuck / disk full / offline ghosts):**
+```sh
+ssh orion.local
+export PATH=/opt/homebrew/bin:$PATH
+cd ~/spore-runner-deploy && docker compose down --remove-orphans && docker compose up -d
+# verify: 6 containers Up, each log shows "Listening for Jobs"
+docker compose logs --tail=40 runner | grep -c "Listening for Jobs"   # → 6
+```
+
+**Rebuild the image after changing `Dockerfile`/`entrypoint.sh`:**
+```sh
+# copy this dir's Dockerfile + entrypoint.sh to ~/spore-runner, then:
+cd ~/spore-runner && docker build -t spore-runner:latest .
+cd ~/spore-runner-deploy && docker compose down --remove-orphans && docker compose up -d
+```
+
+**Install the boot unit (one-time):**
+```sh
+cp infra/ci-runners/boot-recreate.sh ~/spore-runner-deploy/boot-recreate.sh && chmod +x ~/spore-runner-deploy/boot-recreate.sh
+cp infra/ci-runners/host.spore-ci-runners.plist ~/Library/LaunchAgents/com.spore.ci-runners.plist
+launchctl load -w ~/Library/LaunchAgents/com.spore.ci-runners.plist
+```
+
+**Check health (needs `admin:org`):**
+```sh
+gh api orgs/spore-host/actions/runners --jq '.total_count, (.runners[]|"\(.name) \(.status)")'
+```
+
+## Notes
+- Repo-scope queries (`gh api repos/spore-host/spawn/actions/runners`) show **0** —
+  these are **org** runners; always query the org scope.
+- Disk lives on the colima VM volume `/dev/vdb1`; check with
+  `colima ssh -- df -h /mnt/lima-colima`.
+- Related: spore-host#345 (Node24 env injection via the entrypoint).

--- a/infra/ci-runners/boot-recreate.sh
+++ b/infra/ci-runners/boot-recreate.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Recreate the spore.host CI runner fleet (spore-host#381). Run at host boot by
+# the launchd unit, and safe to run by hand any time the org shows offline ghosts
+# or jobs are stuck queued. Idempotent.
+#
+# Why recreate (not `docker compose restart`): the runners are ephemeral; a fresh
+# container re-registers cleanly and starts with empty _work/caches. Restarting
+# the pre-reboot containers in place reuses their baked .runner config (crash-loop)
+# and their grown writable layers (disk fill).
+set -u
+export PATH=/opt/homebrew/bin:$PATH
+DEPLOY_DIR="${SPORE_RUNNER_DIR:-/Users/scttfrdmn/spore-runner-deploy}"
+
+echo "[$(date -u +%FT%TZ)] spore-ci-runners boot-recreate starting"
+
+# 1. Wait for colima (docker backend) to be up — up to ~3 min after boot.
+for i in $(seq 1 36); do
+  if colima status >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    break
+  fi
+  echo "waiting for colima/docker ($i)…"
+  sleep 5
+done
+if ! docker info >/dev/null 2>&1; then
+  echo "colima/docker not up — trying 'colima start'"
+  colima start || { echo "FATAL: colima not available"; exit 1; }
+fi
+
+# 2. Recreate the fleet (fresh containers; --remove-orphans clears stale ones).
+cd "$DEPLOY_DIR" || { echo "FATAL: $DEPLOY_DIR missing"; exit 1; }
+docker compose down --remove-orphans || true
+docker compose up -d
+
+# 3. Prune offline/ghost org runner registrations the ephemeral fleet left behind
+# on unclean shutdowns (harmless but they clutter the org list). Best-effort.
+if command -v gh >/dev/null 2>&1; then
+  gh api orgs/spore-host/actions/runners --paginate \
+    --jq '.runners[] | select(.status=="offline") | .id' 2>/dev/null \
+    | while read -r id; do
+        [ -n "$id" ] && gh api -X DELETE "orgs/spore-host/actions/runners/$id" >/dev/null 2>&1 \
+          && echo "pruned offline runner $id"
+      done
+fi
+
+echo "[$(date -u +%FT%TZ)] spore-ci-runners boot-recreate done"

--- a/infra/ci-runners/docker-compose.yml
+++ b/infra/ci-runners/docker-compose.yml
@@ -1,0 +1,25 @@
+# spore.host self-hosted GitHub Actions runner fleet (orion.local)
+# Ephemeral org runners — each handles one job, then re-registers.
+# Token: ACCESS_TOKEN is read from .env (a GitHub PAT/gh token with admin:org).
+# Scale:  docker compose up -d   (replicas controls count)
+#
+# Reboot resilience (spore-host#381): on the host, recreate (not restart) the
+# fleet at boot via the launchd unit in this dir, and the entrypoint self-heals
+# (--replace re-registers; per-cycle _work/cache cleanup bounds disk). Build the
+# image from ./Dockerfile + ./entrypoint.sh in this dir (`docker build -t
+# spore-runner:latest .`).
+services:
+  runner:
+    image: spore-runner:latest
+    pull_policy: never # locally built image; never try to pull from a registry
+    restart: always
+    environment:
+      ACCESS_TOKEN: ${ACCESS_TOKEN:?set ACCESS_TOKEN in .env}
+      ORG_NAME: spore-host
+      # RUNNER_NAME is derived from the replica's hostname so each is unique.
+      RUNNER_NAME: orion
+      # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 is injected per-job via /home/runner/.env
+      # by the entrypoint (covers bundled Node 20 actions like github-script in
+      # codecov-action@v5). See spore-host#345.
+    deploy:
+      replicas: 6

--- a/infra/ci-runners/entrypoint.sh
+++ b/infra/ci-runners/entrypoint.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+# Org-scoped ephemeral runner. Mints a fresh registration token from the PAT
+# each start, registers, runs one job (ephemeral), then exits and is recreated.
+
+# Unique runner name: "<RUNNER_NAME>-<hostname>". Under docker compose replicas,
+# each container has a distinct hostname, so each runner registers uniquely.
+RUNNER_BASE="${RUNNER_NAME:-orion}"
+RUNNER_FULL="${RUNNER_BASE}-$(hostname)"
+
+# Self-heal disk growth (spore-host#381). The fleet runs `restart: always`, so a
+# finished ephemeral container is restarted IN PLACE — its writable layer (and
+# _work + the Go build/module caches) persists and grows unbounded across cycles
+# (observed: ~7GB/container × 6 → filled the colima volume → jobs orphaned
+# mid-run). Reset the per-job workspace and cap the Go cache at the start of every
+# cycle so a reused container behaves like a fresh one. Cheap: _work is rebuilt
+# per job, and the Go module cache (GOPATH/pkg/mod) is preserved for speed.
+cd /home/runner
+rm -rf /home/runner/_work/_temp/* 2>/dev/null || true
+rm -rf /home/runner/_work/_actions/* 2>/dev/null || true
+# Bound the build cache: if it exceeds the cap, wipe it (it repopulates per job).
+GOCACHE_DIR="${GOCACHE:-/home/runner/.cache/go-build}"
+if [ -d "$GOCACHE_DIR" ]; then
+  cache_mb=$(du -sm "$GOCACHE_DIR" 2>/dev/null | awk '{print $1}')
+  if [ "${cache_mb:-0}" -gt 4000 ]; then
+    echo "go-build cache ${cache_mb}MB > 4000MB cap — clearing (spore-host#381)"
+    rm -rf "$GOCACHE_DIR"/* 2>/dev/null || true
+  fi
+fi
+
+RUNNER_TOKEN=$(curl -fsSL -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/orgs/${ORG_NAME}/actions/runners/registration-token | jq -r .token)
+
+if [ -z "$RUNNER_TOKEN" ] || [ "$RUNNER_TOKEN" = "null" ]; then
+  echo "FATAL: could not mint registration token (check ACCESS_TOKEN / admin:org scope)" >&2
+  exit 1
+fi
+
+# Inject job-level env for every workflow run on this runner. The runner sources
+# /home/runner/.env into each job's environment. FORCE_JAVASCRIPT_ACTIONS_TO_NODE24
+# opts bundled Node 20 actions (e.g. github-script inside codecov-action@v5) onto
+# Node 24 ahead of GitHub's 2026-06-16 forced cutover — a cross-repo fix with no
+# per-repo workflow changes (spore-host#345).
+grep -q '^FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=' /home/runner/.env 2>/dev/null \
+  || echo 'FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true' >> /home/runner/.env
+
+# --replace lets a reused container (same name, leftover .runner config from the
+# prior cycle or a host reboot) re-register cleanly instead of refusing with
+# "already configured" and crash-looping under restart: always (spore-host#381).
+./config.sh \
+  --url "https://github.com/${ORG_NAME}" \
+  --token "$RUNNER_TOKEN" \
+  --name "$RUNNER_FULL" \
+  --labels "self-hosted,linux,orion" \
+  --work /home/runner/_work \
+  --ephemeral \
+  --unattended \
+  --replace
+
+cleanup() {
+  echo "Removing runner registration..."
+  TOK=$(curl -fsSL -X POST -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    https://api.github.com/orgs/${ORG_NAME}/actions/runners/remove-token | jq -r .token)
+  ./config.sh remove --token "$TOK" || true
+}
+trap cleanup EXIT
+./run.sh

--- a/infra/ci-runners/host.spore-ci-runners.plist
+++ b/infra/ci-runners/host.spore-ci-runners.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd unit for orion.local — recreate the runner fleet at boot
+  (spore-host#381). The fleet uses the ephemeral model, so on boot we must
+  RECREATE containers (fresh writable layers, clean registration) rather than let
+  Docker restart the stale pre-reboot containers in place — which crash-looped on
+  the baked "already configured" .runner state and accumulated disk.
+
+  Install:
+    cp host.spore-ci-runners.plist ~/Library/LaunchAgents/com.spore.ci-runners.plist
+    launchctl load -w ~/Library/LaunchAgents/com.spore.ci-runners.plist
+
+  It waits for colima (the docker backend) to be up, then `down --remove-orphans
+  && up -d` from the deploy dir, then prunes any leftover offline org runners.
+  Idempotent and safe to run repeatedly.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.spore.ci-runners</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>/Users/scttfrdmn/spore-runner-deploy/boot-recreate.sh</string>
+  </array>
+  <key>StandardOutPath</key>
+  <string>/tmp/spore-ci-runners.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/spore-ci-runners.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Fixes #381. The orion.local CI runner fleet (the `Test` + `E2E Tier 0` jobs pin to `self-hosted/linux/orion`) kept breaking, and lived **only on the host** — so fixes weren't reviewable. Now versioned here (`infra/ci-runners/`) with a durable fix, and the fix is deployed live.

## Root cause (diagnosed this session)

The 6 runners are **ephemeral** (one job → exit) but the compose uses `restart: always`, which **restarts each finished container in place** instead of recreating it. So each reused container's writable layer accumulated `_work` + a ~3.5GB Go build cache + modules across 45-58 cycles → ~7GB × 6 → the colima volume hit **80%+** → a job mid-run ran out of disk and the runner died, leaving GitHub to time the job out after ~10 min with **no recorded steps**.

That is exactly what spuriously failed **spawn#258** — which **passes on a healthy fleet** (re-run after recovery: Test 2m48s, E2E Tier-0 1m11s ✅). A second mode (the original #381 report): after a host reboot the reused containers' baked `.runner` config made `config.sh` refuse → crash-loop.

## The durable fix (`infra/ci-runners/`)

- **`entrypoint.sh` self-heals each cycle:** clears `_work/_temp` + `_work/_actions`, caps the go-build cache (wipes if >4GB), keeps `--replace` so a reused/rebooted container re-registers cleanly. Bounds disk growth regardless of restart-in-place.
- **`boot-recreate.sh` + `host.spore-ci-runners.plist`:** a launchd unit that, after colima is up at boot, recreates the fleet (`down --remove-orphans && up -d`, *not* restart-in-place) and prunes offline ghost registrations.
- **`docker-compose.yml`** pinned to the locally built image; `.env` (the `admin:org` PAT) gitignored, `.env.example` committed.
- **README** documenting both failure modes + operations (recover, rebuild, install boot unit, health check).

## Deployed live (this session)
- Recovery on orion: `docker compose down && up -d` reclaimed **~38GB** (vdb1 80%→13%), 6 runners re-registered.
- Rebuilt `spore-runner:latest` with the self-healing entrypoint, recreated the fleet (6 listening), installed + loaded the launchd boot unit.

## Note
This versioned copy must be kept in sync with the host (`orion.local:~/spore-runner` build context + `~/spore-runner-deploy`). The README documents the rebuild/recreate flow.