### PR TITLE
feat(infra): container build recipes + base-AMI share (#290, #389)

### DIFF
--- a/infra/amis/containers/README.md
+++ b/infra/amis/containers/README.md
@@ -1,0 +1,62 @@
+# spore.host container catalog (#290)
+
+App images for the **container-based** app catalog. Each app is a Docker image
+that runs on the shared `spore-dcv-base` AMI; there is **no per-app AMI**. This
+replaces the old `infra/amis/<app>.pkr.hcl` per-app, per-region AMI builds whose
+IDs all drifted into dangling/unshared state (#389).
+
+## Why containers
+
+| | Old (AMI per app per region) | Container catalog |
+|---|---|---|
+| Add an app | ~20 min Packer build × 9 regions | write a Dockerfile, `build-push.sh` once |
+| Update a version | rebuild + reshare every region | `docker push` a new tag |
+| Drift risk | 9 × N AMI IDs to keep shared (#389) | 1 base AMI per region, shared once |
+| Multi-version | full rebuild | image tags (`paraview:5.13.2`, `5.12.1`) |
+
+## Layout
+
+```
+containers/
+├── build-push.sh        # build <app>:<version> and push to public ECR
+├── paraview/
+│   ├── Dockerfile        # ParaView + metacity + fullscreen entrypoint
+│   └── entrypoint.sh      # the container CMD = the DCV session
+└── <app>/ ...
+```
+
+## How a launch works
+
+`spawn app launch paraview` →
+1. picks `spore-dcv-base` AMI for the region (`base_amis` in `libs/catalog/catalog.yaml`),
+2. user-data pre-pulls `public.ecr.aws/spore-host/paraview:<tag>`,
+3. creates the DCV session with this as `--init`:
+   ```sh
+   docker run --rm --gpus all --network host -e DISPLAY=:0 \
+     -v /tmp/.X11-unix:/tmp/.X11-unix public.ecr.aws/spore-host/paraview:<tag>
+   ```
+The base AMI provides DCV, the NVIDIA driver + X server on `:0`, Docker, and the
+NVIDIA Container Toolkit (built by `../dcv-gpu-al2023.pkr.hcl`). The container
+provides the app, its window manager, and the fullscreen launcher, drawing into
+the host's DCV display via the bind-mounted X socket.
+
+## Build & publish a new app/version
+
+```sh
+# In the dedicated infra account (812107987990); docker + AWS CLI v2 required.
+./build-push.sh paraview 5.13.2
+# → public.ecr.aws/spore-host/paraview:5.13.2
+# then add image/tag_default/tags_available to libs/catalog/catalog.yaml and
+# cut a libs release.
+```
+
+Dry run (build, no push): `SPORE_BUILD_DRYRUN=true ./build-push.sh paraview 5.13.2`
+
+## Base AMI (one-time per region)
+
+```sh
+# Build the base (GPU) AMI:
+cd .. && packer build -var region=us-east-1 dcv-gpu-al2023.pkr.hcl
+# Share it to the launch account — THE #389 FIX:
+./share-base-ami.sh <ami-id> us-east-1 <launch-account-id>
+```

--- a/infra/amis/containers/build-push.sh
+++ b/infra/amis/containers/build-push.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# build-push.sh — build a spore.host app container and push it to a public ECR
+# repository (#290 container catalog).
+#
+# Replaces the per-app Packer AMI build (paraview.pkr.hcl): instead of baking the
+# app onto a per-region AMI, we publish ONE container image that runs on the
+# shared spore-dcv-base AMI in every region.
+#
+# Usage:
+#   ./build-push.sh <app> <version> [registry]
+#   ./build-push.sh paraview 5.13.2
+#   ./build-push.sh paraview 5.13.2 public.ecr.aws/spore-host
+#
+# Environment:
+#   SPORE_ECR_REGISTRY   default registry (default: public.ecr.aws/spore-host)
+#   SPORE_ECR_REGION     region for ECR Public auth (always us-east-1 for public)
+#   SPORE_BUILD_DRYRUN   "true" → build only, do not push
+#
+# Prerequisites:
+#   - docker (with buildx) and AWS CLI v2
+#   - AWS creds for the registry's account (the dedicated infra account 812107987990)
+#   - The per-app Dockerfile at containers/<app>/Dockerfile
+#
+# Public ECR is auth'd in us-east-1 regardless of where the registry "lives".
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+APP="${1:-}"
+VERSION="${2:-}"
+REGISTRY="${3:-${SPORE_ECR_REGISTRY:-public.ecr.aws/spore-host}}"
+DRYRUN="${SPORE_BUILD_DRYRUN:-false}"
+ECR_REGION="${SPORE_ECR_REGION:-us-east-1}"
+
+if [[ -z "$APP" || -z "$VERSION" ]]; then
+  echo "Usage: $0 <app> <version> [registry]" >&2
+  exit 2
+fi
+
+DOCKERFILE="${SCRIPT_DIR}/${APP}/Dockerfile"
+if [[ ! -f "$DOCKERFILE" ]]; then
+  echo "ERROR: no Dockerfile for '${APP}' at ${DOCKERFILE}" >&2
+  echo "Available: $(ls -d "${SCRIPT_DIR}"/*/ 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+IMAGE="${REGISTRY}/${APP}"
+TAG="${IMAGE}:${VERSION}"
+
+# ParaView needs PV_MAJOR_MINOR derived from the version; pass both build-args.
+MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1,2)"
+
+echo "==> Building ${TAG}"
+docker build \
+  --build-arg "PV_VERSION=${VERSION}" \
+  --build-arg "PV_MAJOR_MINOR=${MAJOR_MINOR}" \
+  -t "$TAG" \
+  -f "$DOCKERFILE" \
+  "${SCRIPT_DIR}/${APP}"
+
+if [[ "$DRYRUN" == "true" ]]; then
+  echo "==> DRYRUN — built ${TAG}, not pushing"
+  exit 0
+fi
+
+echo "==> Authenticating to ECR Public (${ECR_REGION})"
+aws ecr-public get-login-password --region "$ECR_REGION" \
+  | docker login --username AWS --password-stdin public.ecr.aws
+
+# Ensure the public repository exists (idempotent). The ECR Public repo name is
+# just the app (the registry namespace is the public.ecr.aws/<alias> prefix).
+aws ecr-public describe-repositories --region "$ECR_REGION" \
+  --repository-names "$APP" >/dev/null 2>&1 \
+  || aws ecr-public create-repository --region "$ECR_REGION" \
+       --repository-name "$APP" >/dev/null
+
+echo "==> Pushing ${TAG}"
+docker push "$TAG"
+
+echo "==> Done: ${TAG}"
+echo "    Add to catalog (libs/catalog/catalog.yaml):"
+echo "      image: ${IMAGE}"
+echo "      tag_default: \"${VERSION}\""

--- a/infra/amis/containers/paraview/Dockerfile
+++ b/infra/amis/containers/paraview/Dockerfile
@@ -1,0 +1,54 @@
+# ParaView application container for the spore.host container catalog (#290).
+#
+# Runs on the shared spore-dcv-base AMI (which provides DCV, the NVIDIA driver,
+# the X server on :0, Docker, and the NVIDIA Container Toolkit). The container
+# brings ParaView + a minimal window manager + the fullscreen launcher; it draws
+# into the host's DCV display via the bind-mounted X socket. spawn launches it as
+# the DCV session init with:
+#
+#   docker run --rm --gpus all --network host -e DISPLAY=:0 \
+#     -v /tmp/.X11-unix:/tmp/.X11-unix public.ecr.aws/spore-host/paraview:<tag>
+#
+# Build/push: infra/amis/containers/build-push.sh paraview <version>
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ParaView runtime libs + a minimal WM (metacity) + X utilities the launcher uses
+# to maximize the window after DCV resizes the display to the browser viewport.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1-mesa-glx \
+    libglu1-mesa \
+    libxt6 libxrender1 libxext6 libxcursor1 \
+    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+    libxcb-render-util0 libxcb-xinerama0 libxcb-xkb1 libxcb-shape0 libxcb-xinput0 \
+    libxkbcommon-x11-0 libxkbcommon0 libgomp1 libgcc-s1 \
+    libxrandr2 libxi6 libxinerama1 \
+    metacity \
+    x11-utils x11-xserver-utils \
+    fontconfig fonts-dejavu-core \
+    curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG PV_VERSION=5.13.2
+ARG PV_MAJOR_MINOR=5.13
+
+RUN curl -fsSL \
+    "https://www.paraview.org/files/v${PV_MAJOR_MINOR}/ParaView-${PV_VERSION}-MPI-Linux-Python3.10-x86_64.tar.gz" \
+    -o /tmp/pv.tar.gz && \
+    tar -xzf /tmp/pv.tar.gz -C /opt/ && \
+    ln -sf /opt/ParaView-${PV_VERSION}-MPI-Linux-Python3.10-x86_64/bin/paraview \
+           /usr/local/bin/paraview && \
+    rm /tmp/pv.tar.gz && \
+    # VisRTX needs the NVIDIA OptiX SDK (not in the driver); ParaView still GPU-renders via OpenGL.
+    rm -f /opt/ParaView-${PV_VERSION}-MPI-Linux-Python3.10-x86_64/lib/libVisRTX.so \
+          /opt/ParaView-${PV_VERSION}-MPI-Linux-Python3.10-x86_64/lib/libVisRTX.so.0.1.6
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+RUN useradd -m -u 1000 paraview
+USER paraview
+# The container's job IS the DCV session: launch the WM + ParaView fullscreen and
+# block until ParaView exits (then DCV closes the session → spored sees idle).
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/infra/amis/containers/paraview/entrypoint.sh
+++ b/infra/amis/containers/paraview/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# ParaView container entrypoint (#290). DCV/X11 are on the host; this runs in the
+# container against the bind-mounted X socket (DISPLAY=:0). Starts a minimal WM,
+# launches ParaView maximized, and re-maximizes once DCV resizes the virtual
+# display to the browser viewport (ported from the old per-AMI start-paraview-dcv
+# wrapper). Blocks until ParaView exits, which ends the DCV session.
+set -u
+
+# Suppress the welcome dialog (it steals focus on startup).
+mkdir -p "$HOME/.config/ParaView"
+printf '[GeneralSettings]\nShowWelcomeDialog=0\n' > "$HOME/.config/ParaView/ParaView.ini"
+
+xsetroot -solid black 2>/dev/null || true
+metacity --sm-disable &
+sleep 1
+
+/usr/local/bin/paraview --maximize &
+PV_PID=$!
+
+# After DCV resizes the display to the browser viewport, re-maximize the main
+# ParaView window (transient dialogs are skipped).
+INIT_SIZE=$(xdpyinfo 2>/dev/null | grep dimensions | grep -oP '[0-9]+x[0-9]+')
+for _ in $(seq 1 60); do
+  sleep 2
+  SIZE=$(xdpyinfo 2>/dev/null | grep dimensions | grep -oP '[0-9]+x[0-9]+')
+  if [ "$SIZE" != "$INIT_SIZE" ] && [ -n "$SIZE" ]; then
+    sleep 1
+    for w in $(xprop -root 2>/dev/null | grep -oP '0x[0-9a-f]{5,}'); do
+      xprop -id "$w" WM_CLASS 2>/dev/null | grep -qi paraview || continue
+      xprop -id "$w" WM_TRANSIENT_FOR 2>/dev/null | grep -q 'window id' && continue
+      xprop -id "$w" -format _NET_WM_STATE 32a -set _NET_WM_STATE \
+        '_NET_WM_STATE_MAXIMIZED_VERT,_NET_WM_STATE_MAXIMIZED_HORZ' 2>/dev/null
+    done
+    break
+  fi
+done &
+
+wait $PV_PID

--- a/infra/amis/paraview.pkr.hcl
+++ b/infra/amis/paraview.pkr.hcl
@@ -1,3 +1,9 @@
+# DEPRECATED (#290): this baked ParaView onto a per-app, per-region AMI — the
+# model retired by the container catalog. New builds use
+# infra/amis/containers/paraview/ + build-push.sh (one ECR image, runs on the
+# shared spore-dcv-base AMI). Kept for reference (the kiosk-wm/fullscreen logic
+# here was ported into containers/paraview/entrypoint.sh). Do NOT use for new
+# builds — its output AMIs are exactly the dangling/unshared ones from #389.
 packer {
   required_plugins {
     amazon = {

--- a/infra/amis/share-base-ami.sh
+++ b/infra/amis/share-base-ami.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# share-base-ami.sh — share a spore-dcv-base AMI (and its backing snapshots) with
+# the launch account(s), then print the catalog base_amis line.
+#
+# This is the fix for the #389 root cause: every per-app AMI in the old catalog
+# was built in one account and NEVER shared to the account that launches
+# instances, so `spawn app launch` failed at RunInstances with AuthFailure. The
+# container catalog (#290) has exactly ONE shared base AMI per region, so this
+# runs once per region instead of once per app per region.
+#
+# Usage:
+#   ./share-base-ami.sh <ami-id> <region> <launch-account-id> [launch-account-id...]
+#   ./share-base-ami.sh ami-0c37fb59c90d1ed3a us-east-1 435415984226
+#
+# Run with credentials for the AMI's OWNING account (the dedicated infra account
+# 812107987990). Idempotent — re-running just re-asserts the launch permissions.
+set -euo pipefail
+
+AMI_ID="${1:-}"
+REGION="${2:-}"
+shift 2 || true
+ACCOUNTS=("$@")
+
+if [[ -z "$AMI_ID" || -z "$REGION" || ${#ACCOUNTS[@]} -eq 0 ]]; then
+  echo "Usage: $0 <ami-id> <region> <launch-account-id> [more-accounts...]" >&2
+  exit 2
+fi
+
+echo "==> Confirming ${AMI_ID} exists in ${REGION} (owning account)"
+aws ec2 describe-images --region "$REGION" --image-ids "$AMI_ID" \
+  --query 'Images[0].[ImageId,Name,State]' --output text
+
+# Build the LaunchPermission Add list.
+ADD_JSON="$(printf '{"UserId":"%s"},' "${ACCOUNTS[@]}")"
+ADD_JSON="[${ADD_JSON%,}]"
+
+echo "==> Granting launch permission to: ${ACCOUNTS[*]}"
+aws ec2 modify-image-attribute --region "$REGION" --image-id "$AMI_ID" \
+  --launch-permission "{\"Add\":${ADD_JSON}}"
+
+# The instance can't boot unless the backing EBS snapshots are also shared.
+echo "==> Sharing backing snapshots"
+SNAP_IDS=$(aws ec2 describe-images --region "$REGION" --image-ids "$AMI_ID" \
+  --query 'Images[0].BlockDeviceMappings[].Ebs.SnapshotId' --output text)
+for snap in $SNAP_IDS; do
+  [[ -z "$snap" || "$snap" == "None" ]] && continue
+  echo "    ${snap}"
+  aws ec2 modify-snapshot-attribute --region "$REGION" --snapshot-id "$snap" \
+    --attribute createVolumePermission --operation-type add \
+    --user-ids "${ACCOUNTS[@]}"
+done
+
+echo "==> Verifying launch permission"
+aws ec2 describe-image-attribute --region "$REGION" --image-id "$AMI_ID" \
+  --attribute launchPermission --query 'LaunchPermissions' --output json
+
+echo "==> Done. Catalog line for libs/catalog/catalog.yaml base_amis:"
+echo "      ${REGION}: ${AMI_ID}"


### PR DESCRIPTION
## What

Phase A of the #290 container-catalog pivot (infra/recipes only — no billable build). Establishes the container build track that replaces per-app Packer AMIs, and the base-AMI share step that fixes the #389 root cause.

## Changes

- **`infra/amis/containers/paraview/`** — self-contained ParaView image: app + `metacity` WM + a fullscreen `entrypoint.sh` (the kiosk/maximize logic ported from the old `start-paraview-dcv` wrapper). The container CMD **is** the DCV session — it draws into the host's bind-mounted X socket (`/tmp/.X11-unix`, `DISPLAY=:0`) on the shared `spore-dcv-base` AMI.
- **`containers/build-push.sh`** — build `<app>:<version>`, ensure the ECR Public repo, push. Account-agnostic (`SPORE_ECR_REGISTRY`, default `public.ecr.aws/spore-host`); `SPORE_BUILD_DRYRUN=true` builds without pushing.
- **`share-base-ami.sh`** — share a base AMI **and its backing snapshots** to the launch account(s). This is the direct #389 fix: the old per-app AMIs were built in one account and never shared, so `RunInstances` failed `AuthFailure`. Container model = one base AMI/region, shared once.
- **`containers/README.md`** — documents the model and the build/launch flow.
- **`paraview.pkr.hcl`** marked DEPRECATED (its outputs are exactly the #389 dangling AMIs); retained for reference since its kiosk logic moved into the container.

## Verification

`bash -n` clean on all scripts; shellcheck clean except one cosmetic SC2011 (controlled, alphanumeric app dir names). No AWS calls in this PR — the GPU base-AMI build + ECR push run on the dedicated infra account (812107987990) when triggered (Phase E).

## Depends on / refs

- libs v0.38.0 (container catalog schema) ✅
- spawn #260 (container launch path) ✅
- Next: catalog validation CI gate (#290 Phase D), then the real build + paraview launch confirmation (Phase E).

Refs #290, #389.