### PR TITLE
fix(infra): force linux/amd64 container builds + orphan-AMI cleanup (#290, #389)

### DIFF
--- a/infra/amis/cleanup-orphan-amis.sh
+++ b/infra/amis/cleanup-orphan-amis.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# cleanup-orphan-amis.sh — deregister orphaned spore.host app AMIs and delete
+# their backing EBS snapshots, in the AMI's OWNING account (#290 Phase F, #389).
+#
+# The container catalog (#290) retired the per-app, per-region AMIs. This sweeps
+# the leftovers: every self-owned AMI tagged spore:app (or named spore-<app>-*)
+# that is NOT the current base AMI and NOT referenced by the catalog. Deregister
+# alone leaks the snapshot (~$0.05/GB-mo), so we delete the snapshots too.
+#
+# DRY-RUN BY DEFAULT — prints what it WOULD delete and exits 0. Set
+# SPORE_CLEANUP_APPLY=true to actually deregister + delete.
+#
+# Usage:
+#   ./cleanup-orphan-amis.sh <region> [region...]
+#   SPORE_CLEANUP_APPLY=true ./cleanup-orphan-amis.sh us-east-1
+#
+# Environment:
+#   SPORE_KEEP_AMIS   comma-separated AMI IDs to ALWAYS keep (e.g. the live base
+#                     AMIs still referenced by catalog base_amis). Safety net.
+#   SPORE_CLEANUP_APPLY  "true" to perform deletes (default: dry-run).
+#
+# Run with credentials for the account that OWNS the AMIs (e.g. the dedicated
+# infra account 812107987990, or the beta account 942542972736). Self-owned only.
+set -euo pipefail
+
+APPLY="${SPORE_CLEANUP_APPLY:-false}"
+KEEP="${SPORE_KEEP_AMIS:-}"
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 <region> [region...]   (dry-run unless SPORE_CLEANUP_APPLY=true)" >&2
+  exit 2
+fi
+
+# Build a quick lookup of AMI IDs to keep.
+declare -A keep_set
+IFS=',' read -ra _keep <<< "$KEEP"
+for k in "${_keep[@]}"; do
+  [[ -n "$k" ]] && keep_set["$k"]=1
+done
+
+acct=$(aws sts get-caller-identity --query Account --output text)
+echo "==> Owning account: ${acct}   mode: $([[ "$APPLY" == "true" ]] && echo APPLY || echo DRY-RUN)"
+[[ -n "$KEEP" ]] && echo "==> Always-keep: ${KEEP}"
+
+total_amis=0
+total_snaps=0
+
+for region in "$@"; do
+  echo "── ${region} ──────────────────────────────────────────────"
+
+  # Self-owned spore app AMIs: tagged spore:app OR named spore-* (covers older
+  # builds that predate the tag). Base AMIs (spore:type=dcv-*-base) are excluded.
+  mapfile -t amis < <(aws ec2 describe-images --region "$region" --owners self \
+    --filters "Name=name,Values=spore-*" \
+    --query 'Images[].{id:ImageId,name:Name,type:Tags[?Key==`spore:type`]|[0].Value}' \
+    --output text 2>/dev/null | sort)
+
+  if [[ ${#amis[@]} -eq 0 ]]; then
+    echo "  (no self-owned spore-* AMIs)"
+    continue
+  fi
+
+  while IFS=$'\t' read -r ami_id name ami_type; do
+    [[ -z "$ami_id" ]] && continue
+
+    # Skip the shared base AMIs — they're the live catalog targets.
+    if [[ "$ami_type" == dcv-*-base ]]; then
+      echo "  KEEP (base)   ${ami_id}  ${name}"
+      continue
+    fi
+    if [[ -n "${keep_set[$ami_id]:-}" ]]; then
+      echo "  KEEP (listed) ${ami_id}  ${name}"
+      continue
+    fi
+
+    # Backing snapshots for this AMI.
+    mapfile -t snaps < <(aws ec2 describe-images --region "$region" --image-ids "$ami_id" \
+      --query 'Images[0].BlockDeviceMappings[].Ebs.SnapshotId' --output text 2>/dev/null | tr '\t' '\n' | grep -v '^None$' || true)
+
+    echo "  ORPHAN        ${ami_id}  ${name}  snaps=[${snaps[*]:-}]"
+    total_amis=$((total_amis + 1))
+    total_snaps=$((total_snaps + ${#snaps[@]}))
+
+    if [[ "$APPLY" == "true" ]]; then
+      echo "    deregister ${ami_id}"
+      aws ec2 deregister-image --region "$region" --image-id "$ami_id"
+      for s in "${snaps[@]}"; do
+        [[ -z "$s" ]] && continue
+        echo "    delete snapshot ${s}"
+        aws ec2 delete-snapshot --region "$region" --snapshot-id "$s" || \
+          echo "    WARN: could not delete ${s} (still in use?)"
+      done
+    fi
+  done < <(printf '%s\n' "${amis[@]}")
+done
+
+echo "==> $([[ "$APPLY" == "true" ]] && echo "Deleted" || echo "Would delete") ${total_amis} AMIs + ${total_snaps} snapshots"
+[[ "$APPLY" != "true" ]] && echo "    (dry-run; set SPORE_CLEANUP_APPLY=true to apply)"
+exit 0

--- a/infra/amis/containers/README.md
+++ b/infra/amis/containers/README.md
@@ -42,15 +42,34 @@ the host's DCV display via the bind-mounted X socket.
 
 ## Build & publish a new app/version
 
+The app images are **x86_64** (the base AMI and app binaries are x86_64), so the
+build must target `linux/amd64`. `build-push.sh` forces `--platform linux/amd64`
+via buildx — on an arm64 host (Apple Silicon) that cross-builds under QEMU, which
+works but is slow.
+
+**Preferred: build natively on a throwaway x86 EC2 instance (via spawn).** No
+emulation, native speed, and an instance role avoids local credential expiry.
+Sketch (run in the ECR/infra account 812107987990):
+
 ```sh
-# In the dedicated infra account (812107987990); docker + AWS CLI v2 required.
-./build-push.sh paraview 5.13.2
-# → public.ecr.aws/spore-host/paraview:5.13.2
-# then add image/tag_default/tags_available to libs/catalog/catalog.yaml and
-# cut a libs release.
+spawn launch --instance-type c7i.2xlarge --region us-east-1 \
+  --ttl 1h --terminate-on-complete \
+  --command 'set -e; dnf install -y docker git && systemctl start docker &&
+    git clone https://github.com/spore-host/spore-host &&
+    cd spore-host/infra/amis/containers &&
+    ./build-push.sh paraview 5.13.2'
+# the instance has an instance role with ecr-public:* push perms.
 ```
 
-Dry run (build, no push): `SPORE_BUILD_DRYRUN=true ./build-push.sh paraview 5.13.2`
+**Local fallback** (no AWS / for a quick check; cross-builds on arm64):
+
+```sh
+./build-push.sh paraview 5.13.2            # build + push from your workstation
+SPORE_BUILD_DRYRUN=true ./build-push.sh paraview 5.13.2   # build only, no push
+```
+
+Either way: then add `image`/`tag_default`/`tags_available` to
+`libs/catalog/catalog.yaml` and cut a libs release.
 
 ## Base AMI (one-time per region)
 

--- a/infra/amis/containers/build-push.sh
+++ b/infra/amis/containers/build-push.sh
@@ -50,15 +50,17 @@ TAG="${IMAGE}:${VERSION}"
 # ParaView needs PV_MAJOR_MINOR derived from the version; pass both build-args.
 MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1,2)"
 
-echo "==> Building ${TAG}"
-docker build \
-  --build-arg "PV_VERSION=${VERSION}" \
-  --build-arg "PV_MAJOR_MINOR=${MAJOR_MINOR}" \
-  -t "$TAG" \
-  -f "$DOCKERFILE" \
-  "${SCRIPT_DIR}/${APP}"
+# Always build linux/amd64 — the base AMI and the app binaries are x86_64. On an
+# arm64 host this cross-builds via buildx+QEMU. --load (dry-run) imports the
+# single-arch image locally; the push path builds and pushes in one step.
+PLATFORM="linux/amd64"
 
+echo "==> Building ${TAG} (${PLATFORM})"
 if [[ "$DRYRUN" == "true" ]]; then
+  docker buildx build --platform "$PLATFORM" --load \
+    --build-arg "PV_VERSION=${VERSION}" \
+    --build-arg "PV_MAJOR_MINOR=${MAJOR_MINOR}" \
+    -t "$TAG" -f "$DOCKERFILE" "${SCRIPT_DIR}/${APP}"
   echo "==> DRYRUN — built ${TAG}, not pushing"
   exit 0
 fi
@@ -74,8 +76,13 @@ aws ecr-public describe-repositories --region "$ECR_REGION" \
   || aws ecr-public create-repository --region "$ECR_REGION" \
        --repository-name "$APP" >/dev/null
 
-echo "==> Pushing ${TAG}"
-docker push "$TAG"
+echo "==> Building + pushing ${TAG} (${PLATFORM})"
+# buildx --push builds the amd64 image and pushes it in one step (so an arm64
+# host publishes a correct x86_64 image, not its native arch).
+docker buildx build --platform "$PLATFORM" --push \
+  --build-arg "PV_VERSION=${VERSION}" \
+  --build-arg "PV_MAJOR_MINOR=${MAJOR_MINOR}" \
+  -t "$TAG" -f "$DOCKERFILE" "${SCRIPT_DIR}/${APP}"
 
 echo "==> Done: ${TAG}"
 echo "    Add to catalog (libs/catalog/catalog.yaml):"

--- a/infra/amis/containers/paraview/Dockerfile
+++ b/infra/amis/containers/paraview/Dockerfile
@@ -10,7 +10,12 @@
 #     -v /tmp/.X11-unix:/tmp/.X11-unix public.ecr.aws/spore-host/paraview:<tag>
 #
 # Build/push: infra/amis/containers/build-push.sh paraview <version>
-FROM ubuntu:22.04
+#
+# Pinned to linux/amd64: the ParaView tarball below is x86_64, and the
+# spore-dcv-base AMI runs on x86_64 GPU instances (g6/g5/g4dn). Without this
+# pin, building on an arm64 host (e.g. Apple Silicon) produces an arm64 image
+# wrapping an x86_64 binary that cannot exec.
+FROM --platform=linux/amd64 ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## What

Follow-up to #390, driven by actually **building the paraview container locally** (the de-risking step). Two things:

### 1. Platform bug (would have shipped a broken image)
On an arm64 host (Apple Silicon), the image built **arm64** while the ParaView tarball inside is **x86_64**, and the base AMI runs on x86_64 GPU instances (g6/g5/g4dn) — the binary could never exec.
- `Dockerfile`: `FROM --platform=linux/amd64 ubuntu:22.04`.
- `build-push.sh`: build via `docker buildx --platform linux/amd64` (`--load` for dry-run, `--push` for publish), so any host emits a correct x86_64 image.
- **Verified:** rebuilt image is `amd64 linux` with a valid x86_64 ELF ParaView binary.
- README documents the **preferred build method**: a throwaway x86 EC2 instance via `spawn` (native, no QEMU, instance-role creds), with local buildx as fallback.

### 2. Orphan-AMI cleanup (Phase F tooling)
`cleanup-orphan-amis.sh` — **dry-run by default**. Deregisters orphaned per-app AMIs and deletes their backing EBS snapshots in the owning account, keeping the shared base AMIs (`spore:type=dcv-*-base`) and anything in `SPORE_KEEP_AMIS`. `SPORE_CLEANUP_APPLY=true` to apply. Run when creds for the owning accounts (812107987990 / 942542972736) are available.

## Verification

`bash -n` clean; both buildx paths exercised locally (dry-run produced a correct amd64 image). No billable AWS calls in this PR.

Refs #290, #389.