### PR TITLE
feat(infra): chimerax container + Ubuntu 24.04 base for app images (#290)

### DIFF
--- a/infra/amis/containers/build-push.sh
+++ b/infra/amis/containers/build-push.sh
@@ -47,8 +47,30 @@ fi
 IMAGE="${REGISTRY}/${APP}"
 TAG="${IMAGE}:${VERSION}"
 
-# ParaView needs PV_MAJOR_MINOR derived from the version; pass both build-args.
-MAJOR_MINOR="$(echo "$VERSION" | cut -d. -f1,2)"
+# Per-app build-args + preconditions.
+BUILD_ARGS=()
+case "$APP" in
+  paraview)
+    # ParaView needs PV_MAJOR_MINOR derived from the version.
+    BUILD_ARGS+=(--build-arg "PV_VERSION=${VERSION}")
+    BUILD_ARGS+=(--build-arg "PV_MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)")
+    ;;
+  chimerax)
+    # LICENSE GATE: ChimeraX has no unattended download (UCSF requires accepting a
+    # non-commercial license per download). The .deb must be placed in the app dir
+    # by a human who accepted the license. Fail clearly if it's missing.
+    DEB_GLOB=("${SCRIPT_DIR}/${APP}"/ucsf-chimerax_*.deb)
+    if [[ ! -e "${DEB_GLOB[0]}" ]]; then
+      echo "ERROR: no ChimeraX .deb in ${SCRIPT_DIR}/${APP}/" >&2
+      echo "  ChimeraX requires accepting a non-commercial license to download." >&2
+      echo "  1) Visit https://www.cgl.ucsf.edu/chimerax/download.html, accept the license," >&2
+      echo "     and download the Ubuntu 24.04 .deb (ucsf-chimerax_${VERSION}ubuntu24.04_amd64.deb)." >&2
+      echo "  2) Place it in ${SCRIPT_DIR}/${APP}/ and re-run this script." >&2
+      exit 1
+    fi
+    BUILD_ARGS+=(--build-arg "CHIMERAX_DEB=$(basename "${DEB_GLOB[0]}")")
+    ;;
+esac
 
 # Always build linux/amd64 — the base AMI and the app binaries are x86_64. On an
 # arm64 host this cross-builds via buildx+QEMU. --load (dry-run) imports the
@@ -58,8 +80,7 @@ PLATFORM="linux/amd64"
 echo "==> Building ${TAG} (${PLATFORM})"
 if [[ "$DRYRUN" == "true" ]]; then
   docker buildx build --platform "$PLATFORM" --load \
-    --build-arg "PV_VERSION=${VERSION}" \
-    --build-arg "PV_MAJOR_MINOR=${MAJOR_MINOR}" \
+    "${BUILD_ARGS[@]}" \
     -t "$TAG" -f "$DOCKERFILE" "${SCRIPT_DIR}/${APP}"
   echo "==> DRYRUN — built ${TAG}, not pushing"
   exit 0
@@ -80,8 +101,7 @@ echo "==> Building + pushing ${TAG} (${PLATFORM})"
 # buildx --push builds the amd64 image and pushes it in one step (so an arm64
 # host publishes a correct x86_64 image, not its native arch).
 docker buildx build --platform "$PLATFORM" --push \
-  --build-arg "PV_VERSION=${VERSION}" \
-  --build-arg "PV_MAJOR_MINOR=${MAJOR_MINOR}" \
+  "${BUILD_ARGS[@]}" \
   -t "$TAG" -f "$DOCKERFILE" "${SCRIPT_DIR}/${APP}"
 
 echo "==> Done: ${TAG}"

--- a/infra/amis/containers/chimerax/.gitignore
+++ b/infra/amis/containers/chimerax/.gitignore
@@ -1,0 +1,3 @@
+# The ChimeraX .deb is downloaded by a human after accepting UCSF's
+# non-commercial license — never commit it (license + size).
+*.deb

--- a/infra/amis/containers/chimerax/Dockerfile
+++ b/infra/amis/containers/chimerax/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install ChimeraX from the human-provided .deb. apt resolves its dependencies.
 COPY ${CHIMERAX_DEB} /tmp/chimerax.deb
-RUN apt-get update && apt-get install -y /tmp/chimerax.deb \
+RUN apt-get update && apt-get install -y --no-install-recommends /tmp/chimerax.deb \
     && rm -f /tmp/chimerax.deb \
     && rm -rf /var/lib/apt/lists/* \
     && test -x /usr/bin/chimerax

--- a/infra/amis/containers/chimerax/Dockerfile
+++ b/infra/amis/containers/chimerax/Dockerfile
@@ -1,0 +1,50 @@
+# UCSF ChimeraX application container for the spore.host container catalog (#290).
+#
+# LICENSE GATE: ChimeraX is distributed under a non-commercial license that must
+# be ACCEPTED interactively before download (POST choice=Accept to UCSF's
+# chimerax-get.py — there is no unattended download URL). This Dockerfile does NOT
+# bypass that. You must download the .deb yourself after accepting the license at
+# https://www.cgl.ucsf.edu/chimerax/download.html and place it in THIS directory
+# (infra/amis/containers/chimerax/) before building. build-push.sh checks for it.
+#
+# Runs on the shared spore-dcv-base AMI (DCV, NVIDIA driver, X server, Docker,
+# NVIDIA Container Toolkit, spored). The container brings ChimeraX + a minimal WM
+# + the fullscreen launcher and draws into the host's DCV session display.
+#
+# Build/push: infra/amis/containers/build-push.sh chimerax 1.12   (after placing the .deb)
+#
+# Pinned linux/amd64: the .deb is amd64 and the base AMI runs x86_64 GPU instances.
+FROM --platform=linux/amd64 ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The ChimeraX .deb you downloaded after accepting the UCSF license. Default is
+# the 1.12 Ubuntu 24.04 package name; override with --build-arg CHIMERAX_DEB=...
+ARG CHIMERAX_DEB=ucsf-chimerax_1.12ubuntu24.04_amd64.deb
+
+# Minimal WM (metacity) + X utilities for the fullscreen launcher, matching the
+# paraview image. ChimeraX's own deps are resolved by apt from the .deb.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    metacity \
+    x11-utils x11-xserver-utils \
+    libgl1 libglx-mesa0 libglu1-mesa libxrender1 libxtst6 \
+    fontconfig fonts-dejavu-core \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install ChimeraX from the human-provided .deb. apt resolves its dependencies.
+COPY ${CHIMERAX_DEB} /tmp/chimerax.deb
+RUN apt-get update && apt-get install -y /tmp/chimerax.deb \
+    && rm -f /tmp/chimerax.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && test -x /usr/bin/chimerax
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Ubuntu 24.04 ships a default 'ubuntu' user at uid 1000; remove it so we can own
+# 1000 (matches the DCV session's ec2-user uid). 22.04 had no such user.
+RUN userdel -r ubuntu 2>/dev/null || true; useradd -m -u 1000 chimerax
+USER chimerax
+# The container CMD IS the DCV session: launch the WM + ChimeraX fullscreen.
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/infra/amis/containers/chimerax/entrypoint.sh
+++ b/infra/amis/containers/chimerax/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# UCSF ChimeraX container entrypoint (#290). DCV/X11 are on the host; this runs in
+# the container against the bind-mounted X socket with the session's DISPLAY
+# (passed in by spore-app-run, #263). Starts a minimal WM, launches ChimeraX
+# fullscreen, and re-maximizes once DCV resizes the virtual display to the browser
+# viewport. Blocks until ChimeraX exits, which ends the DCV session.
+set -u
+
+xsetroot -solid black 2>/dev/null || true
+metacity --sm-disable &
+sleep 1
+
+# ChimeraX honors --fullscreen; start it and capture the PID.
+/usr/bin/chimerax --fullscreen &
+CX_PID=$!
+
+# After DCV resizes the display to the browser viewport, re-maximize the main
+# ChimeraX window (skip transient dialogs).
+INIT_SIZE=$(xdpyinfo 2>/dev/null | grep dimensions | grep -oP '[0-9]+x[0-9]+')
+for _ in $(seq 1 60); do
+  sleep 2
+  SIZE=$(xdpyinfo 2>/dev/null | grep dimensions | grep -oP '[0-9]+x[0-9]+')
+  if [ "$SIZE" != "$INIT_SIZE" ] && [ -n "$SIZE" ]; then
+    sleep 1
+    for w in $(xprop -root 2>/dev/null | grep -oP '0x[0-9a-f]{5,}'); do
+      xprop -id "$w" WM_CLASS 2>/dev/null | grep -qi chimerax || continue
+      xprop -id "$w" WM_TRANSIENT_FOR 2>/dev/null | grep -q 'window id' && continue
+      xprop -id "$w" -format _NET_WM_STATE 32a -set _NET_WM_STATE \
+        '_NET_WM_STATE_MAXIMIZED_VERT,_NET_WM_STATE_MAXIMIZED_HORZ' 2>/dev/null
+    done
+    break
+  fi
+done &
+
+wait $CX_PID

--- a/infra/amis/containers/paraview/Dockerfile
+++ b/infra/amis/containers/paraview/Dockerfile
@@ -15,14 +15,15 @@
 # spore-dcv-base AMI runs on x86_64 GPU instances (g6/g5/g4dn). Without this
 # pin, building on an arm64 host (e.g. Apple Silicon) produces an arm64 image
 # wrapping an x86_64 binary that cannot exec.
-FROM --platform=linux/amd64 ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ParaView runtime libs + a minimal WM (metacity) + X utilities the launcher uses
 # to maximize the window after DCV resizes the display to the browser viewport.
+# (ParaView bundles its own Python/Qt, so the base distro version is not load-bearing.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgl1-mesa-glx \
+    libgl1 libglx-mesa0 \
     libglu1-mesa \
     libxt6 libxrender1 libxext6 libxcursor1 \
     libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
@@ -52,7 +53,9 @@ RUN curl -fsSL \
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-RUN useradd -m -u 1000 paraview
+# Ubuntu 24.04 ships a default 'ubuntu' user at uid 1000; remove it so we can own
+# 1000 (matches the DCV session's ec2-user uid). 22.04 had no such user.
+RUN userdel -r ubuntu 2>/dev/null || true; useradd -m -u 1000 paraview
 USER paraview
 # The container's job IS the DCV session: launch the WM + ParaView fullscreen and
 # block until ParaView exits (then DCV closes the session → spored sees idle).


### PR DESCRIPTION
## What

Adds the ChimeraX container and modernizes the app-image base to Ubuntu 24.04.

## ChimeraX (license-gated)
- `containers/chimerax/Dockerfile` (Ubuntu 24.04) installs **ChimeraX 1.12** from a `.deb` **you provide** — UCSF gates downloads behind an interactive non-commercial license (POST `choice=Accept`; no unattended URL). This does **not** bypass the license: `build-push.sh chimerax 1.12` fails with clear instructions if no `.deb` is present in the app dir. `.gitignore` keeps the `.deb` out of git.
- `containers/chimerax/entrypoint.sh` — metacity + fullscreen launcher mirroring paraview.

## Ubuntu 24.04 (was 22.04, just inherited)
- Both Dockerfiles → `ubuntu:24.04` (current LTS, supported to 2029). ParaView bundles its own Python/Qt so its base isn't load-bearing; ChimeraX has a real 24.04 `.deb`.
- Fixed two 24.04 breakages found by building locally: the mesa package rename (`libgl1-mesa-glx` → `libgl1 libglx-mesa0`), and the new default `ubuntu` user at uid 1000 colliding with our `useradd -u 1000` (now `userdel ubuntu` first).
- **paraview 24.04 image rebuilt + repushed** to `public.ecr.aws/f8g1e7l5/paraview:5.13.2` — verified amd64, all ParaView libs resolve, runs as uid 1000.

## build-push.sh
App-aware build-args (paraview `PV_*`; chimerax `.deb` precondition + `CHIMERAX_DEB`).

## Notes
chimerax launch isn't functional until someone builds+pushes its image (needs the licensed `.deb`); the catalog bump to 1.12 is libs PR #15. paraview remains fully working.

Refs #290.