### PR TITLE
fix(infra): chimerax container actually launches — Qt6 xcb deps + no --fullscreen (#290)

### DIFF
--- a/infra/amis/containers/chimerax/Dockerfile
+++ b/infra/amis/containers/chimerax/Dockerfile
@@ -30,6 +30,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1 libglx-mesa0 libglu1-mesa libxrender1 libxtst6 \
     fontconfig fonts-dejavu-core \
     ca-certificates \
+    `# ChimeraX 1.12 uses Qt6, whose xcb platform plugin needs libxcb-cursor0` \
+    `# (+ the xcb helper libs); without it Qt aborts: "no Qt platform plugin".` \
+    libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+    libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 \
+    libxkbcommon-x11-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ChimeraX from the human-provided .deb. apt resolves its dependencies.

--- a/infra/amis/containers/chimerax/entrypoint.sh
+++ b/infra/amis/containers/chimerax/entrypoint.sh
@@ -10,8 +10,9 @@ xsetroot -solid black 2>/dev/null || true
 metacity --sm-disable &
 sleep 1
 
-# ChimeraX honors --fullscreen; start it and capture the PID.
-/usr/bin/chimerax --fullscreen &
+# ChimeraX has no --fullscreen flag; the WM (metacity) + the re-maximize loop
+# below own fullscreen. Start it plain and capture the PID.
+/usr/bin/chimerax &
 CX_PID=$!
 
 # After DCV resizes the display to the browser viewport, re-maximize the main


### PR DESCRIPTION
Follow-up to #393, found by a **real GPU launch** of chimerax (built from the licensed .deb, pushed to ECR). The handshake reached `ready` but the container exited immediately. Two bugs, both fixed and re-confirmed live:

1. **Qt6 xcb plugin deps missing.** ChimeraX 1.12 uses Qt6; its xcb platform plugin needs `libxcb-cursor0` (+ the xcb helper libs and `libxkbcommon-x11-0`). Without them: *"no Qt platform plugin could be initialized … Fatal Python error: Aborted"*. ParaView bundles Qt5, so it never hit this. Added the full set.
2. **Bad flag.** entrypoint launched `chimerax --fullscreen`, but ChimeraX has no `--fullscreen` (exit 64). Dropped it — metacity + the entrypoint's re-maximize loop handle fullscreen.

## Verified live (g6.xlarge, us-east-1, terminated + leak-checked)
After the fix, re-launch: container **`Up`**, `metacity` + `chimerax` processes alive, and the **ChimeraX window is mapped on the DCV session display** (`xwininfo` shows `"ChimeraX"`). chimerax now streams end-to-end like paraview.

Image `public.ecr.aws/f8g1e7l5/chimerax:1.12` rebuilt + pushed with both fixes.

Refs #290.