### PR TITLE
ci(security): pin Actions to SHAs (clear Semgrep) + fix stale dependabot docker entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Los_Angeles"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -39,6 +41,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Los_Angeles"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -72,6 +76,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Los_Angeles"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -90,6 +96,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Los_Angeles"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,9 +58,15 @@ updates:
           - "minor"
           - "patch"
 
-  # Docker for spawn
+  # Docker — point at the directories that actually contain Dockerfiles. The
+  # previous single "/spawn" entry had no Dockerfile there and errored every run
+  # ("No Dockerfiles nor Kubernetes YAML found in /spawn").
   - package-ecosystem: "docker"
-    directory: "/spawn"
+    directories:
+      - "/infra/ci-runners"
+      - "/infra/amis"
+      - "/infra/amis/containers/paraview"
+      - "/infra/amis/containers/chimerax"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -69,7 +75,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "component:spawn"
       - "type:security"
     commit-message:
       prefix: "deps(docker)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
           - module: lambda/spore-bot
             min_coverage: '12'   # current ~13.8%
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.26'
           cache: true
@@ -56,7 +56,7 @@ jobs:
             || { echo "::error::coverage ${total}% is below floor ${MIN_COVERAGE}%"; exit 1; }
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ${{ matrix.module }}/coverage.out
           flags: ${{ matrix.module }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,9 +16,9 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: npm
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
         with:
           role-to-assume: arn:aws:iam::966362334030:role/GitHubActionsDocsDeployRole
           aws-region: us-east-1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,10 +16,10 @@ jobs:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.26'
 
@@ -44,7 +44,7 @@ jobs:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
       # gitleaks BINARY (MIT, free for orgs); the action wrapper needs a paid
@@ -62,10 +62,10 @@ jobs:
     name: Trivy Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Trivy filesystem scan (vulns + secrets)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -74,7 +74,7 @@ jobs:
           exit-code: 1
 
       - name: Trivy IaC scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           scan-ref: .
@@ -87,7 +87,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Semgrep scan
         run: semgrep scan --config=auto --error .


### PR DESCRIPTION
Two fixes from the org-wide external-issues sweep:

1. **Pin all GitHub Actions to commit SHAs** (with version comments) across ci/docs/security workflows; `trivy-action` @master→v0.36.0. Clears the fleet-wide Semgrep `github-actions-mutable-action-tag` failure + hardens the CI supply chain.
2. **Fix the failing Dependabot `docker` config.** It pointed at `/spawn` (no Dockerfile) → `ERROR: No Dockerfiles found in /spawn` every scheduled run. Repointed at the directories that actually contain Dockerfiles (`infra/ci-runners`, `infra/amis`, `infra/amis/containers/{paraview,chimerax}`), so Dependabot now watches the real base images instead of erroring. (The stale PR #71 it had opened is already closed.)