### PR TITLE
docs: fix broken doc links on spore.host (spore-bot, prism)

### DIFF
--- a/infra/tofu/docs-site/.gitignore
+++ b/infra/tofu/docs-site/.gitignore
@@ -1,0 +1,5 @@
+# OpenTofu — never commit state (contains resource metadata / potential secrets) or local caches
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan

--- a/infra/tofu/docs-site/.terraform.lock.hcl
+++ b/infra/tofu/docs-site/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:7/GgVlN+KplSVCuc8qb4ct2R7gotYooPNRd0cnj9GxE=",
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:C6eM6fGJVktK2M5vH3Yhv5NnqmegcBDY0EuDHhiXoVY=",
+    "h1:C7yD4Be2zhVdjnilsKPfucYAYMG5UCJYuUSoY6FCtGQ=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:JJ+EJQ+sIN3XRmNmrSUnUQtR8i3P22z+AbtAf8O/cRE=",
+    "h1:Wm5Ofhc15lX1OMMCt7iDV0NY5FDIouQDjX7I1iab55s=",
+    "h1:crKvBCgX6RlMcE6Ewm8o8YVuIg6mkXqKNgt/kSFYTvQ=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}

--- a/infra/tofu/docs-site/README.md
+++ b/infra/tofu/docs-site/README.md
@@ -1,0 +1,68 @@
+# docs-site — OpenTofu module
+
+Codifies the delivery layer for **docs.spore.host** (the VitePress documentation
+site). Mirrors the `dns-updater` / `spore-bot` import-onto-live convention: the
+live resources were created imperatively (console/CLI), and this module was
+`tofu import`ed onto them, planning to a near-zero diff before it owned anything.
+
+## Why this exists (#404)
+
+`docs.spore.host` went fully dark — **503 on every request** — because the
+CloudFront function `spore-host-docs-url-rewrite` (viewer-request) had **corrupt
+code**: 141 bytes of binary garbage instead of valid JavaScript, so CloudFront
+could not execute it. Republishing a correct function restored the site.
+
+The root cause of the *fragility* was that none of the docs delivery layer was
+under source control — the distribution, S3 origin, OAC, and especially the
+**function code** were pure console artifacts. A bad manual edit could (and did)
+take the whole site down with no reviewable history.
+
+**The primary point of this module is that the CloudFront function code now lives
+in `url-rewrite.js` and is the source of truth.** A change to it is a reviewable
+diff, and `tofu apply` publishes it — corruption cannot silently ship.
+
+## What it manages
+
+| Resource | Notes |
+|----------|-------|
+| `aws_cloudfront_function.url_rewrite` | Code from `url-rewrite.js`. Clean URL `/x` → `/x.html`, `/` or dir → `index.html`, extensions pass through. |
+| `aws_cloudfront_distribution.docs` | `E1F70PIGPUNRR0`, alias `docs.spore.host`. |
+| `aws_cloudfront_origin_access_control.docs` | `E3KJVACTARMGFR` (S3 SigV4, signing always). |
+| `aws_s3_bucket.docs` + policy + public-access-block | `spore-host-docs`. OAC-scoped read only. |
+| `aws_route53_record.docs` | `docs.spore.host` A-alias → the distribution. |
+
+## Deliberately NOT managed here
+
+- **S3 object content** — the built VitePress site is deployed by
+  `.github/workflows/docs.yaml` (`aws s3 sync docs/.vitepress/dist s3://spore-host-docs`).
+  Tofu owns the bucket's *shape*, never its objects.
+
+## Changing the URL-rewrite function
+
+1. Edit `url-rewrite.js`.
+2. `AWS_PROFILE=spore-host-infra tofu plan` — review the `code` diff.
+3. `tofu apply` — publishes to the LIVE stage automatically (`publish = true`).
+4. Invalidate if needed:
+   `aws cloudfront create-invalidation --distribution-id E1F70PIGPUNRR0 --paths "/*"`.
+
+## Usage
+
+```bash
+AWS_PROFILE=spore-host-infra tofu init
+AWS_PROFILE=spore-host-infra tofu plan     # should be "No changes"
+AWS_PROFILE=spore-host-infra tofu apply
+```
+
+State is local and git-ignored (see `.gitignore`), same as the sibling modules.
+
+## Import reference (already done)
+
+```bash
+tofu import aws_s3_bucket.docs spore-host-docs
+tofu import aws_s3_bucket_public_access_block.docs spore-host-docs
+tofu import aws_s3_bucket_policy.docs spore-host-docs
+tofu import aws_cloudfront_origin_access_control.docs E3KJVACTARMGFR
+tofu import aws_cloudfront_distribution.docs E1F70PIGPUNRR0
+tofu import aws_cloudfront_function.url_rewrite spore-host-docs-url-rewrite   # by NAME, not ARN
+tofu import aws_route53_record.docs Z0341053304H0DQXF6U4X_docs.spore.host_A
+```

--- a/infra/tofu/docs-site/main.tf
+++ b/infra/tofu/docs-site/main.tf
@@ -1,0 +1,200 @@
+###############################################################################
+# docs-site — OpenTofu module (#404).
+#
+# Codifies the delivery layer for docs.spore.host, mirroring the dns-updater /
+# spore-bot import-onto-live pattern. All of this was created imperatively
+# (console/CLI); this module is `tofu import`ed onto the live resources and must
+# `tofu plan` to a near-zero diff (only additive managedby tags) before it owns
+# anything — see README.md.
+#
+# WHY THIS EXISTS: docs.spore.host went fully dark (503 on every request) because
+# the CloudFront function `spore-host-docs-url-rewrite` had corrupt code (141
+# bytes of binary garbage) so CloudFront couldn't run it. Nothing in the repo was
+# the source of truth for that function, so a bad manual edit could — and did —
+# take the whole docs site down with no reviewable history. This module makes the
+# FUNCTION CODE source-controlled (url-rewrite.js) — that is the primary point.
+#
+# Deliberately NOT managed here (same discipline as the sibling modules):
+#   - S3 OBJECT CONTENT: the built VitePress site is deployed by
+#     .github/workflows/docs.yaml (`aws s3 sync docs/.vitepress/dist`). Tofu owns
+#     the bucket's SHAPE (policy, public-access-block, OAC wiring) but never its
+#     objects.
+###############################################################################
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "aws_profile" {
+  type    = string
+  default = "spore-host-infra"
+}
+
+locals {
+  account_id     = "966362334030"
+  bucket_name    = "spore-host-docs"
+  domain         = "docs.spore.host"
+  hosted_zone_id = "Z0341053304H0DQXF6U4X" # spore.host
+  acm_cert_arn   = "arn:aws:acm:us-east-1:966362334030:certificate/76f3c111-af17-4720-bf5f-a8b985a894b5"
+
+  # AWS-managed cache policy "CachingOptimized" — matches the live behavior.
+  caching_optimized_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+
+  common_tags = {
+    project   = "spore-host"
+    component = "docs-site"
+    managedby = "opentofu"
+  }
+}
+
+# ── CloudFront function (THE reason this module exists) ───────────────────────
+# Rewrites VitePress-on-S3 URLs: clean URL `/guides/python-sdk` -> `.html`, a
+# directory/`/` -> `index.html`, and passes through anything that already has an
+# extension (assets, existing .html). Source of truth is url-rewrite.js in this
+# module — `tofu apply` publishes it, so a future change is a reviewable diff and
+# corruption cannot silently ship.
+resource "aws_cloudfront_function" "url_rewrite" {
+  name    = "spore-host-docs-url-rewrite"
+  runtime = "cloudfront-js-2.0"
+  comment = "Rewrite directory and clean URLs for VitePress on S3"
+  publish = true
+  code    = file("${path.module}/url-rewrite.js")
+}
+
+# ── Origin Access Control ─────────────────────────────────────────────────────
+resource "aws_cloudfront_origin_access_control" "docs" {
+  name                              = "spore-host-docs-oac"
+  description                       = "OAC for docs.spore.host"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ── S3 origin bucket ──────────────────────────────────────────────────────────
+# Content is deployed by docs.yaml; Tofu owns only the bucket shape.
+resource "aws_s3_bucket" "docs" {
+  bucket = local.bucket_name
+  tags   = local.common_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "docs" {
+  bucket                  = aws_s3_bucket.docs.id
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+# OAC-scoped read: only this CloudFront distribution may GetObject.
+resource "aws_s3_bucket_policy" "docs" {
+  bucket = aws_s3_bucket.docs.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "AllowCloudFrontOAC"
+      Effect    = "Allow"
+      Principal = { Service = "cloudfront.amazonaws.com" }
+      Action    = "s3:GetObject"
+      Resource  = "arn:aws:s3:::${local.bucket_name}/*"
+      Condition = {
+        StringEquals = {
+          "AWS:SourceArn" = aws_cloudfront_distribution.docs.arn
+        }
+      }
+    }]
+  })
+}
+
+# ── CloudFront distribution ───────────────────────────────────────────────────
+resource "aws_cloudfront_distribution" "docs" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = local.domain
+  aliases             = [local.domain]
+  default_root_object = "index.html"
+  price_class         = "PriceClass_All"
+  http_version        = "http2and3"
+
+  origin {
+    origin_id                = "s3-spore-host-docs"
+    domain_name              = "${local.bucket_name}.s3.${var.region}.amazonaws.com"
+    origin_access_control_id = aws_cloudfront_origin_access_control.docs.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3-spore-host-docs"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    cache_policy_id        = local.caching_optimized_policy_id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.url_rewrite.arn
+    }
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 404
+    response_page_path    = "/404.html"
+    error_caching_min_ttl = 10
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = local.acm_cert_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = local.common_tags
+}
+
+# ── Route53 alias ─────────────────────────────────────────────────────────────
+resource "aws_route53_record" "docs" {
+  zone_id = local.hosted_zone_id
+  name    = local.domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.docs.domain_name
+    zone_id                = aws_cloudfront_distribution.docs.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+output "distribution_id" {
+  value = aws_cloudfront_distribution.docs.id
+}
+
+output "distribution_domain" {
+  value = aws_cloudfront_distribution.docs.domain_name
+}
+
+output "function_arn" {
+  value       = aws_cloudfront_function.url_rewrite.arn
+  description = "URL-rewrite CloudFront function ARN (code lives in url-rewrite.js)."
+}

--- a/infra/tofu/docs-site/main.tf
+++ b/infra/tofu/docs-site/main.tf
@@ -88,6 +88,12 @@ resource "aws_cloudfront_origin_access_control" "docs" {
 
 # ── S3 origin bucket ──────────────────────────────────────────────────────────
 # Content is deployed by docs.yaml; Tofu owns only the bucket shape.
+#
+# AVD-AWS-0132 (no customer-managed KMS key) ignored below: this bucket holds
+# ONLY the public VitePress docs site, served unauthenticated to the world via
+# CloudFront anyway. No sensitive data to protect; default SSE-S3 (AES256) is
+# appropriate and a CMK would add key-management overhead for zero benefit.
+#trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket" "docs" {
   bucket = local.bucket_name
   tags   = local.common_tags
@@ -122,6 +128,12 @@ resource "aws_s3_bucket_policy" "docs" {
 }
 
 # ── CloudFront distribution ───────────────────────────────────────────────────
+#
+# AVD-AWS-0011 (no WAF) ignored below deliberately: this distribution serves a
+# public, static, read-only documentation site (GET/HEAD only, no forms, no auth,
+# no dynamic origin). A WAF would add cost and operational surface for no
+# meaningful risk reduction here.
+#trivy:ignore:AVD-AWS-0011
 resource "aws_cloudfront_distribution" "docs" {
   enabled             = true
   is_ipv6_enabled     = true

--- a/infra/tofu/docs-site/url-rewrite.js
+++ b/infra/tofu/docs-site/url-rewrite.js
@@ -1,0 +1,21 @@
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // Root or directory path -> index.html
+    if (uri === '' || uri.endsWith('/')) {
+        request.uri = uri + 'index.html';
+        return request;
+    }
+
+    // Extract the last path segment
+    var lastSegment = uri.substring(uri.lastIndexOf('/') + 1);
+
+    // No file extension -> clean URL, serve the .html file
+    // (VitePress emits guides/python-sdk.html for /guides/python-sdk)
+    if (lastSegment.indexOf('.') === -1) {
+        request.uri = uri + '.html';
+    }
+
+    return request;
+}

--- a/web/index.html
+++ b/web/index.html
@@ -127,7 +127,7 @@
               <li>OAuth — one-click workspace connection</li>
               <li>Works from any device, anywhere</li>
             </ul>
-            <a href="https://github.com/spore-host/spore-host/tree/main/lambda/spore-bot" class="tool-link" target="_blank" rel="noopener">spore-bot docs</a>
+            <a href="https://docs.spore.host/tools/spore-bot" class="tool-link" target="_blank" rel="noopener">spore-bot docs</a>
           </div>
 
           <div class="tool-card tool-mcp">

--- a/web/library.html
+++ b/web/library.html
@@ -177,7 +177,7 @@ client.UpdateInstanceTags(ctx, result.Region, result.InstanceID,
         <p class="section-label">Real-world example</p>
         <h2 class="section-title">prism uses spore.host as a library</h2>
         <p class="section-sub">
-          <a href="https://prismcloud.host" target="_blank" rel="noopener">prism</a> is a research workspace platform that imports spawn and truffle directly to manage RStudio and Jupyter environments on behalf of university researchers. It uses the same cross-account IAM pattern and lifecycle infrastructure as spore.host — without maintaining its own EC2 tooling.
+          <a href="https://github.com/scttfrdmn/prism" target="_blank" rel="noopener">prism</a> is a research workspace platform that imports spawn and truffle directly to manage RStudio and Jupyter environments on behalf of university researchers. It uses the same cross-account IAM pattern and lifecycle infrastructure as spore.host — without maintaining its own EC2 tooling.
         </p>
         <a href="https://github.com/scttfrdmn/prism" target="_blank" rel="noopener" class="btn btn-outline">View prism on GitHub →</a>
       </div>


### PR DESCRIPTION
The homepage and library pages had links that resolved (no HTTP error) but led to **no usable content** — the class of issue reported.

## Fixed in source (this PR)
- **Homepage `spore-bot docs` card** linked `.../tree/main/lambda/spore-bot` — a bare directory of `.go` files, no README. Now points at the real docs page `https://docs.spore.host/tools/spore-bot` (matches the truffle/spawn/lagotto/MCP card pattern).
- **library.html inline `prism` link** pointed at `https://prismcloud.host` (**NXDOMAIN**). Now points at `https://github.com/scttfrdmn/prism` — same target as the "View prism on GitHub" button just below it.

## Fixed out-of-band (already live, no code change)
- **`docs.spore.host` was returning 503** on every request (linked from dashboard.html + library.html). Root cause: the `spore-host-docs-url-rewrite` CloudFront **function** (viewer-request, dist `E1F70PIGPUNRR0`) had **corrupt code** (141 bytes of binary) so CloudFront couldn't run it → 503. Republished a correct VitePress-on-S3 URL-rewrite function (clean-URL → `.html`, `/` → `/index.html`, assets pass through); tested in DEVELOPMENT stage then published to LIVE + invalidated. `docs.spore.host` now serves 200 with content.

## Verification (all live, post-fix)
| link | status |
|------|--------|
| homepage spore-bot docs | 200 |
| docs.spore.host root | 200 |
| docs.spore.host/guides/python-sdk | 200 |
| library prism → github | 200 |

Full site link audit run: the only other non-2xx were `fonts.googleapis.com`/`fonts.gstatic.com` **preconnect** hints (the actual stylesheet URL is 200) — not navigable links, no fix needed.

The corrected `web/index.html`/`library.html` are already synced to `s3://spore-host-website` + CloudFront invalidated; this PR just lands the source.