### PR TITLE
docs: Workflow Engines overview (all 5) + refresh Nextflow guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -77,6 +77,7 @@ export default defineConfig({
             { text: 'MPI Clusters', link: '/guides/mpi' },
             { text: 'Pipelines', link: '/guides/pipelines' },
             { text: 'Plugins', link: '/guides/plugins' },
+            { text: 'Workflow Engines', link: '/guides/workflow-engines' },
             { text: 'Nextflow (nf-spawn)', link: '/guides/nextflow' },
           ]
         },

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -35,3 +35,10 @@ Task-oriented guides for common workflows. If you're new, start with **Getting S
 | [Pipelines](/guides/pipelines) | Chain jobs so each stage launches the next |
 | [Plugins](/guides/plugins) | Extend instances with pre-built or custom plugins at launch time |
 | [Job Arrays](/guides/job-arrays) | Launch and manage groups of related instances |
+
+## Workflow Engines
+
+| Guide | What you'll learn |
+|-------|------------------|
+| [Workflow Engines](/guides/workflow-engines) | Run Nextflow, WDL, CWL, Snakemake, or Airflow with spawn as the execution backend — each task on an ephemeral instance |
+| [Nextflow (nf-spawn)](/guides/nextflow) | Dispatch each Nextflow process to its own ephemeral EC2 instance |

--- a/docs/guides/nextflow.md
+++ b/docs/guides/nextflow.md
@@ -4,9 +4,8 @@
 
 This lets you run bioinformatics pipelines (including [nf-core](https://nf-co.re) pipelines) without AWS Batch, ECS, or any queue infrastructure.
 
-::: warning Early prototype
-nf-spawn is under active development. Not production-ready — expect rough edges.
-:::
+nf-spawn is one of five [workflow-engine integrations](/guides/workflow-engines)
+on spore.host; it's under active development with its own roadmap.
 
 ## How it works
 
@@ -21,31 +20,29 @@ Each task gets a fresh instance. When the task script finishes, spored terminate
 
 ## Requirements
 
-- [spawn](https://github.com/spore-host/spawn) installed and on `PATH`
+- [spawn](https://github.com/spore-host/spawn) and [truffle](https://github.com/spore-host/truffle) on `PATH`
 - AWS credentials configured
-- Nextflow 23.10+
-- Java 17+ (to build the plugin)
+- Nextflow 26.04.x (the version nf-spawn v0.8.0 is built against)
+- JDK 21+ (to build the plugin)
 
 ## Installation
 
 ```bash
-# Clone and build
+# Clone and build+install into ~/.nextflow/plugins/
 git clone https://github.com/spore-host/nf-spawn
 cd nf-spawn
-./gradlew jar
-
-# Install into Nextflow plugins directory
-NXF_HOME=${NXF_HOME:-$HOME/.nextflow}
-mkdir -p $NXF_HOME/plugins/nf-spawn-0.1.0
-cp build/libs/nf-spawn-0.1.0.jar $NXF_HOME/plugins/nf-spawn-0.1.0/
+./gradlew installPlugin
 ```
+
+See the [nf-spawn README](https://github.com/spore-host/nf-spawn) for the exact
+plugin id/version to declare (it tracks the built version).
 
 ## Configuration
 
 ```groovy
 // nextflow.config
 plugins {
-    id 'nf-spawn@0.1.0'
+    id 'nf-spawn@0.8.0'
 }
 
 process {
@@ -112,6 +109,7 @@ No Batch job queue, no ECS cluster, no idle capacity — instances spin up and d
 
 ## See also
 
+- [Workflow Engines overview](/guides/workflow-engines) — all five engine integrations
 - [nf-spawn on GitHub](https://github.com/spore-host/nf-spawn)
 - [spawn launch reference](/tools/reference/spawn#spawn-launch)
 - [Instance sizing with truffle](/tools/truffle)

--- a/docs/guides/workflow-engines.md
+++ b/docs/guides/workflow-engines.md
@@ -1,0 +1,78 @@
+# Workflow Engines
+
+spore.host is a first-class execution backend for **five workflow engines**. In
+every case the model is the same: each task/step/job/rule runs on its own
+**purpose-sized, ephemeral EC2 instance** that auto-terminates when it finishes —
+no cluster, no queue, no standing capacity. You keep writing your workflow in the
+engine you already use; spawn just runs the work.
+
+Each integration is a small, versioned, released package that plugs into the
+engine's own extension point and reuses the same spawn machinery (truffle
+auto-sizing, `--on-complete terminate` + TTL, a durable `.exitcode`-in-S3
+completion signal).
+
+## The five integrations
+
+| Engine | Package | How you enable it | Repo |
+|--------|---------|-------------------|------|
+| **Nextflow** | `nf-spawn` | `executor = 'spawn'` in `nextflow.config` | [spore-host/nf-spawn](https://github.com/spore-host/nf-spawn) |
+| **WDL** | `miniwdl-spawn` | `MINIWDL__SCHEDULER__CONTAINER_BACKEND=spawn` | [spore-host/miniwdl-spawn](https://github.com/spore-host/miniwdl-spawn) |
+| **CWL** | `cwl-spawn` | `cwl-spawn workflow.cwl inputs.yml` | [spore-host/cwl-spawn](https://github.com/spore-host/cwl-spawn) |
+| **Snakemake** | `snakemake-executor-plugin-spawn` | `snakemake --executor spawn` | [spore-host/snakemake-executor-plugin-spawn](https://github.com/spore-host/snakemake-executor-plugin-spawn) |
+| **Apache Airflow** | `spawn-airflow` | `SpawnRunTaskOperator(...)` in a DAG | [spore-host/spawn-airflow](https://github.com/spore-host/spawn-airflow) |
+
+The three [AWS HealthOmics](https://aws.amazon.com/healthomics/)-supported
+languages — **Nextflow, WDL, CWL** — were prioritized first for life-sciences
+relevance (spore.host is a cost-efficient alternative to HealthOmics, not a client
+of it). **Snakemake** and **Airflow** followed on demand.
+
+## Which one?
+
+- **Already have a Nextflow / WDL / CWL / Snakemake workflow?** Use the matching
+  plugin — your workflow runs unchanged; only the executor changes, so the engine
+  still owns parsing, scheduling, scatter/gather, and output collection.
+- **Bioinformatics / nf-core pipelines?** → **Nextflow** ([guide](/guides/nextflow)).
+- **Prefer declarative per-task resources with auto-sizing?** WDL, CWL, and
+  Snakemake all declare CPU/RAM, which spawn feeds to `truffle` to pick the
+  cheapest fitting instance automatically.
+- **Orchestrating a broader DAG (not just a bioinformatics pipeline)?** →
+  **Airflow**: add a `SpawnRunTaskOperator` task wherever you want a step to run
+  on an ephemeral instance. It's deferrable, so wide fan-out DAGs don't pin a
+  worker slot per in-flight instance.
+
+## Sizing
+
+Where the engine declares resources, spawn sizes the instance automatically via
+`truffle search --pick-first` (cheapest instance that fits):
+
+- **Nextflow** — `ext.instanceType` (explicit) per process.
+- **WDL** — `runtime { cpu, memory }` → auto-sized (or `spawn_instance_type`).
+- **CWL** — `ResourceRequirement` (`coresMin`/`ramMin`) → auto-sized.
+- **Snakemake** — `threads` + `resources: mem_mb` → auto-sized.
+- **Airflow** — `cpus=` / `memory_gib=` on the operator → auto-sized (or
+  `instance_type=`).
+
+## Requirements (all engines)
+
+- [spawn](https://github.com/spore-host/spawn) and
+  [truffle](https://github.com/spore-host/truffle) on `PATH`
+- AWS credentials configured
+- An S3 location for the work/exit-code bridge (each engine's docs name the exact
+  flag or env var)
+
+Every task launches with a **TTL backstop** and `--on-complete terminate`, so a
+run can't leak billable instances even if a step is interrupted.
+
+## Not yet first-class
+
+Snakemake and Airflow were promoted from the "integration pattern" tier on
+demand. Others — Prefect, Argo Workflows, Dagster, Luigi, Temporal, AWS Step
+Functions — currently have example patterns (spawn invoked as a launcher via
+`spawn pipeline` / `spawn queue`) rather than a native plugin. If you need one of
+those promoted to first-class, open an issue.
+
+## See also
+
+- [Nextflow integration guide](/guides/nextflow)
+- [Pipelines](/guides/pipelines) — the engine-agnostic `spawn pipeline` / `spawn queue`
+- [Instance sizing with truffle](/tools/truffle)


### PR DESCRIPTION
spore.host is now a first-class execution backend for **five** workflow engines — Nextflow, WDL, CWL, Snakemake, and Airflow (#321/#395/#396/#405/#406) — but the docs only covered Nextflow, and that guide was stale.

## Changes
- **New `docs/guides/workflow-engines.md`** — overview + comparison table of all five integrations (nf-spawn, miniwdl-spawn, cwl-spawn, snakemake-executor-plugin-spawn, spawn-airflow): how to enable each, per-engine sizing, a "which one?" section, and the HealthOmics prioritization note.
- **Refreshed `nextflow.md`** — nf-spawn **v0.8.0**, Nextflow **26.04.x**, JDK 21, `./gradlew installPlugin` (was v0.1.0 / Nextflow 23.10 / manual jar copy); dropped the stale "early prototype" warning; cross-linked the overview.
- Wired the new page into the guides sidebar (`config.mts`) and `guides/index.md` (new **Workflow Engines** section).

Docs-only; VitePress build verified locally. On merge, the Deploy Docs workflow republishes docs.spore.host.

Closes the documentation gap for the workflow-engine work.