### PR TITLE
ci(security): pin Go 1.26.5 to clear GO-2026-5856 (crypto/tls)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: ${{ matrix.module }}/go.sum
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Security
+- **Pinned the CI Go toolchain to 1.26.5** to clear GO-2026-5856, a `crypto/tls`
+  standard-library advisory present in go1.26.4 (affects the Go Lambdas / modules
+  built by CI). govulncheck is green again.
+
 ### Added
 - **`infra/ci-runners/` — the self-hosted CI runner fleet is now versioned** (it
   previously lived only on orion.local, so fixes weren't reviewable) (#381). The


### PR DESCRIPTION
GO-2026-5856 (`crypto/tls`, go1.26.4, fixed 1.26.5) affects every Go module built with the toolchain. This repo pins `go-version: '1.26'` = vulnerable 1.26.4; the last green Security scan predates the advisory and would fail on the next commit (the Go Lambda modules use TLS via the AWS SDK). Pin to 1.26.5 in ci + security. Completes the fleet-wide fix (spawn v0.69.0, truffle #75, lagotto #72).