### PR TITLE
Harden auth: hash API keys, log KeyID, per-account ExternalId (#374 safe slices)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Security
+- **rest-api: API keys are now stored and looked up by SHA-256 hash.** The raw
+  `sk_...` key was the DynamoDB partition key, so a table dump yielded usable
+  credentials. `validateAPIKey` now hashes the presented key and looks it up by
+  hash; legacy plaintext-keyed rows still authenticate (dual-read) and are
+  rewritten to their hashed form on first use, so the migration is transparent
+  and needs no client changes. New keys must be inserted hashed (see
+  `infra/DEPLOY.md`) (#374).
+- **rest-api: request log now includes a truncated, non-secret KeyID.** Each
+  request logs `keyid=` (first 8 hex chars of the key's SHA-256) for
+  attribution; the previous `Principal.KeyID` exposed the raw key's first 8
+  chars, which leaked the secret's prefix (#374).
+- **spore-bot: cross-account role assumption now uses a per-registration STS
+  ExternalId.** Registrations get a high-entropy `external_id` (generated at
+  register time, or supplied by the admin so it can be pre-baked into the
+  customer role's trust policy), and the assume uses it. Existing registrations
+  without one fall back to the shared `BOT_EXTERNAL_ID` so nothing breaks; the
+  static fallback (and EC2 `Resource:"*"` scoping) will be removed in a later,
+  coordinated customer-role redeploy (#374).
 - **spore-bot: removed the dead log-only instance-identity verification.** The
   PKCS#7/embedded-cert check in the notify path (`verifyNotifyAuth` + embedded EC2
   certs, `signature.go`) never rejected anything — it only logged — and its

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -373,14 +373,19 @@ echo "REST API URL: $REST_API_URL"
 
 ## Step 7 — Create an API key for the CLI
 
+Keys are stored **hashed** — the `api_key` partition key holds the SHA-256 of
+the key, never the plaintext, so a table dump yields no usable credentials
+(#374). Hand the plaintext to the user; store only its hash.
+
 ```sh
-# Generate a key and insert it into DynamoDB
+# Generate a key; the table stores its SHA-256, not the key itself.
 API_KEY="sk_integ_$(openssl rand -hex 16)"
+API_KEY_HASH=$(printf '%s' "$API_KEY" | shasum -a 256 | cut -d' ' -f1)
 
 aws dynamodb put-item \
   --table-name spore-api-keys \
   --item "{
-    \"api_key\": {\"S\": \"$API_KEY\"},
+    \"api_key\": {\"S\": \"$API_KEY_HASH\"},
     \"project\": {\"S\": \"spore-aws-internal\"},
     \"created_at\": {\"S\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"},
     \"active\": {\"BOOL\": true}
@@ -388,8 +393,12 @@ aws dynamodb put-item \
   --region us-east-1
 
 echo "API key: $API_KEY"
-echo "Save this — it will not be shown again."
+echo "Save this — it will not be shown again (only its hash is stored)."
 ```
+
+> Legacy keys inserted with the plaintext as the partition key still work: the
+> rest-api looks up by hash first, then falls back to plaintext and rewrites the
+> row to its hashed form on first use.
 
 ---
 

--- a/lambda/rest-api/auth.go
+++ b/lambda/rest-api/auth.go
@@ -3,8 +3,12 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -22,6 +26,21 @@ type Principal struct {
 	CreatedAt time.Time
 }
 
+// hashKey returns the hex-encoded SHA-256 of an API key. Keys are stored and
+// looked up by this hash so a table dump never yields usable credentials
+// (#374). The hash is also the source of the truncated KeyID we log.
+func hashKey(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:])
+}
+
+// keyID returns a short, non-secret identifier for a key, safe to log. It is
+// the first 8 hex chars of the key's SHA-256 — stable per key, but not
+// reversible to the secret (unlike the old key[:8], which leaked the prefix).
+func keyID(key string) string {
+	return hashKey(key)[:8]
+}
+
 func validateAPIKey(ctx context.Context, key string) (*Principal, error) {
 	table := os.Getenv("API_KEYS_TABLE")
 	if table == "" {
@@ -32,18 +51,31 @@ func validateAPIKey(ctx context.Context, key string) (*Principal, error) {
 		return nil, err
 	}
 	client := dynamodb.NewFromConfig(cfg)
-	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
-		TableName: aws.String(table),
-		Key: map[string]dynamodbtypes.AttributeValue{
-			"api_key": &dynamodbtypes.AttributeValueMemberS{Value: key},
-		},
-	})
-	if err != nil || out.Item == nil {
-		return nil, fmt.Errorf("key not found")
+
+	// Dual-read migration (#374): keys are stored hashed, but legacy rows still
+	// key on the plaintext. Look up by hash first; on a miss, fall back to the
+	// plaintext PK and, on a hit, rewrite the row to its hashed form so the
+	// plaintext copy disappears over time. New keys are only ever written hashed.
+	hashed := hashKey(key)
+	item, err := getKeyItem(ctx, client, table, hashed)
+	if err != nil {
+		return nil, err
+	}
+	if item == nil {
+		item, err = getKeyItem(ctx, client, table, key)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return nil, fmt.Errorf("key not found")
+		}
+		// Best-effort migrate legacy plaintext row → hashed. A failure here must
+		// not fail the request; the row is re-migrated on the next call.
+		migrateKeyToHash(ctx, client, table, key, hashed, item)
 	}
 
 	get := func(k string) string {
-		if v, ok := out.Item[k].(*dynamodbtypes.AttributeValueMemberS); ok {
+		if v, ok := item[k].(*dynamodbtypes.AttributeValueMemberS); ok {
 			return v.Value
 		}
 		return ""
@@ -55,10 +87,67 @@ func validateAPIKey(ctx context.Context, key string) (*Principal, error) {
 	}
 
 	return &Principal{
-		KeyID:     key[:8] + "...",
+		KeyID:     keyID(key),
 		Project:   get("project"),
 		AccountID: get("account_id"),
 	}, nil
+}
+
+// getKeyItem fetches the row whose api_key partition key equals pk (a hash or,
+// for legacy rows, the plaintext key). Returns (nil, nil) when absent.
+func getKeyItem(ctx context.Context, client *dynamodb.Client, table, pk string) (map[string]dynamodbtypes.AttributeValue, error) {
+	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key: map[string]dynamodbtypes.AttributeValue{
+			"api_key": &dynamodbtypes.AttributeValueMemberS{Value: pk},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("lookup api key: %w", err)
+	}
+	return out.Item, nil
+}
+
+// migrateKeyToHash rewrites a legacy plaintext-keyed row under its hashed PK and
+// deletes the plaintext row. Best-effort: any error is logged and swallowed so a
+// migration hiccup never blocks an otherwise-valid caller. The write is
+// conditioned on the hashed row not already existing to avoid clobbering.
+func migrateKeyToHash(ctx context.Context, client *dynamodb.Client, table, plaintext, hashed string, item map[string]dynamodbtypes.AttributeValue) {
+	// Guard against a corrupt row whose stored api_key isn't the plaintext we
+	// looked up — hashing that would strand it under the wrong PK.
+	if v, ok := item["api_key"].(*dynamodbtypes.AttributeValueMemberS); !ok || subtle.ConstantTimeCompare([]byte(v.Value), []byte(plaintext)) != 1 {
+		return
+	}
+	newItem := make(map[string]dynamodbtypes.AttributeValue, len(item))
+	for k, v := range item {
+		newItem[k] = v
+	}
+	newItem["api_key"] = &dynamodbtypes.AttributeValueMemberS{Value: hashed}
+	if _, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(table),
+		Item:                newItem,
+		ConditionExpression: aws.String("attribute_not_exists(api_key)"),
+	}); err != nil {
+		// ConditionalCheckFailed means the hashed row already exists (a
+		// concurrent migration) — fine; still drop the plaintext copy below.
+		if !isConditionalCheckFailed(err) {
+			log.Printf("api-key migrate: put hashed row failed for keyid=%s: %v", keyID(plaintext), err)
+			return
+		}
+	}
+	if _, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(table),
+		Key: map[string]dynamodbtypes.AttributeValue{
+			"api_key": &dynamodbtypes.AttributeValueMemberS{Value: plaintext},
+		},
+	}); err != nil {
+		log.Printf("api-key migrate: delete plaintext row failed for keyid=%s: %v", keyID(plaintext), err)
+	}
+}
+
+func isConditionalCheckFailed(err error) bool {
+	var cf *dynamodbtypes.ConditionalCheckFailedException
+	return errors.As(err, &cf)
 }
 
 // GenerateAPIKey creates a new random API key (used by spawn api-key create).

--- a/lambda/rest-api/main.go
+++ b/lambda/rest-api/main.go
@@ -48,7 +48,7 @@ func handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 	}
 	_ = cfg // used by sub-handlers
 
-	log.Printf("%s %s principal=%s", method, path, principal.Project)
+	log.Printf("%s %s principal=%s keyid=%s", method, path, principal.Project, principal.KeyID)
 
 	// Route
 	parts := strings.Split(strings.Trim(path, "/"), "/")

--- a/lambda/rest-api/util_test.go
+++ b/lambda/rest-api/util_test.go
@@ -100,6 +100,35 @@ func TestGenerateAPIKey(t *testing.T) {
 	}
 }
 
+func TestHashKeyAndKeyID(t *testing.T) {
+	const key = "sk_deadbeef"
+	h := hashKey(key)
+	// SHA-256 hex is 64 chars and deterministic.
+	if len(h) != 64 {
+		t.Errorf("hashKey len = %d, want 64", len(h))
+	}
+	if h != hashKey(key) {
+		t.Error("hashKey not deterministic")
+	}
+	// The hash must not reveal the plaintext (not a prefix/substring).
+	if strings.Contains(h, key) || strings.Contains(h, "deadbeef") {
+		t.Errorf("hash %q leaks plaintext", h)
+	}
+	// keyID is the first 8 hex chars of the hash — stable, non-secret, and
+	// derived from the hash (never the raw key prefix).
+	id := keyID(key)
+	if id != h[:8] {
+		t.Errorf("keyID = %q, want %q", id, h[:8])
+	}
+	if strings.HasPrefix(key, id) {
+		t.Errorf("keyID %q is a prefix of the raw key — leaks the secret", id)
+	}
+	// Different keys → different ids.
+	if keyID("sk_other") == id {
+		t.Error("keyID collision across distinct keys")
+	}
+}
+
 func TestDecodeOptions(t *testing.T) {
 	got := decodeOptions("ttl=4h,idle=30m,bad,name=test")
 	want := map[string]string{"ttl": "4h", "idle": "30m", "name": "test"} // "bad" (no =) skipped

--- a/lambda/spore-bot/admin.go
+++ b/lambda/spore-bot/admin.go
@@ -33,6 +33,7 @@ type adminRequest struct {
 	UserEmail      string   `json:"user_email,omitempty"` // alternative to user_id; resolved server-side
 	InstanceID     string   `json:"instance_id"`
 	RoleARN        string   `json:"role_arn"`
+	ExternalID     string   `json:"external_id,omitempty"` // STS ExternalId for RoleARN; generated if omitted
 	DNSName        string   `json:"dns_name,omitempty"`
 	TagPrefix      string   `json:"tag_prefix,omitempty"`
 	AllowedActions []string `json:"allowed_actions"`
@@ -192,11 +193,26 @@ func adminRegister(ctx context.Context, reg *Registry, r adminRequest, callerARN
 		r.AllowedActions = []string{"status"}
 	}
 
+	// Per-registration STS ExternalId (#374): use the admin-supplied value when
+	// present (so it can be pre-baked into the customer role's trust policy),
+	// otherwise generate a high-entropy one. The customer role must trust this
+	// ExternalId; until it does, the assume falls back to the shared
+	// BOT_EXTERNAL_ID in crossAccountEC2.
+	externalID := r.ExternalID
+	if externalID == "" {
+		generated, err := generateExternalID()
+		if err != nil {
+			return adminError(500, fmt.Sprintf("generate external id: %v", err)), nil
+		}
+		externalID = generated
+	}
+
 	registration := &BotRegistration{
 		UserKey:        userKey(r.Platform, r.WorkspaceID, r.UserID),
 		Nickname:       r.Nickname,
 		InstanceID:     r.InstanceID,
 		RoleARN:        r.RoleARN,
+		ExternalID:     externalID,
 		DNSName:        r.DNSName,
 		TagPrefix:      r.TagPrefix,
 		AllowedActions: r.AllowedActions,
@@ -212,10 +228,11 @@ func adminRegister(ctx context.Context, reg *Registry, r adminRequest, callerARN
 		"user_key":        registration.UserKey,
 		"nickname":        registration.Nickname,
 		"instance_id":     registration.InstanceID,
+		"external_id":     registration.ExternalID,
 		"allowed_actions": registration.AllowedActions,
 		"enabled":         registration.Enabled,
 		"registered_by":   callerARN,
-		"note":            "Registration created. Run set-enabled with enabled:true to grant access.",
+		"note":            "Registration created. Add external_id to the cross-account role's trust policy, then run set-enabled with enabled:true to grant access.",
 	})
 }
 

--- a/lambda/spore-bot/executor.go
+++ b/lambda/spore-bot/executor.go
@@ -168,7 +168,7 @@ func matchByEC2(ctx context.Context, regs []BotRegistration, target string) *Bot
 		if r.RoleARN == "" {
 			continue
 		}
-		ec2Client, err := crossAccountEC2(ctx, cfg, r.RoleARN, r.InstanceID)
+		ec2Client, err := crossAccountEC2(ctx, cfg, r.RoleARN, r.InstanceID, r.ExternalID)
 		if err != nil {
 			continue
 		}
@@ -310,7 +310,7 @@ func cmdList(ctx context.Context, reg *Registry, action *BotAction) (string, err
 
 // isTerminatedInEC2 returns true if the instance is terminated or not found in EC2.
 func isTerminatedInEC2(ctx context.Context, reg *BotRegistration) bool {
-	ec2Client, err := crossAccountEC2(ctx, cfg, reg.RoleARN, reg.InstanceID)
+	ec2Client, err := crossAccountEC2(ctx, cfg, reg.RoleARN, reg.InstanceID, reg.ExternalID)
 	if err != nil {
 		return false
 	}
@@ -353,7 +353,7 @@ func cmdEC2Op(ctx context.Context, cfg aws.Config, action *BotAction, op string)
 	}
 
 	// Assume cross-account role for this instance's AWS account
-	ec2Client, err := crossAccountEC2(ctx, cfg, reg.RoleARN, reg.InstanceID)
+	ec2Client, err := crossAccountEC2(ctx, cfg, reg.RoleARN, reg.InstanceID, reg.ExternalID)
 	if err != nil {
 		return "", fmt.Errorf("assume role: %w", err)
 	}
@@ -378,12 +378,17 @@ func cmdEC2Op(ctx context.Context, cfg aws.Config, action *BotAction, op string)
 	return "", fmt.Errorf("unknown op: %s", op)
 }
 
-func crossAccountEC2(ctx context.Context, cfg aws.Config, roleARN, instanceID string) (*ec2.Client, error) {
+func crossAccountEC2(ctx context.Context, cfg aws.Config, roleARN, instanceID, externalID string) (*ec2.Client, error) {
 	stsClient := sts.NewFromConfig(cfg)
 	creds := stscreds.NewAssumeRoleProvider(stsClient, roleARN, func(o *stscreds.AssumeRoleOptions) {
 		o.RoleSessionName = "spore-bot-" + instanceID
-		// ExternalId matches what bot-cross-account-role.yaml sets in the trust policy
-		externalID := getEnv("BOT_EXTERNAL_ID", "spawn-bot")
+		// Prefer the per-registration ExternalId; fall back to the shared
+		// BOT_EXTERNAL_ID for legacy records whose trust policy still uses it
+		// (#374 — the static fallback stays until every customer role is
+		// re-deployed with its own high-entropy ExternalId).
+		if externalID == "" {
+			externalID = getEnv("BOT_EXTERNAL_ID", "spawn-bot")
+		}
 		o.ExternalID = aws.String(externalID)
 	})
 	ec2Cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithCredentialsProvider(creds))
@@ -616,6 +621,17 @@ func generateConnectCode() (string, error) {
 		return "", err
 	}
 	return strings.ToUpper(hex.EncodeToString(b)), nil
+}
+
+// generateExternalID returns a high-entropy STS ExternalId for a cross-account
+// role assumption (32 bytes of crypto/rand, hex-encoded), prefixed so it's
+// self-describing in trust policies and logs (#374).
+func generateExternalID() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "spore-" + hex.EncodeToString(b), nil
 }
 
 // cmdConnect generates a connect code for self-registration.

--- a/lambda/spore-bot/external_id_test.go
+++ b/lambda/spore-bot/external_id_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerateExternalID covers the per-registration STS ExternalId (#374):
+// it must be high-entropy, unique, and carry the self-describing prefix.
+func TestGenerateExternalID(t *testing.T) {
+	a, err := generateExternalID()
+	if err != nil {
+		t.Fatalf("generateExternalID: %v", err)
+	}
+	if !strings.HasPrefix(a, "spore-") {
+		t.Errorf("external id %q missing spore- prefix", a)
+	}
+	// "spore-" + 64 hex chars (32 bytes of entropy).
+	if len(a) != len("spore-")+64 {
+		t.Errorf("external id len = %d, want %d", len(a), len("spore-")+64)
+	}
+	b, _ := generateExternalID()
+	if a == b {
+		t.Error("two generated external ids collided")
+	}
+	// It must never equal the shared static fallback.
+	if a == "spawn-bot" {
+		t.Error("generated external id equals the static fallback")
+	}
+}

--- a/lambda/spore-bot/registry.go
+++ b/lambda/spore-bot/registry.go
@@ -17,10 +17,15 @@ type BotRegistration struct {
 	// PK: {platform}#{workspace-id}#{user-id}
 	UserKey string `dynamodbav:"user_key"`
 	// SK: {nickname}
-	Nickname       string   `dynamodbav:"nickname"`
-	InstanceID     string   `dynamodbav:"instance_id"`
-	AWSAccountID   string   `dynamodbav:"aws_account_id"`
-	RoleARN        string   `dynamodbav:"role_arn"`
+	Nickname     string `dynamodbav:"nickname"`
+	InstanceID   string `dynamodbav:"instance_id"`
+	AWSAccountID string `dynamodbav:"aws_account_id"`
+	RoleARN      string `dynamodbav:"role_arn"`
+	// ExternalID is the per-registration STS ExternalId used when assuming
+	// RoleARN. Generated at register time (or supplied by the admin so it can
+	// be baked into the customer role's trust policy). Empty on legacy records,
+	// which fall back to the shared BOT_EXTERNAL_ID (#374).
+	ExternalID     string   `dynamodbav:"external_id,omitempty"`
 	DNSName        string   `dynamodbav:"dns_name,omitempty"`
 	TagPrefix      string   `dynamodbav:"tag_prefix"`
 	AllowedActions []string `dynamodbav:"allowed_actions"`


### PR DESCRIPTION
Safe-slices subset of the last two open [#374](https://github.com/spore-host/spore-host/issues/374) items. No customer coordination required; the gated remainders (static-fallback removal, EC2 `Resource:"*"` scoping) stay out of scope, so **#374 stays open**.

## #374.8 — hash API keys + log KeyID (rest-api)
- **KeyID logging (Slice A):** request log now emits `keyid=` — the first 8 hex chars of the key's SHA-256. Replaces `Principal.KeyID = key[:8]`, which leaked the raw secret's prefix (and would panic on a short key).
- **Hash dual-read migration (Slice B):** `validateAPIKey` hashes the presented key and looks it up by hash; on a miss it falls back to the legacy plaintext PK and, on a hit, best-effort rewrites the row to its hashed form (conditional `PutItem` + `DeleteItem`, failures logged not fatal). New keys are stored hashed only. Transparent to clients; no coordination.
- `infra/DEPLOY.md` Step 7 now inserts the SHA-256 as the partition key.

## #374.1 — per-account ExternalId (spore-bot, additive half only)
- New `ExternalID` field on `BotRegistration`, generated at register time (32 bytes crypto/rand, `spore-`-prefixed) or admin-supplied via `external_id`, returned in the register response so it can be baked into the customer role's trust policy.
- All four `crossAccountEC2` call sites assume with `reg.ExternalID`; **empty/legacy records fall back to the shared `BOT_EXTERNAL_ID`** — the static fallback is retained.

### Out of scope (gated — #374 stays open)
- Removing the static `BOT_EXTERNAL_ID` fallback → needs a coordinated customer-role redeploy.
- EC2 `Resource:"*"` → `spawn:managed=true` scoping lives in `deployment/cloudformation/bot-cross-account-role.yaml`, which isn't in this repo.

## Verification
`go build`, `go vet`, `go test`, `gofmt` clean in both `lambda/rest-api` and `lambda/spore-bot`. New unit tests: `TestHashKeyAndKeyID`, `TestGenerateExternalID`.