### PR TITLE
Remove static BOT_EXTERNAL_ID cross-account fallback, fail closed (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Security
+- **spore-bot: removed the static `BOT_EXTERNAL_ID` cross-account fallback (fail
+  closed).** Assuming a registration's cross-account role now requires that
+  registration's own per-account `external_id` (generated at register time since
+  the per-registration ExternalId change); a registration without one can no
+  longer assume its role via the shared `spawn-bot` value, which has been
+  removed. Safe now that both bot deployments run the per-account read path and
+  no live registration depends on the shared value. Any account's
+  `SpawnBotCrossAccount` trust policy must require its per-account ExternalId
+  (spawn CFN `ExternalId` parameter) before that account's instances can be
+  controlled (#413, #374).
 - **rest-api: API keys are now stored and looked up by SHA-256 hash.** The raw
   `sk_...` key was the DynamoDB partition key, so a table dump yielded usable
   credentials. `validateAPIKey` now hashes the presented key and looks it up by
@@ -28,10 +38,10 @@ own changelogs for CLI releases.
 - **spore-bot: cross-account role assumption now uses a per-registration STS
   ExternalId.** Registrations get a high-entropy `external_id` (generated at
   register time, or supplied by the admin so it can be pre-baked into the
-  customer role's trust policy), and the assume uses it. Existing registrations
-  without one fall back to the shared `BOT_EXTERNAL_ID` so nothing breaks; the
-  static fallback (and EC2 `Resource:"*"` scoping) will be removed in a later,
-  coordinated customer-role redeploy (#374).
+  customer role's trust policy), and the assume uses it. (The shared
+  `BOT_EXTERNAL_ID` fallback that initially backed this has since been removed —
+  see above; EC2 `Resource:"*"` scoping is opt-in via the spawn CFN template.)
+  (#374).
 - **spore-bot: removed the dead log-only instance-identity verification.** The
   PKCS#7/embedded-cert check in the notify path (`verifyNotifyAuth` + embedded EC2
   certs, `signature.go`) never rejected anything — it only logged — and its

--- a/lambda/spore-bot/admin.go
+++ b/lambda/spore-bot/admin.go
@@ -195,9 +195,9 @@ func adminRegister(ctx context.Context, reg *Registry, r adminRequest, callerARN
 
 	// Per-registration STS ExternalId (#374): use the admin-supplied value when
 	// present (so it can be pre-baked into the customer role's trust policy),
-	// otherwise generate a high-entropy one. The customer role must trust this
-	// ExternalId; until it does, the assume falls back to the shared
-	// BOT_EXTERNAL_ID in crossAccountEC2.
+	// otherwise generate a high-entropy one. Every registration must carry one —
+	// there is no shared fallback (#413), so the customer role's trust policy
+	// must be updated to require this ExternalId before the bot can act on it.
 	externalID := r.ExternalID
 	if externalID == "" {
 		generated, err := generateExternalID()

--- a/lambda/spore-bot/executor.go
+++ b/lambda/spore-bot/executor.go
@@ -379,16 +379,17 @@ func cmdEC2Op(ctx context.Context, cfg aws.Config, action *BotAction, op string)
 }
 
 func crossAccountEC2(ctx context.Context, cfg aws.Config, roleARN, instanceID, externalID string) (*ec2.Client, error) {
+	// Fail closed: every registration must carry its own per-account ExternalId
+	// (generated at register time since #412). The shared static "spawn-bot"
+	// fallback has been removed (#413) now that no live registration depends on
+	// it — a missing ExternalId is a misconfigured registration, not something
+	// to paper over with a guessable shared secret.
+	if externalID == "" {
+		return nil, fmt.Errorf("registration has no external_id; re-register the instance (per-account ExternalId is required since #412)")
+	}
 	stsClient := sts.NewFromConfig(cfg)
 	creds := stscreds.NewAssumeRoleProvider(stsClient, roleARN, func(o *stscreds.AssumeRoleOptions) {
 		o.RoleSessionName = "spore-bot-" + instanceID
-		// Prefer the per-registration ExternalId; fall back to the shared
-		// BOT_EXTERNAL_ID for legacy records whose trust policy still uses it
-		// (#374 — the static fallback stays until every customer role is
-		// re-deployed with its own high-entropy ExternalId).
-		if externalID == "" {
-			externalID = getEnv("BOT_EXTERNAL_ID", "spawn-bot")
-		}
 		o.ExternalID = aws.String(externalID)
 	})
 	ec2Cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithCredentialsProvider(creds))

--- a/lambda/spore-bot/external_id_test.go
+++ b/lambda/spore-bot/external_id_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 // TestGenerateExternalID covers the per-registration STS ExternalId (#374):
@@ -23,8 +26,24 @@ func TestGenerateExternalID(t *testing.T) {
 	if a == b {
 		t.Error("two generated external ids collided")
 	}
-	// It must never equal the shared static fallback.
+	// It must never equal the (now-removed) shared static value.
 	if a == "spawn-bot" {
-		t.Error("generated external id equals the static fallback")
+		t.Error("generated external id equals the removed static value")
+	}
+}
+
+// TestCrossAccountEC2_FailsClosedWithoutExternalID covers #413: a registration
+// with no per-account ExternalId can no longer assume its role via the removed
+// shared "spawn-bot" fallback — it must fail closed.
+func TestCrossAccountEC2_FailsClosedWithoutExternalID(t *testing.T) {
+	// A non-empty BOT_EXTERNAL_ID env must NOT resurrect the old fallback.
+	t.Setenv("BOT_EXTERNAL_ID", "spawn-bot")
+	_, err := crossAccountEC2(context.Background(), aws.Config{},
+		"arn:aws:iam::123456789012:role/SpawnBotCrossAccount", "i-0abc", "")
+	if err == nil {
+		t.Fatal("expected error when externalID is empty, got nil (fallback not removed?)")
+	}
+	if !strings.Contains(err.Error(), "external_id") {
+		t.Errorf("error %q should mention the missing external_id", err)
 	}
 }

--- a/lambda/spore-bot/registry.go
+++ b/lambda/spore-bot/registry.go
@@ -23,8 +23,9 @@ type BotRegistration struct {
 	RoleARN      string `dynamodbav:"role_arn"`
 	// ExternalID is the per-registration STS ExternalId used when assuming
 	// RoleARN. Generated at register time (or supplied by the admin so it can
-	// be baked into the customer role's trust policy). Empty on legacy records,
-	// which fall back to the shared BOT_EXTERNAL_ID (#374).
+	// be baked into the customer role's trust policy). Required: since #413
+	// there is no shared fallback, so a registration with an empty ExternalID
+	// can no longer assume its role — it must be re-registered (#374).
 	ExternalID     string   `dynamodbav:"external_id,omitempty"`
 	DNSName        string   `dynamodbav:"dns_name,omitempty"`
 	TagPrefix      string   `dynamodbav:"tag_prefix"`


### PR DESCRIPTION
Completes #413 — the last gated remainder of the 2026-06 audit (#374). Removes the shared static `spawn-bot` ExternalId fallback so cross-account role assumption requires each registration's own per-account `external_id`.

## Change
- **`executor.go`** — `crossAccountEC2` fails closed when `external_id` is empty (returns an error) instead of falling back to `getEnv("BOT_EXTERNAL_ID","spawn-bot")`. The three callers (`matchByEC2`, `isTerminatedInEC2`, the exec path) already degrade gracefully on error.
- **`admin.go` / `registry.go`** — comments updated; every registration must carry an ExternalId, no shared fallback.
- **`external_id_test.go`** — `TestCrossAccountEC2_FailsClosedWithoutExternalID` asserts that even a set `BOT_EXTERNAL_ID` env can't resurrect the fallback.
- **CHANGELOG** — new Security entry; corrected the earlier "will be removed in a later redeploy" note.

## Why this is safe now (prereqs met, see #413)
- Both bot deployments (`spore-bot`, `prism-bot`) run the per-account read path from #412 (deployed 2026-07-18).
- The shared `spore-bot-registry` has no registration depending on the static value (cleared; all were test artifacts).
- New registrations always get a generated `external_id`.

## Operational note
After merge + redeploy, any account's `SpawnBotCrossAccount` trust policy must require its per-account ExternalId (spawn CFN `ExternalId` parameter, spore-host/spawn#368) before that account's instances can be controlled — an empty/legacy registration now fails closed by design.

Closes #413. Refs #374, #412, spore-host/spawn#368.