### PR TITLE
docs Tier 1: fix correctness bugs + AWS auth model

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -41,6 +41,7 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: 'Installation', link: '/guides/installation' },
+            { text: 'AWS Authentication', link: '/guides/aws-auth' },
             { text: 'Your First Instance', link: '/guides/first-instance' },
             { text: 'Python SDK', link: '/guides/python-sdk' },
             { text: 'Go Library', link: '/guides/go-library' },

--- a/docs/guides/aws-auth.md
+++ b/docs/guides/aws-auth.md
@@ -1,0 +1,73 @@
+# AWS Authentication
+
+spore.host tools (`spawn`, `truffle`, `lagotto`) act on AWS with **your own AWS credentials**. There is no separate spore.host login — if the AWS CLI can reach your account, so can spore.host. This page is the one place that explains how to authenticate, how profiles work, and how your authentication relates to permissions and to what spore.host does on your behalf.
+
+## Sign in with `aws login`
+
+The recommended way to authenticate is **`aws login`** (AWS CLI **v2.34+**), which signs you in and manages **short-lived, auto-refreshing** credentials:
+
+```sh
+aws login                     # opens your browser to sign in
+aws sts get-caller-identity   # confirm: prints your account + identity
+```
+
+That's it — `spawn`, `truffle`, and `lagotto` pick these credentials up automatically through the standard AWS credential chain.
+
+::: tip Why `aws login` over static keys
+`aws login` credentials expire and refresh, so there's no long-lived secret to leak. Prefer it. Static access keys (`aws configure`) still work as a fallback — see below — but treat them as legacy/CI-only.
+:::
+
+### Static keys (fallback)
+
+If your organization issues static keys instead of federated login:
+
+```sh
+aws configure   # Access Key ID, Secret Access Key, region
+```
+
+Or export them (e.g. in CI): `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`.
+
+## Profiles and per-tool config
+
+Select a profile per-command or for the session with the standard AWS variable:
+
+```sh
+AWS_PROFILE=research spawn launch experiment --instance-type g5.xlarge --ttl 8h
+export AWS_PROFILE=research
+```
+
+spore.host also has a **suite-wide config layer** (`sporeconfig`) so you can pin a profile/region/account for the spore.host tools specifically, resolved **flag > env > file > default**:
+
+| Layer | Example |
+|-------|---------|
+| Flag  | `spawn --profile research --region us-west-2 launch …` |
+| Env   | `export SPORE_PROFILE=research SPORE_REGION=us-west-2` |
+| File  | `~/.config/spore/config.toml` → `[spore]\nprofile = "research"` |
+
+`SPORE_PROFILE`/`SPORE_REGION` override `AWS_PROFILE`/`AWS_REGION` for spore.host tools only, leaving the plain AWS CLI unaffected. `SPORE_ACCOUNT` (or `--account`) records the AWS account you expect, so a tool refuses to act if your credentials resolve to a different account — a guard against launching in the wrong place.
+
+## Authentication vs permissions vs "what runs where"
+
+Three distinct things, easy to conflate:
+
+1. **Authentication** — *who you are.* `aws login` (or a profile/keys) proves your identity to AWS.
+2. **Permissions** — *what you're allowed to do.* Your IAM role/user must allow the EC2/IAM actions spawn makes. That's the [minimal IAM policy](/reference/iam-permissions) — attach it to the identity you authenticate as. If a launch fails with `AccessDenied` / `UnauthorizedOperation`, this is what to check.
+3. **What acts on your behalf** — spore.host's hosted services (DNS subdomains, Slack/Teams notifications) run in spore.host's own AWS account and are reached over an HTTPS API; the **launched EC2 instances run in *your* account** under *your* credentials. So: you authenticate as you → your IAM policy grants the launch → spawn runs `RunInstances` in your account → the in-instance `spored` daemon manages lifecycle → optional hosted features (DNS/notify) are called out to spore.host's API. (Running everything in your *own* account instead — including the hosted pieces — is [self-hosting](/guides/self-hosting).)
+
+## SSH keys and the instance login user
+
+When spawn launches an instance it sets you up to **log in as yourself**, not as `ec2-user`:
+
+- It creates a Linux user on the instance **matching your local username**, with sudo, and installs your SSH **public** key into that user's `~/.ssh/authorized_keys`.
+- For the keypair, spawn **uses your existing default SSH key** — `~/.ssh/id_ed25519` if present, else `~/.ssh/id_rsa` — and imports its public key to EC2. If you have no default key, spawn generates and manages its own under `~/.spawn/keys/`. (Windows targets require RSA, since the EC2 Administrator password can only be decrypted with an RSA key; if your default key isn't RSA, spawn falls back to a managed RSA key for those.)
+
+So `spawn connect <name>` just works — it logs in as your user with the matching key. Nothing to configure.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `Unable to locate credentials` | Run `aws login` (or set a profile/keys); verify with `aws sts get-caller-identity`. |
+| `AccessDenied` / `UnauthorizedOperation` on launch | Your IAM identity is missing an action — attach the [minimal policy](/reference/iam-permissions). |
+| Acting in the wrong account | Set `SPORE_ACCOUNT` (or `--account`) to the intended account ID; check `AWS_PROFILE`/`SPORE_PROFILE`. |
+| Credentials expired mid-session | `aws login` again (short-lived credentials refresh on re-login). |

--- a/docs/guides/first-instance.md
+++ b/docs/guides/first-instance.md
@@ -52,7 +52,7 @@ Expected output:
 }
 ```
 
-If this fails, run `aws configure` and enter your Access Key ID, Secret Access Key, and preferred region. spore.host uses the same credentials as the AWS CLI — nothing extra to configure.
+If this fails, sign in with **`aws login`** (AWS CLI v2.34+; static `aws configure` keys also work). spore.host uses the same credentials as the AWS CLI — nothing extra to configure. See [AWS Authentication](/guides/aws-auth) for profiles and how auth relates to permissions.
 
 ---
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -73,24 +73,21 @@ Then add to `~/.claude/claude_desktop_config.json`:
 
 ## AWS credentials
 
-spore.host uses whichever credentials are active in your shell — the same ones the AWS CLI uses. No additional configuration is required if you've already run `aws configure`.
+spore.host uses whichever credentials are active in your shell — the same ones the AWS CLI uses. The recommended way to obtain them is **`aws login`** (AWS CLI v2.34+), which manages short-lived credentials for you; static `aws configure` keys also work.
 
 ```sh
-# Verify credentials are working
-aws sts get-caller-identity
+aws login                       # sign in
+aws sts get-caller-identity     # verify
 ```
 
-If you use multiple AWS profiles, you can set the active profile per-command:
+If you use multiple AWS profiles, set the active profile per-command or for the session:
 
 ```sh
-AWS_PROFILE=my-research-account spawn launch --name experiment --instance-type g5.xlarge --ttl 8h
-```
-
-Or set it as a default for your shell session:
-
-```sh
+AWS_PROFILE=my-research-account spawn launch experiment --instance-type g5.xlarge --ttl 8h
 export AWS_PROFILE=my-research-account
 ```
+
+See [AWS Authentication](/guides/aws-auth) for the full model (profiles, `SPORE_*` config, and how authentication relates to permissions).
 
 ## IAM permissions
 

--- a/docs/guides/mpi.md
+++ b/docs/guides/mpi.md
@@ -54,7 +54,7 @@ spawn launch \
 ## Monitoring the cluster
 
 ```sh
-spawn list --job-array climate-sim     # all nodes in the cluster
+spawn list --job-array-name climate-sim   # all nodes in the cluster
 spawn status climate-sim-0             # status of the head node
 spawn status climate-sim-1             # status of worker node 1
 ```
@@ -83,11 +83,14 @@ Write the completion file only from the head node (rank 0). MPI programs run on 
 For large datasets that all cluster nodes need to read, attach an FSx Lustre filesystem:
 
 ```sh
-# Create a new FSx filesystem backed by S3
+# Create a new FSx filesystem backed by S3.
+# --fsx-create REQUIRES --fsx-lifecycle: 'ephemeral' (reaped when this cluster
+# terminates) or 'durable' (persists; add --fsx-ttl, e.g. 7d).
 spawn launch sim \
   --count 8 --mpi --efa \
   --instance-type hpc6a.48xlarge \
   --fsx-create \
+  --fsx-lifecycle ephemeral \
   --fsx-s3-bucket my-data-bucket \
   --fsx-import-path s3://my-data-bucket/inputs/ \
   --fsx-export-path s3://my-data-bucket/outputs/ \

--- a/docs/guides/parameter-sweeps.md
+++ b/docs/guides/parameter-sweeps.md
@@ -4,19 +4,7 @@ A parameter sweep runs the same job across many combinations of input parameters
 
 ## The basic pattern
 
-```sh
-spawn launch hp-search \
-  --instance-type g5.xlarge \
-  --ttl 4h \
-  --params "learning_rate=0.001,0.01,0.1;batch_size=32,64,128" \
-  --command "python train.py --lr {learning_rate} --batch {batch_size}"
-```
-
-This launches 9 instances (3 learning rates × 3 batch sizes), each running the training script with a different combination. Each instance has its own TTL and terminates independently when done.
-
-## Parameter file format
-
-For larger sweeps, define parameters in a YAML file:
+A sweep is driven by a **parameter file** (`--param-file`, YAML/JSON/CSV): `defaults` shared by every instance, plus a `params` list where each entry is one combination to launch.
 
 ```yaml
 # sweep.yaml
@@ -24,6 +12,7 @@ defaults:
   instance_type: g5.xlarge
   ttl: 4h
   on_complete: terminate
+  command: "python train.py --lr {learning_rate} --batch {batch_size}"
 
 params:
   - learning_rate: 0.001
@@ -32,27 +21,41 @@ params:
     batch_size: 64
   - learning_rate: 0.01
     batch_size: 32
-  # ... more combinations
+  - learning_rate: 0.01
+    batch_size: 64
 ```
 
 ```sh
 spawn launch hp-search --param-file sweep.yaml
 ```
 
-## Generating combinations automatically
+This launches one instance per `params` entry (4 here), each running `command` with its combination substituted (`{learning_rate}`, `{batch_size}`). Each instance has its own TTL and terminates independently when done.
 
-Instead of listing every combination, use ranges and spore.host expands them:
+::: tip Preview before you launch
+Add `--estimate-only` to see the instance count and cost estimate without launching anything.
+:::
 
-```sh
-spawn launch grid-search \
-  --instance-type g5.xlarge \
-  --ttl 2h \
-  --params "learning_rate=log:0.0001:0.1:5;dropout=0.1,0.2,0.3,0.5" \
-  --cartesian \
-  --command "python train.py --lr {learning_rate} --dropout {dropout}"
+## Every combination of several lists
+
+List each parameter's values under `defaults` isn't how it works — instead enumerate the combinations you want in `params`. To sweep the full grid of several lists, generate the `params` list with a few lines of your own script (any language) and write it to the YAML/JSON file:
+
+```python
+# gen-sweep.py — write every learning_rate × batch_size combination
+import itertools, yaml
+lrs, batches = [0.001, 0.01, 0.1], [32, 64, 128]
+params = [{"learning_rate": lr, "batch_size": b} for lr, b in itertools.product(lrs, batches)]
+yaml.safe_dump({"defaults": {"instance_type": "g5.xlarge", "ttl": "4h",
+    "command": "python train.py --lr {learning_rate} --batch {batch_size}"},
+    "params": params}, open("sweep.yaml", "w"))
 ```
 
-`log:0.0001:0.1:5` generates 5 values logarithmically spaced between 0.0001 and 0.1.
+```sh
+python gen-sweep.py && spawn launch grid-search --param-file sweep.yaml   # 9 instances
+```
+
+::: info Inline `--params` / auto-expanded ranges
+Passing parameters inline (`--params …`) and auto-generating ranges/cartesian products from the CLI are not yet available — the CLI returns *"inline --params not yet implemented, use --param-file for now."* Generate the `params` list into a file as shown above.
+:::
 
 ## Monitoring a sweep
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -22,8 +22,11 @@ The official registry lives at
 Install onto a running instance with `spawn plugin install <ref>`:
 
 ```sh
-# From the official registry, by name
-spawn plugin install tailscale --instance my-job --config auth_key=tskey-auth-...
+# From the official registry, by name.
+# tailscale mints a short-lived key from your OAuth client, so you pass the ACL
+# tag as config and the OAuth client via env — not a raw auth key.
+export TS_API_CLIENT_ID=...  TS_API_CLIENT_SECRET=...
+spawn plugin install tailscale --instance my-job --config tag=tag:spore
 
 # Pin to a specific version
 spawn plugin install rstudio-server@v1.0.0 --instance my-job
@@ -63,7 +66,7 @@ ttl: 8h
 plugins:
   - ref: tailscale
     config:
-      auth_key: tskey-auth-...
+      tag: tag:spore   # OAuth client via TS_API_CLIENT_ID/SECRET env (see above)
 ```
 
 ```sh

--- a/docs/guides/spot-instances.md
+++ b/docs/guides/spot-instances.md
@@ -28,9 +28,8 @@ truffle spot g5.xlarge --regions us-east-1,us-west-2,eu-west-1 --show-savings
 `--show-savings` adds On-Demand and Savings columns so you can see the real discount per AZ (on-demand rates are pulled live from the AWS Price List API).
 
 ::: tip Finding the right instance type
-Not sure which instance to use? See [Finding the Right Instance](/guides/finding-instances) for a step-by-step walkthrough: `truffle find` → `truffle search` → `truffle spot` → `truffle quotas`.
+Not sure which instance to use? See [Finding the Right Instance](/guides/finding-instances) for a step-by-step walkthrough: `truffle find` → `truffle spot` → `truffle quotas`.
 :::
-```
 
 Spot prices vary by region and AZ — sometimes significantly. Running in `us-west-2` instead of `us-east-1` can save an additional 20–30% on the already-discounted Spot price.
 
@@ -91,7 +90,9 @@ spawn launch \
 Some instance types have much more stable Spot availability than others. Use truffle to compare:
 
 ```sh
-truffle find "nvidia gpu" --spot --sort-by-price --region us-east-1
+truffle spot "g5.xlarge" --sort-by-price --region us-east-1
 ```
+
+`truffle spot` reports live Spot prices and per-AZ availability; `--sort-by-price` orders cheapest-first (add `--show-savings` for the discount vs On-Demand). These Spot flags live on `truffle spot`, not `truffle find`.
 
 Types with high availability tend to be larger families (more AZs, more capacity pool) and slightly older generations.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,18 +32,18 @@ truffle --version
 spawn --version
 ```
 
-## Configure AWS credentials
+## Authenticate with AWS
 
-spore.host uses your existing AWS credentials — the same ones you use for the AWS CLI. If you've already run `aws configure`, you're set.
+spore.host uses whatever AWS credentials your shell already has. The recommended way to get them is **`aws login`** (AWS CLI v2.34+), which signs you in and refreshes short-lived credentials automatically:
 
 ```sh
-# Check that credentials work
-aws sts get-caller-identity
+aws login                       # sign in (opens your browser)
+aws sts get-caller-identity     # confirm you're authenticated
 ```
 
-::: tip Don't have AWS CLI configured yet?
-Run `aws configure` and provide your Access Key ID, Secret Access Key, and preferred region. spore.host requires permissions to describe and launch EC2 instances — see [IAM Permissions](/reference/iam-permissions) for the minimal policy.
-:::
+If your organization issues static keys instead, `aws configure` (Access Key ID / Secret Access Key / region) also works — `aws login` is preferred because the credentials are short-lived.
+
+Your credentials need permission to launch and manage EC2 instances; see the [minimal IAM policy](/reference/iam-permissions). For the full picture — profiles, `SPORE_*` config, and how your auth relates to what spore.host does on your behalf — see [AWS Authentication](/guides/aws-auth).
 
 ## Find an instance
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -4,15 +4,25 @@ spore.host tools read configuration from environment variables and `~/.spawn/con
 
 ## AWS credentials
 
-spore.host uses the standard AWS credential chain — no custom variables required.
+spore.host uses the standard AWS credential chain — no custom variables required. The recommended way to populate it is [`aws login`](/guides/aws-auth) (AWS CLI v2.34+); the variables below are for profile selection or the static-key fallback.
 
 | Variable | Description |
 |----------|-------------|
 | `AWS_PROFILE` | AWS CLI profile to use (recommended over static keys) |
 | `AWS_REGION` | Default AWS region |
-| `AWS_ACCESS_KEY_ID` | Static access key (prefer profiles or IAM roles) |
-| `AWS_SECRET_ACCESS_KEY` | Static secret key |
+| `AWS_ACCESS_KEY_ID` | Static access key — fallback only; prefer `aws login` / profiles |
+| `AWS_SECRET_ACCESS_KEY` | Static secret key (fallback) |
 | `AWS_SESSION_TOKEN` | Temporary session token (for assumed roles) |
+
+## spore.host config
+
+The suite-wide [`sporeconfig`](/guides/aws-auth) layer (all CLIs), resolved flag > env > `~/.config/spore/config.toml` > default:
+
+| Variable | Description |
+|----------|-------------|
+| `SPORE_PROFILE` | AWS profile for spore.host tools (overrides `AWS_PROFILE` for them) |
+| `SPORE_REGION` | Default region for spore.host tools |
+| `SPORE_ACCOUNT` | Expected AWS account ID (guards against launching in the wrong account) |
 
 ```sh
 # Use a named profile

--- a/docs/reference/iam-permissions.md
+++ b/docs/reference/iam-permissions.md
@@ -1,22 +1,23 @@
 # IAM Permissions
 
-spore.host requires IAM permissions to launch, manage, and terminate EC2 instances. Use the minimal policy below and expand only as needed.
+spore.host tools act on EC2 with **your** AWS credentials (see [AWS Authentication](../guides/aws-auth.md) for how those are obtained). This page is the least-privilege IAM policy those credentials need. Attach it to the IAM role/user you authenticate as, and expand only as your usage grows (Spot, DNS, FSx below).
 
 ## Minimal policy
 
-This policy covers core operations: launching instances, managing lifecycle, and querying state.
+This is the complete set required for the core flow — **`spawn launch` → connect → manage → terminate**. It is verified against the actual AWS API calls spawn makes; a smaller policy will fail at launch (see the callout below).
 
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "EC2Launch",
+      "Sid": "EC2ReadAndLaunch",
       "Effect": "Allow",
       "Action": [
         "ec2:RunInstances",
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceTypes",
+        "ec2:DescribeInstanceTypeOfferings",
         "ec2:DescribeInstanceStatus",
         "ec2:DescribeImages",
         "ec2:DescribeSubnets",
@@ -24,10 +25,44 @@ This policy covers core operations: launching instances, managing lifecycle, and
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeKeyPairs",
         "ec2:DescribeAvailabilityZones",
-        "ec2:DescribeSpotPriceHistory",
-        "ec2:DescribeServiceQuotas"
+        "ec2:DescribeSpotPriceHistory"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "EC2ProvisionSupport",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ImportKeyPair",
+        "ec2:CreateSecurityGroup",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "InstanceProfileForSpored",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:CreateRole",
+        "iam:PutRolePolicy",
+        "iam:AttachRolePolicy",
+        "iam:GetInstanceProfile",
+        "iam:CreateInstanceProfile",
+        "iam:AddRoleToInstanceProfile"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/spored*",
+        "arn:aws:iam::*:instance-profile/spored*"
+      ]
+    },
+    {
+      "Sid": "PassSporedRoleToEC2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::*:role/spored*",
+      "Condition": { "StringEquals": { "iam:PassedToService": "ec2.amazonaws.com" } }
     },
     {
       "Sid": "EC2Manage",
@@ -36,7 +71,6 @@ This policy covers core operations: launching instances, managing lifecycle, and
         "ec2:StartInstances",
         "ec2:StopInstances",
         "ec2:TerminateInstances",
-        "ec2:CreateTags",
         "ec2:DeleteTags",
         "ec2:DescribeTags",
         "ec2:ModifyInstanceAttribute"
@@ -49,7 +83,7 @@ This policy covers core operations: launching instances, managing lifecycle, and
       }
     },
     {
-      "Sid": "STS",
+      "Sid": "Identity",
       "Effect": "Allow",
       "Action": ["sts:GetCallerIdentity"],
       "Resource": "*"
@@ -58,8 +92,12 @@ This policy covers core operations: launching instances, managing lifecycle, and
 }
 ```
 
-::: tip Scope TerminateInstances
-The condition on `EC2Manage` ensures you can only stop/terminate instances tagged `spawn:managed=true`. This prevents accidental termination of unrelated instances.
+::: warning Why the extra statements are required
+A launch does more than `RunInstances`. spawn **imports your SSH public key** (`ec2:ImportKeyPair`), may **create a security group** for the instance (`ec2:CreateSecurityGroup` / `AuthorizeSecurityGroupIngress`), and — so the in-instance `spored` daemon can manage the instance's lifecycle — **creates a `spored` IAM role + instance profile and passes it to EC2 at launch** (the `iam:*` on `spored*` + `iam:PassRole`). Omit these and `spawn launch` fails partway. The `iam:*` grants are scoped to `spored*` names so they can't touch other roles.
+:::
+
+::: tip Scope on tags
+`EC2Manage` is conditioned on `spawn:managed=true`, so you can only start/stop/terminate instances spawn created — never unrelated ones. The read (`Describe*`) and launch statements can't be tag-scoped (the resources don't exist yet at describe/launch time).
 :::
 
 ## Spot instances
@@ -123,15 +161,19 @@ truffle checks instance quotas before suggesting instance types. Add:
 }
 ```
 
-## Quick setup
+## Applying the policy
 
-The easiest approach is to attach `PowerUserAccess` in development and tighten later:
+Save the minimal policy to `spore-host-policy.json`, then attach it to the role or user you authenticate as ([aws login](../guides/aws-auth.md) or a profile):
 
 ```sh
-# Attach the managed policy to your IAM user (development only)
-aws iam attach-user-policy \
-  --user-name your-iam-user \
-  --policy-arn arn:aws:iam::aws:policy/PowerUserAccess
+aws iam put-role-policy \
+  --role-name your-spore-host-role \
+  --policy-name spore-host \
+  --policy-document file://spore-host-policy.json
 ```
 
-For production, use the minimal policy above with an IAM role and assume it via `AWS_PROFILE`.
+Add the [Spot](#spot-instances), [DNS](#dns-integration), [FSx](#fsx-for-lustre), or [service-quota](#service-quotas) statements only if you use those features.
+
+::: tip Prefer least privilege over `PowerUserAccess`
+It's tempting to attach `PowerUserAccess` while getting started, but the policy above is small and complete — start with it. If you must broaden temporarily, tighten back to this policy before any shared or production use.
+:::


### PR DESCRIPTION
Tier 1 of the documentation remediation (see the audit). **User-blocking correctness fixes + the AWS-auth story** — docs-only, deploys continuously on merge.

## IAM policy (was broken)
`reference/iam-permissions.md`'s "minimal policy" could not launch an instance. Now includes everything spawn actually calls (verified against `spawn/pkg/aws`): `iam:PassRole` + `spored*` instance-profile actions, `ec2:ImportKeyPair` (spawn imports a public key — not `CreateKeyPair`), `CreateSecurityGroup`/`AuthorizeSecurityGroupIngress`. Removed the invalid `ec2:DescribeServiceQuotas`; replaced the `PowerUserAccess` recommendation with least-privilege guidance.

## AWS auth model (was wrong site-wide)
Introduced **`aws login`** (AWS CLI v2.34+) as the recommended path and demoted static `aws configure` keys to a fallback, across quickstart / first-instance / installation / environment-variables. Added the `SPORE_PROFILE/REGION/ACCOUNT` config layer. New **`guides/aws-auth.md`** is the canonical page: `aws login`, profiles, sporeconfig, the authentication↔permissions↔hosted-vs-self-hosted model, and the SSH-key / local-user login story — wired into Getting Started nav so it's not orphaned.

## Hard-error examples (verified against the CLI)
- `parameter-sweeps.md`: inline `--params` is unimplemented in code → rewrote around `--param-file` (with a script to generate combinations).
- `mpi.md`: `--fsx-create` now requires `--fsx-lifecycle`; `spawn list --job-array` → `--job-array-name`.
- `plugins.md`: tailscale `--config auth_key=` → `tag` + OAuth env (matches the plugin spec).
- `spot-instances.md`: `truffle find --spot --sort-by-price` → `truffle spot … --sort-by-price` (those flags live on `spot`); fixed a stray code fence.

`npm run build` (VitePress) clean — no dead links.

Note: the stale per-command **reference tables** are intentionally NOT hand-edited here — Tier 2 regenerates them from the CLIs (`gen-docs`) so they can't re-drift. The matching **spawn SSH-key code fix** (prefer `~/.ssh` default) ships as its own spawn PR.