### PR TITLE
Docs Tier 3: pipelines/SageMaker prose fixes + nav hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,22 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Fixed
+- **Docs: corrected the Pipelines guide** — `spawn pipeline launch` takes a JSON
+  definition file (not the fictional YAML + `--slack-workspace`/`--efs-id`
+  flags), stages form a DAG via `depends_on`, and data is handed off with
+  `data_input`/`data_output`. Also fixed `status`/`cancel`/`collect` (take a
+  pipeline id) vs `graph` (takes the file).
+- **Docs: rewrote the lagotto SageMaker section** — `--service sagemaker` now
+  **submits your training job** (`--sagemaker-config`) when the EC2-family proxy
+  fires; it is no longer notify-only. `--action notify` (alert only) and `spawn`
+  (submit) are both valid; `hold` is rejected.
+- **Docs: fixed the sidebar** — wired the orphaned Discord setup guide into nav
+  and de-duplicated the two "Self-Hosting" entries into one group.
+
 ### Added
+- **Docs: truffle overview now documents the shared `--profile`/`--account`
+  config** and links the AWS auth guide.
 - **Docs: the CLI command/flag reference is now generated + drift-gated.** Each
   CLI (spawn/truffle/lagotto) emits its exhaustive reference from the binary
   (`libs/docgen`); the umbrella vendors those fragments into `docs/gen/<cli>/`,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,8 +62,8 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: 'Slack Setup', link: '/guides/slack-setup' },
-            { text: 'Self-Hosting', link: '/guides/self-hosting' },
             { text: 'Teams Setup', link: '/guides/teams-setup' },
+            { text: 'Discord Setup', link: '/guides/discord-setup' },
             { text: 'AI Assistant (MCP)', link: '/guides/mcp-setup' },
             { text: 'Lifecycle Notifications', link: '/guides/notifications' },
           ]
@@ -86,6 +86,7 @@ export default defineConfig({
           text: 'Self-Hosting',
           collapsed: true,
           items: [
+            { text: 'Overview', link: '/guides/self-hosting' },
             { text: 'Self-Hosting spore-bot', link: '/spore-bot-self-hosting' },
           ]
         },

--- a/docs/guides/pipelines.md
+++ b/docs/guides/pipelines.md
@@ -31,63 +31,84 @@ spawn launch \
 
 ## Automated pipeline definition
 
-Instead of launching stages manually, define the full pipeline in a YAML file and let spore.host manage the handoffs:
+Instead of launching stages by hand, define the whole DAG in a **pipeline definition file** and let a Lambda orchestrator manage the handoffs. `spawn pipeline launch` uploads the definition to S3 and starts the orchestrator, which launches each stage when its dependencies complete.
 
-```yaml
-# pipeline.yaml
-name: ml-pipeline
+The definition is JSON. Stages declare their dependencies with `depends_on`, so the pipeline is a DAG — independent stages run in parallel, dependent ones wait:
 
-stages:
-  - name: prep
-    instance_type: c6i.4xlarge
-    ttl: 4h
-    command: python prepare_data.py --output s3://my-bucket/prepared/
-
-  - name: train
-    instance_type: p4d.24xlarge
-    ttl: 24h
-    spot: true
-    command: python train.py --data s3://my-bucket/prepared/
-
-  - name: eval
-    instance_type: c6i.2xlarge
-    ttl: 2h
-    command: python evaluate.py --model s3://my-bucket/model/
+```json
+{
+  "pipeline_id": "ml-pipeline",
+  "pipeline_name": "Training pipeline",
+  "on_failure": "stop",
+  "stages": [
+    {
+      "stage_id": "prep",
+      "instance_type": "c6i.4xlarge",
+      "command": "python prepare_data.py --output s3://my-bucket/prepared/",
+      "timeout": "4h"
+    },
+    {
+      "stage_id": "train",
+      "instance_type": "p4d.24xlarge",
+      "spot": true,
+      "depends_on": ["prep"],
+      "command": "python train.py --data s3://my-bucket/prepared/",
+      "timeout": "24h"
+    },
+    {
+      "stage_id": "eval",
+      "instance_type": "c6i.2xlarge",
+      "depends_on": ["train"],
+      "command": "python evaluate.py --model s3://my-bucket/model/",
+      "timeout": "2h"
+    }
+  ]
+}
 ```
+
+Preview the DAG before running it, then launch:
 
 ```sh
-spawn pipeline launch pipeline.yaml --slack-workspace T03NE3GTY
+spawn pipeline graph pipeline.json     # ASCII render of the dependency graph
+spawn pipeline launch pipeline.json    # upload + start the orchestrator
+spawn pipeline launch pipeline.json --wait   # block until the pipeline finishes
 ```
 
-Each stage launches automatically when the previous one completes. You'll get a Slack notification at each stage transition.
+Each stage launches automatically once every stage in its `depends_on` list has succeeded. Set `"on_failure": "continue"` at the top level to keep running independent branches when one stage fails (the default, `"stop"`, halts the pipeline).
 
 ## Passing data between stages
 
-Stages communicate through shared storage — S3 is the most common approach, but any storage accessible from EC2 works (EFS, FSx for Lustre, etc.):
+Stages hand data off through S3. Give a stage a `data_output` block to publish its results, and a downstream stage a `data_input` block naming the source stage — the orchestrator wires the S3 locations so the consumer downloads them before its command runs:
 
-```sh
-# Mount shared EFS across all stages
-spawn pipeline \
-  --file pipeline.yaml \
-  --efs-id fs-0abc123 \
-  --efs-mount /shared
+```json
+{
+  "stage_id": "prep",
+  "instance_type": "c6i.4xlarge",
+  "command": "python prepare_data.py --output /mnt/out/",
+  "data_output": { "mode": "s3", "paths": ["/mnt/out/"] }
+},
+{
+  "stage_id": "train",
+  "instance_type": "p4d.24xlarge",
+  "depends_on": ["prep"],
+  "data_input": { "mode": "s3", "source_stage": "prep", "dest_path": "/mnt/data" },
+  "command": "python train.py --data /mnt/data"
+}
 ```
 
-All pipeline instances mount the EFS filesystem, so output from stage 1 at `/shared/prepared/` is immediately available to stage 2.
+For tightly-coupled stages that stream rather than stage through S3, use `"mode": "stream"` with a `protocol` (`tcp`, `grpc`, or `zmq`) and `port`; the orchestrator discovers peer addresses across stages.
 
 ## Error handling
 
-If a stage fails (exits with non-zero), the pipeline stops and you receive a notification. Check the stage log from Slack: `/spore status pipeline-train`
-
-To resume from a failed stage:
-
-```sh
-spawn pipeline launch pipeline.yaml
-```
+If a stage exits non-zero the pipeline stops (unless `on_failure` is `continue`). Fix the cause and re-launch — re-running `spawn pipeline launch` starts a fresh run of the definition.
 
 ## Monitoring
 
+`status`, `cancel`, and `collect` take the **pipeline id** (the `pipeline_id` from the definition); `graph` takes the definition **file**:
+
 ```sh
-spawn pipeline status ml-pipeline    # current stage, elapsed time, cost
-spawn pipeline cancel ml-pipeline    # stop current stage and all remaining
+spawn pipeline list                    # all pipelines and their state
+spawn pipeline status ml-pipeline      # current stage, elapsed time, cost
+spawn pipeline collect ml-pipeline     # download results (--stage to pick one)
+spawn pipeline cancel ml-pipeline      # stop the current stage and all remaining
 ```

--- a/docs/tools/lagotto.md
+++ b/docs/tools/lagotto.md
@@ -40,8 +40,13 @@ lagotto watch "g5.xlarge" --action spawn \
 # Watch for Spot capacity under a price ceiling
 lagotto watch "p4d.24xlarge" --spot --max-price 10.00
 
-# Watch for SageMaker ml.* capacity (EC2-family proxy — see below)
+# Watch for SageMaker ml.* capacity and submit your training job when it appears
 lagotto watch "ml.g5.2xlarge" --service sagemaker \
+  --sagemaker-config train-job.json \
+  --notify email:you@example.com
+
+# …or only be notified, and submit the job yourself
+lagotto watch "ml.g5.2xlarge" --service sagemaker --action notify \
   --notify email:you@example.com
 ```
 
@@ -54,11 +59,18 @@ quota is sufficient. AWS exposes **no** read-only SageMaker capacity API, so
 SageMaker `ml.g5` capacity is likely available — but SageMaker is a separate
 managed pool, so it is not a guarantee.
 
-Because Lagotto cannot submit your SageMaker job for you, SageMaker watches are
-**notify-only** (`--action spawn`/`hold` are rejected). When the proxy fires, the
-notification tells you it's worth **retrying your SageMaker job** — and to leave
-the watch running and retry again on the next notification if the job still hits
-`CapacityError`.
+When the proxy fires, lagotto can **submit your SageMaker job for you**: pass the
+job definition with `--sagemaker-config <file.json>` (the `CreateTrainingJobInput`
+document, validated server-side at submit). lagotto submits it, then polls the
+job — a `Completed`/running job records a match, a `CapacityError` leaves the
+watch active to retry on the next cycle. This makes a capacity-blocked SageMaker
+job fire-and-forget.
+
+If you'd rather submit the job yourself, use `--action notify` (no
+`--sagemaker-config`): the notification tells you it's worth retrying, and the
+watch keeps running so you're alerted again if the job still hits `CapacityError`.
+`--action hold` is rejected for SageMaker — there is no capacity-reservation
+equivalent.
 
 ### `lagotto list`
 
@@ -139,7 +151,10 @@ When a watch matches, Lagotto can:
 | `spawn` | Launches an instance using the config file given in `--spawn-config` |
 | `hold` | Creates a short-lived On-Demand Capacity Reservation to hold the capacity |
 
-SageMaker watches (`--service sagemaker`) support `notify` only.
+SageMaker watches (`--service sagemaker`) support `notify` (alert only) or `spawn`
+— for SageMaker, `spawn` **submits your training job** via
+`--sagemaker-config` rather than launching an EC2 instance. `hold` is not
+supported (no capacity-reservation equivalent).
 
 ## Watch lifecycle
 

--- a/docs/tools/truffle.md
+++ b/docs/tools/truffle.md
@@ -8,6 +8,10 @@ Truffle finds and compares EC2 instance types. It's read-only — it never launc
 brew install spore-host/tap/truffle
 ```
 
+## AWS profile & account
+
+Like the rest of the suite, truffle honors the shared spore.host config: a global `--profile` (and `--account` guard), the `SPORE_PROFILE`/`AWS_PROFILE` env vars, and the `[spore]` table of `~/.config/spore/config.toml`, resolved **flag > env > file > default**. An unset profile uses the ambient AWS credential chain. Region is per-request via `--regions`/`--region`. See [AWS Authentication](/guides/aws-auth) for the full model, and the [command reference](/tools/reference/truffle#global-flags) for every global flag.
+
 ## Sub-commands
 
 Truffle has distinct sub-commands for different tasks. They are **not interchangeable** — flags available on one command may not exist on another.


### PR DESCRIPTION
Tier-3 correctness prose (traced against the live CLIs):

- **pipelines.md** — rewrote the automated section against the real `spawn pipeline` command: **JSON** definition file, DAG via `depends_on`, S3 handoff via `data_input`/`data_output`, and correct `status`/`cancel`/`collect` (pipeline id) vs `graph` (file). Removed the fictional YAML schema and `--slack-workspace`/`--efs-id`/`--efs-mount`/`spawn pipeline --file` flags.
- **tools/lagotto.md** — rewrote the stale SageMaker section: `--service sagemaker` now **submits your training job** via `--sagemaker-config` when the EC2-family proxy fires (it was documented as notify-only). Documents `notify` vs `spawn` and the `hold` rejection.
- **Nav hygiene** — wired the orphaned Discord setup guide into the sidebar; consolidated the two "Self-Hosting" entries into one group.
- **tools/truffle.md** — documents the shared `--profile`/`--account` config and links the auth guide.

`npm run build` clean.