### PR TITLE
Docs Tier 3: coverage prose (managing-instances, plugin.yaml ref, SSH FAQ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Fixed
+- **Docs: corrected the SSH/connectivity FAQ** — `spawn connect` logs you in as
+  your own username (the instance matches your local user) and reuses your
+  `~/.ssh/id_ed25519`/`id_rsa` key when present; added SSM/private-subnet and
+  common-failure troubleshooting. Replaces the stale `ec2-user`/`spawn-default`
+  and `--key-name` guidance.
 - **Docs: corrected the Pipelines guide** — `spawn pipeline launch` takes a JSON
   definition file (not the fictional YAML + `--slack-workspace`/`--efs-id`
   flags), stages form a DAG via `depends_on`, and data is handed off with
@@ -27,6 +32,13 @@ own changelogs for CLI releases.
   and de-duplicated the two "Self-Hosting" entries into one group.
 
 ### Added
+- **Docs: new "Managing Instances & Data" guide** covering the operational spawn
+  commands that had no prose — `stage` (cross-region S3 staging), `snapshot` +
+  `launch --attach-volume` (large reference data as an EBS volume),
+  `upgrade-spored`, and `resources`/`orphans` (inventory + cost hygiene).
+- **Docs: complete `plugin.yaml` field reference** in the Plugins guide (top-level,
+  config params, conditions, local/remote phases, step fields, outputs) derived
+  from the loader schema.
 - **Docs: truffle overview now documents the shared `--profile`/`--account`
   config** and links the AWS auth guide.
 - **Docs: the CLI command/flag reference is now generated + drift-gated.** Each

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,7 @@ export default defineConfig({
             { text: 'GPU Training Jobs', link: '/guides/gpu-training' },
             { text: 'Jupyter Notebooks', link: '/guides/jupyter' },
             { text: 'Spot Instances', link: '/guides/spot-instances' },
+            { text: 'Managing Instances & Data', link: '/guides/managing-instances' },
           ]
         },
         {

--- a/docs/guides/managing-instances.md
+++ b/docs/guides/managing-instances.md
@@ -1,0 +1,93 @@
+# Managing instances & data
+
+Beyond launching and connecting, spawn has a set of operational commands for
+moving large data onto instances, keeping the `spored` agent current, and finding
+what's running (or lingering) in your account. This guide covers those; every flag
+is in the [spawn command reference](/tools/reference/spawn).
+
+## Staging data across regions
+
+Downloading the same dataset into every instance of a multi-region sweep pays the
+cross-region transfer rate ($0.09/GB) over and over. `spawn stage` replicates the
+data **once** into a regional S3 bucket per region, so each instance downloads from
+its own region for free.
+
+```sh
+spawn stage estimate ./reference-db --regions us-east-1,us-west-2  # what you'd save
+spawn stage upload ./reference-db --regions us-east-1,us-west-2 \
+  --dest /mnt/data/reference-db
+spawn stage list                 # what's staged, where
+spawn stage delete <id>          # remove staged data when the sweep is done
+```
+
+Staged data lands at `--dest` on each instance (default `/mnt/data/<filename>`).
+Associate an upload with a sweep via `--sweep-id` to track it alongside the run.
+
+## Large reference data as an attached volume
+
+For read-only reference data that's too big to bake into an AMI — a Kraken2 DB, a
+BLAST index, ML weights — build an **EBS snapshot** once and attach it at launch,
+instead of re-downloading it on every instance.
+
+```sh
+# Build a snapshot from a directory, tarball, or raw image (no instance launched)
+spawn snapshot create --from ./kraken2-db --size 200 \
+  --name kraken2-standard --description "Kraken2 standard DB"
+
+# Attach it read-only at launch (repeatable; :ro is the common case)
+spawn launch bio-run --attach-volume snap-0abc123:/mnt/kraken2:ro
+```
+
+`spawn snapshot create` accepts a local path or `s3://…` source and can encrypt
+with a `--kms-key`. Inside a running instance, `spawn snapshot mount` creates and
+mounts a volume from a snapshot on the spot. Because the data lives on a snapshot,
+many instances can attach the same reference set without duplicating it into
+custom AMIs.
+
+## Keeping spored current
+
+`spored` is the in-instance lifecycle agent that enforces the TTL and runs the
+completion/idle/pre-stop hooks. To move a long-running instance onto a newer agent
+**without** terminating it — and without losing its lifecycle state (the TTL
+deadline, accumulated compute-seconds, and hook config all live in EC2 tags the new
+agent re-reads) — use `upgrade-spored`:
+
+```sh
+spawn upgrade-spored <instance-id>              # to the latest release
+spawn upgrade-spored <instance-id> --version 0.75.0
+```
+
+The swap is driven over SSM. A downgrade is refused unless you pass `--force`.
+
+## Seeing what's running — and what's orphaned
+
+spawn tags every resource it creates with `spawn:managed=true`, so it can inventory
+them via the Resource Groups Tagging API:
+
+```sh
+spawn resources                  # everything spore.host created (yours) in the region
+spawn resources --all-regions    # across every enabled region
+spawn resources --all            # include resources other principals created
+```
+
+`spawn orphans` narrows that to resources that look **abandoned** — and are still
+billing:
+
+- EBS volumes in the `available` state (detached)
+- security groups attached to no instance
+- Elastic IPs that are unassociated or attached to a stopped instance (an EIP bills
+  even while the instance is stopped)
+- the shared key pair / IAM role when no instances remain
+
+```sh
+spawn orphans                    # your orphaned resources in this region
+spawn orphans --all-regions
+```
+
+Run `spawn orphans` after a batch of work to catch anything the lifecycle reaper
+didn't — leftover volumes and unassociated EIPs are the usual small, silent costs.
+
+::: tip Cost hygiene
+Instances always carry a TTL and terminate themselves, but volumes, EIPs, and
+security groups can outlive them. `spawn orphans` is the fast way to find those.
+:::

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -119,6 +119,67 @@ braces) are substituted at run time. See
 for the full spec, including controller-side `local` steps and the `push` API for
 moving captured values to the instance.
 
+### `plugin.yaml` field reference
+
+**Top level:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Plugin id, kebab-case; must match the directory name. |
+| `version` | string | SemVer (e.g. `v1.0.0`). |
+| `description` | string | One-line summary. |
+| `config` | map | User-supplied parameters, keyed by name (see below). |
+| `conditions` | block | `local` / `remote` lists of preconditions checked before running. |
+| `local` | block | Steps that run on **your machine** (the controller). |
+| `remote` | block | Steps that run on **the instance**. |
+| `outputs` | map | Values surfaced after provisioning, keyed by name. |
+
+**`config.<name>` (a parameter):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | `string`, `int`, or `bool`. |
+| `required` | bool | Fail if the user didn't supply it. |
+| `default` | any | Value used when unset. |
+| `description` | string | Shown in help/validation. |
+
+**`conditions.local[]` / `conditions.remote[]`:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | `command` (a probe command must succeed) or `platform`. |
+| `run` | string | Command to run for `type: command`. |
+| `os` | string | Required OS for `type: platform` (e.g. `linux`). |
+| `message` | string | Shown when the condition fails. |
+
+**`remote` phases:** `install`, `configure`, `start`, `stop`, each a list of
+[steps](#step-fields); plus `health` (`interval` + `steps`) for the recurring
+health-check loop.
+
+**`local` block:** `provision`, `deprovision`, and `reconcile` (re-run when the
+instance's IP changes after a stop/start) step lists, plus `env_passthrough` — the
+allowlist of controller env vars a local step may read. Local steps otherwise run
+with a minimal environment (`PATH`+`HOME` only) so plugin scripts can't scoop up
+your AWS/other credentials; a plugin that needs a controller-side secret (e.g.
+Tailscale's `TS_API_CLIENT_SECRET`) lists it here and spawn injects only those.
+
+#### Step fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | `run`, `fetch`, `extract`, or `push`. |
+| `run` | string | Shell command (`type: run`). |
+| `url` / `dest` | string | Download source / destination (`type: fetch`). |
+| `src` / `dest` | string | Archive path / target dir (`type: extract`). |
+| `key` / `value` | string | Value to push to the instance (`type: push`). |
+| `background` | bool | Run without waiting (e.g. a long-lived server). |
+| `capture` | map | `varname` → JMESPath into the step's stdout JSON, for later template use. |
+| `env` | map | Extra environment for this step. |
+| `as_user` | bool | Run a remote `run` step as the instance's login user, not root (for tools that refuse root, e.g. Globus Connect Personal). |
+
+**`outputs.<name>.source`** is `local_capture` (captured by a `local` step) or
+`pushed` (delivered via the push API).
+
 ### Validate before you ship
 
 Lint a spec offline (no instance, no AWS) with `spawn plugin validate`:

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -74,22 +74,43 @@ Spored receives the two-minute warning via the EC2 metadata service. It runs you
 ### How do I connect?
 
 ```sh
-spawn connect my-instance   # prints the SSH command
+spawn connect my-instance   # finds your key and connects; falls back to SSM
 ```
 
-Or directly: `ssh ec2-user@<public-ip>`
+`spawn connect` logs you in as **your own username** — the instance creates a
+Linux user matching your local login name and installs your SSH public key into
+its `authorized_keys`, so you connect as you (not a generic `ec2-user`). It finds
+your key automatically; if SSH isn't reachable it falls back to AWS Session
+Manager. Aliased as `spawn ssh`.
 
-### How do I find the key?
+### Which SSH key does spawn use?
 
-Spawn creates a key pair named `spawn-default` on first use and saves the private key to `~/.spawn/keys/spawn-default.pem`. Use it with `-i ~/.spawn/keys/spawn-default.pem` if needed.
+If you have a default key — `~/.ssh/id_ed25519` (or `~/.ssh/id_rsa`) — spawn
+imports **that** public key, so you connect with the key you already use. Only if
+you have no default key does it generate and use a managed key under
+`~/.spawn/keys/`. Point `spawn connect` at a specific key with `--key <path>`.
 
 ### Why does SSH fail right after launch?
 
-The instance takes 30–90 seconds to boot and start sshd. Wait and retry.
+The instance takes 30–90 seconds to boot and start sshd. Wait and retry, or use
+`spawn connect` which handles the retry (and falls back to SSM).
 
-### Can I use my existing SSH key?
+### `spawn connect` can't reach the instance — what now?
 
-Yes: `spawn launch --key-name my-existing-keypair`
+- **No public IP / private subnet:** use SSM instead —
+  `spawn connect my-instance --session-manager` (no inbound SSH needed).
+- **Security group:** if you're connecting over SSH, port 22 must allow your IP.
+  spawn opens it for you at launch; a later network change can break it.
+- **Wrong user or key:** override with `--user <name>` / `--key <path>`. By
+  default the user is your local username and the key is your default/managed key.
+- **Instance stopped:** `spawn connect` auto-starts a stopped/hibernated instance
+  unless you pass `--no-start`.
+
+### Can I use my own EC2 key pair?
+
+Yes — `spawn launch --key-name my-existing-keypair` uses an existing EC2 key pair
+by name. Most users don't need this: spawn imports your local `~/.ssh` public key
+automatically (see above).
 
 ---
 


### PR DESCRIPTION
Fills the Tier-3 coverage gaps — features the generated reference lists but no prose explained, traced against the live CLIs.

- **New `guides/managing-instances.md`** — the operational spawn commands with zero prose before: `stage` (cross-region S3 staging), `snapshot` + `launch --attach-volume` (large reference data as an EBS volume), `upgrade-spored`, `resources`/`orphans` (inventory + cost hygiene). Wired into the Compute nav.
- **Complete `plugin.yaml` field reference** in `guides/plugins.md`, from the loader schema (`spec.go`): top-level, config params, conditions, local/remote phases, step fields, outputs.
- **Rewrote the SSH/connectivity FAQ** — log-in-as-you (local-user match + your key in authorized_keys), `~/.ssh` default-key reuse, SSM/private-subnet + common-failure troubleshooting. Replaces stale `ec2-user`/`spawn-default`/`--key-name` answers.

`npm run build` clean.

(The rstudio-server plugin README lands in the spore-plugins repo separately.)