### PR TITLE
Docs Tier 3: --min-viable + spawn alerts coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Added
+- **Docs: job arrays now document `--min-viable`** (spot partial-success floor)
+  and parameter sweeps document `spawn alerts` (completion/failure/cost-threshold
+  notifications via email/Slack/SNS/webhook) — both features the reference listed
+  but no guide explained.
+
 ### Fixed
 - **Docs: corrected the SSH/connectivity FAQ** — `spawn connect` logs you in as
   your own username (the instance matches your local user) and reuses your

--- a/docs/guides/job-arrays.md
+++ b/docs/guides/job-arrays.md
@@ -39,6 +39,25 @@ spawn extend --job-array-name data-proc 2h   # extend all at once
 spawn terminate --job-array-name data-proc   # permanently terminate the whole array
 ```
 
+## Partial success (`--min-viable`)
+
+Spot capacity can be uneven — you ask for 8 instances but only 6 land. By default
+a job array succeeds if **at least one** member launches. Set a floor with
+`--min-viable`:
+
+```sh
+spawn launch --name data-proc --count 8 --min-viable 6 \
+  --job-array-name data-proc --spot \
+  --command "python process.py --shard {index} --total {total}"
+```
+
+If fewer than `--min-viable` members launch, the array is treated as failed and
+the launched instances are cleaned up, so you don't pay for a run that can't
+complete. Because the members that *did* launch are cleaned up on failure, size
+`--min-viable` to the smallest count your job can actually finish with. It
+defaults to `1` and is ignored for `--mpi` clusters (which need all ranks — see
+the [MPI guide](/guides/mpi)).
+
 ## Available template variables and environment variables
 
 Inside `--command`, you can use template substitutions:

--- a/docs/guides/parameter-sweeps.md
+++ b/docs/guides/parameter-sweeps.md
@@ -67,6 +67,26 @@ spawn sweep cancel <sweep-id>         # terminate all remaining instances
 
 With Slack connected, you'll get a DM when the sweep finishes (all instances have terminated).
 
+## Alerts on completion, failure, or cost
+
+For explicit, per-sweep notifications — beyond the default Slack DM — attach an
+**alert** to a sweep with `spawn alerts`. Alerts can fire on completion, on
+failure, or when the sweep's running cost crosses a threshold, and deliver via
+email, Slack, SNS, or a webhook:
+
+```sh
+spawn alerts create <sweep-id> --on-complete --email me@example.com
+spawn alerts create <sweep-id> --on-failure  --slack https://hooks.slack.com/services/...
+spawn alerts create <sweep-id> --cost-threshold 100 --email me@example.com
+
+spawn alerts list                 # all alerts
+spawn alerts history              # what has fired
+spawn alerts delete <alert-id>
+```
+
+The cost-threshold alert is the cheap insurance for a large sweep: get pinged the
+moment spend crosses your ceiling, then `spawn sweep cancel` if it's running away.
+
 ## Collecting results
 
 Each instance writes its results to a path you control — typically S3. The convention is to include the sweep index or parameters in the path:


### PR DESCRIPTION
Two more reference-listed-but-unexplained features:
- **job-arrays.md** — a 'Partial success' section for `--min-viable` (the spot capacity floor; launched members are cleaned up on shortfall; ignored for `--mpi`).
- **parameter-sweeps.md** — an 'Alerts' section for `spawn alerts create/list/history/delete` (on-complete / on-failure / cost-threshold via email/Slack/SNS/webhook).

`npm run build` clean.