### PR TITLE
fix(ci): sync-cli-docs duplicate Authorization header

### DIFF
--- a/.github/workflows/sync-cli-docs.yaml
+++ b/.github/workflows/sync-cli-docs.yaml
@@ -32,6 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # Don't leave the checkout token as a git auth extraheader:
+          # create-pull-request adds its own Authorization header, and git then
+          # rejects the request with `Duplicate header: "Authorization"` (HTTP 400).
+          persist-credentials: false
 
       - name: Determine which CLIs to sync
         id: which


### PR DESCRIPTION
The first real `cli-docs-updated` dispatches (after the v0.78.0/v0.45.0/v0.50.0 releases) reached the umbrella and vendored the docs fine, but the **Open sync PR** step failed: `remote: Duplicate header: "Authorization"` (HTTP 400).

Cause: `actions/checkout` persists the workflow token as a git `http.extraheader` Authorization; `peter-evans/create-pull-request` then adds its own Authorization header. `persist-credentials: false` on the checkout lets the PR action own auth (the documented fix).