### PR TITLE
Docs AIRA compliance: a11y contrast + AI-readiness (llms.txt, sitemap, descriptions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **Docs AI-readiness: `llms.txt` manifest** (#424) — a curated
+  [llmstxt.org](https://llmstxt.org) entry map, generated at build time from the
+  sidebar (a `buildEnd` hook) so it can't drift from the nav.
+- **Docs discoverability: `sitemap.xml`, per-page descriptions, OpenGraph** (#425)
+  — set the VitePress `sitemap.hostname` (`docs.spore.host`); added a
+  `description:` to ~40 content pages (→ real `<meta name="description">` and
+  better AI/search snippets); added default OG/Twitter card `head` tags.
+
+### Fixed
+- **Docs accessibility: WCAG AA contrast** (#423) — tool badges are small
+  (0.7rem) bold text, so they need 4.5:1: several failed in light and/or dark
+  mode. Badge text now uses per-mode colors that all clear 4.5:1, and dark-mode
+  link text uses a lightened brand blue (the `#4059E5` override dropped to 3.09:1
+  on the dark background); the hero brand button keeps its solid blue + white.
+
 - **Docs: job arrays now document `--min-viable`** (spot partial-success floor)
   and parameter sweeps document `spawn alerts` (completion/failure/cost-threshold
   notifications via email/Slack/SNS/webhook) — both features the reference listed

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,9 +1,160 @@
 import { defineConfig } from 'vitepress'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SITE_URL = 'https://docs.spore.host'
+
+// Sidebar is a top-level const so the llms.txt generator (buildEnd, below) can
+// walk the exact same structure the site renders — the manifest can't drift from
+// the nav.
+const sidebar = {
+  '/': [
+    { text: 'Quick Start', link: '/quickstart' },
+    { text: 'How It Works', link: '/how-it-works' },
+  ],
+  '/guides/': [
+    {
+      text: 'Getting Started',
+      collapsed: false,
+      items: [
+        { text: 'Installation', link: '/guides/installation' },
+        { text: 'AWS Authentication', link: '/guides/aws-auth' },
+        { text: 'Your First Instance', link: '/guides/first-instance' },
+        { text: 'Python SDK', link: '/guides/python-sdk' },
+        { text: 'Go Library', link: '/guides/go-library' },
+      ]
+    },
+    {
+      text: 'Compute',
+      collapsed: false,
+      items: [
+        { text: 'Finding the Right Instance', link: '/guides/finding-instances' },
+        { text: 'GPU Training Jobs', link: '/guides/gpu-training' },
+        { text: 'Jupyter Notebooks', link: '/guides/jupyter' },
+        { text: 'Spot Instances', link: '/guides/spot-instances' },
+        { text: 'Managing Instances & Data', link: '/guides/managing-instances' },
+      ]
+    },
+    {
+      text: 'Automation & Control',
+      collapsed: false,
+      items: [
+        { text: 'Slack Setup', link: '/guides/slack-setup' },
+        { text: 'Teams Setup', link: '/guides/teams-setup' },
+        { text: 'Discord Setup', link: '/guides/discord-setup' },
+        { text: 'AI Assistant (MCP)', link: '/guides/mcp-setup' },
+        { text: 'Lifecycle Notifications', link: '/guides/notifications' },
+      ]
+    },
+    {
+      text: 'Advanced',
+      collapsed: false,
+      items: [
+        { text: 'Parameter Sweeps', link: '/guides/parameter-sweeps' },
+        { text: 'Job Arrays', link: '/guides/job-arrays' },
+        { text: 'Batch Queues', link: '/guides/batch-queue' },
+        { text: 'MPI Clusters', link: '/guides/mpi' },
+        { text: 'Pipelines', link: '/guides/pipelines' },
+        { text: 'Plugins', link: '/guides/plugins' },
+        { text: 'Workflow Engines', link: '/guides/workflow-engines' },
+        { text: 'Nextflow (nf-spawn)', link: '/guides/nextflow' },
+      ]
+    },
+    {
+      text: 'Self-Hosting',
+      collapsed: true,
+      items: [
+        { text: 'Overview', link: '/guides/self-hosting' },
+        { text: 'Self-Hosting spore-bot', link: '/spore-bot-self-hosting' },
+      ]
+    },
+  ],
+  '/tools/': [
+    {
+      text: 'Tools',
+      items: [
+        { text: 'Overview', link: '/tools/' },
+        { text: 'Truffle', link: '/tools/truffle' },
+        { text: 'Spawn', link: '/tools/spawn' },
+        { text: 'Spored', link: '/tools/spored' },
+        { text: 'Lagotto', link: '/tools/lagotto' },
+        { text: 'Spore-bot', link: '/tools/spore-bot' },
+        { text: 'MCP Server', link: '/tools/mcp-server' },
+      ]
+    },
+    {
+      text: 'Command Reference',
+      items: [
+        { text: 'truffle', link: '/tools/reference/truffle' },
+        { text: 'spawn', link: '/tools/reference/spawn' },
+        { text: 'lagotto', link: '/tools/reference/lagotto' },
+      ]
+    },
+  ],
+  '/reference/': [
+    {
+      text: 'Reference',
+      items: [
+        { text: 'Configuration', link: '/reference/configuration' },
+        { text: 'EC2 Tags', link: '/reference/ec2-tags' },
+        { text: 'IAM Permissions', link: '/reference/iam-permissions' },
+        { text: 'Lifecycle Events', link: '/reference/lifecycle-events' },
+        { text: 'Environment Variables', link: '/reference/environment-variables' },
+        { text: 'FAQ', link: '/reference/faq' },
+        { text: 'Cheat Sheet', link: '/reference/cheatsheet' },
+      ]
+    },
+  ],
+}
+
+// Build an llms.txt manifest (https://llmstxt.org) from the sidebar so AI
+// assistants get a curated, always-current map of the docs. Written to the build
+// output dir at build time; regenerated on every build, so it can't go stale.
+function writeLlmsTxt(outDir: string) {
+  const lines: string[] = []
+  lines.push('# spore.host documentation')
+  lines.push('')
+  lines.push('> Ephemeral compute for researchers and data scientists: find the right EC2 instance (truffle), launch and manage it (spawn), and watch for capacity (lagotto). Instances self-terminate via TTL and idle detection.')
+  lines.push('')
+  const sections: Array<[string, any[]]> = [
+    ['Start here', sidebar['/']],
+    ['Guides', sidebar['/guides/']],
+    ['Tools & command reference', sidebar['/tools/']],
+    ['Reference', sidebar['/reference/']],
+  ]
+  const link = (item: any) =>
+    item.link && item.link.startsWith('/')
+      ? `- [${item.text}](${SITE_URL}${item.link})`
+      : null
+  for (const [heading, groups] of sections) {
+    lines.push(`## ${heading}`)
+    lines.push('')
+    for (const entry of groups) {
+      if (entry.items) {
+        for (const item of entry.items) {
+          const l = link(item)
+          if (l) lines.push(l)
+        }
+      } else {
+        const l = link(entry)
+        if (l) lines.push(l)
+      }
+    }
+    lines.push('')
+  }
+  fs.writeFileSync(path.join(outDir, 'llms.txt'), lines.join('\n'))
+}
 
 export default defineConfig({
   title: 'spore.host',
   description: 'Ephemeral compute for researchers and data scientists.',
   lang: 'en-US',
+
+  // Emit sitemap.xml for search + AI indexers (VitePress only generates it when
+  // a hostname is set). docs.spore.host is the CloudFront-fronted docs domain.
+  sitemap: {
+    hostname: 'https://docs.spore.host',
+  },
 
   srcExclude: [
     'research/**',
@@ -16,6 +167,14 @@ export default defineConfig({
     ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
     ['link', { href: 'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=Atkinson+Hyperlegible+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap', rel: 'stylesheet' }],
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
+    // Default OpenGraph/Twitter card metadata (per-page title/description still
+    // override via frontmatter). Helps link unfurls and AI/social indexers.
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:site_name', content: 'spore.host docs' }],
+    ['meta', { property: 'og:title', content: 'spore.host documentation' }],
+    ['meta', { property: 'og:description', content: 'Ephemeral compute for researchers and data scientists.' }],
+    ['meta', { property: 'og:url', content: 'https://docs.spore.host/' }],
+    ['meta', { name: 'twitter:card', content: 'summary' }],
   ],
 
   themeConfig: {
@@ -30,105 +189,7 @@ export default defineConfig({
       { text: 'spore.host', link: 'https://spore.host', target: '_blank' },
     ],
 
-    sidebar: {
-      '/': [
-        { text: 'Quick Start', link: '/quickstart' },
-        { text: 'How It Works', link: '/how-it-works' },
-      ],
-      '/guides/': [
-        {
-          text: 'Getting Started',
-          collapsed: false,
-          items: [
-            { text: 'Installation', link: '/guides/installation' },
-            { text: 'AWS Authentication', link: '/guides/aws-auth' },
-            { text: 'Your First Instance', link: '/guides/first-instance' },
-            { text: 'Python SDK', link: '/guides/python-sdk' },
-            { text: 'Go Library', link: '/guides/go-library' },
-          ]
-        },
-        {
-          text: 'Compute',
-          collapsed: false,
-          items: [
-            { text: 'Finding the Right Instance', link: '/guides/finding-instances' },
-            { text: 'GPU Training Jobs', link: '/guides/gpu-training' },
-            { text: 'Jupyter Notebooks', link: '/guides/jupyter' },
-            { text: 'Spot Instances', link: '/guides/spot-instances' },
-            { text: 'Managing Instances & Data', link: '/guides/managing-instances' },
-          ]
-        },
-        {
-          text: 'Automation & Control',
-          collapsed: false,
-          items: [
-            { text: 'Slack Setup', link: '/guides/slack-setup' },
-            { text: 'Teams Setup', link: '/guides/teams-setup' },
-            { text: 'Discord Setup', link: '/guides/discord-setup' },
-            { text: 'AI Assistant (MCP)', link: '/guides/mcp-setup' },
-            { text: 'Lifecycle Notifications', link: '/guides/notifications' },
-          ]
-        },
-        {
-          text: 'Advanced',
-          collapsed: false,
-          items: [
-            { text: 'Parameter Sweeps', link: '/guides/parameter-sweeps' },
-            { text: 'Job Arrays', link: '/guides/job-arrays' },
-            { text: 'Batch Queues', link: '/guides/batch-queue' },
-            { text: 'MPI Clusters', link: '/guides/mpi' },
-            { text: 'Pipelines', link: '/guides/pipelines' },
-            { text: 'Plugins', link: '/guides/plugins' },
-            { text: 'Workflow Engines', link: '/guides/workflow-engines' },
-            { text: 'Nextflow (nf-spawn)', link: '/guides/nextflow' },
-          ]
-        },
-        {
-          text: 'Self-Hosting',
-          collapsed: true,
-          items: [
-            { text: 'Overview', link: '/guides/self-hosting' },
-            { text: 'Self-Hosting spore-bot', link: '/spore-bot-self-hosting' },
-          ]
-        },
-      ],
-      '/tools/': [
-        {
-          text: 'Tools',
-          items: [
-            { text: 'Overview', link: '/tools/' },
-            { text: 'Truffle', link: '/tools/truffle' },
-            { text: 'Spawn', link: '/tools/spawn' },
-            { text: 'Spored', link: '/tools/spored' },
-            { text: 'Lagotto', link: '/tools/lagotto' },
-            { text: 'Spore-bot', link: '/tools/spore-bot' },
-            { text: 'MCP Server', link: '/tools/mcp-server' },
-          ]
-        },
-        {
-          text: 'Command Reference',
-          items: [
-            { text: 'truffle', link: '/tools/reference/truffle' },
-            { text: 'spawn', link: '/tools/reference/spawn' },
-            { text: 'lagotto', link: '/tools/reference/lagotto' },
-          ]
-        },
-      ],
-      '/reference/': [
-        {
-          text: 'Reference',
-          items: [
-            { text: 'Configuration', link: '/reference/configuration' },
-            { text: 'EC2 Tags', link: '/reference/ec2-tags' },
-            { text: 'IAM Permissions', link: '/reference/iam-permissions' },
-            { text: 'Lifecycle Events', link: '/reference/lifecycle-events' },
-            { text: 'Environment Variables', link: '/reference/environment-variables' },
-            { text: 'FAQ', link: '/reference/faq' },
-            { text: 'Cheat Sheet', link: '/reference/cheatsheet' },
-          ]
-        },
-      ],
-    },
+    sidebar,
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/spore-host/spore-host' },
@@ -147,5 +208,11 @@ export default defineConfig({
     search: {
       provider: 'local',
     },
+  },
+
+  // Generate llms.txt (AI-assistant manifest) into the build output on every
+  // build, derived from the sidebar above so it can't drift from the nav.
+  buildEnd(siteConfig) {
+    writeLlmsTxt(siteConfig.outDir)
   },
 })

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -16,6 +16,29 @@
   --sp-lagotto: #0891b2;
   --sp-bot:     #7c3aed;
   --sp-mcp:     #4264F5;
+
+  /* Badge TEXT colours — darker than the accent --sp-* so small (0.7rem) bold
+     badge text clears WCAG AA (4.5:1) on the light badge backgrounds. */
+  --sp-badge-truffle: #b45309;
+  --sp-badge-spawn:   #4059E5;
+  --sp-badge-lagotto: #0e7490;
+  --sp-badge-bot:     #7c3aed;
+  --sp-badge-mcp:     #3730a3;
+}
+
+/* Dark mode: the strong brand blue (#4059E5) only reaches 3.09:1 as link text
+   on the dark background — below AA. Lighten brand-1 for links/text in dark mode;
+   the hero brand button keeps its solid blue bg + white text (set explicitly
+   below), so this doesn't wash the button out. */
+.dark {
+  --vp-c-brand-1: #8aa2ff;
+
+  /* Badge text lightened for the dark badge backgrounds (all clear 4.5:1). */
+  --sp-badge-truffle: #d97706;
+  --sp-badge-spawn:   #93b0ff;
+  --sp-badge-lagotto: #0891b2;
+  --sp-badge-bot:     #c4b5fd;
+  --sp-badge-mcp:     #a5b4fc;
 }
 
 /* ── Typography ── */
@@ -37,6 +60,7 @@
 .VPHero .actions .VPButton.brand {
   background: var(--sp-spawn);
   border-color: var(--sp-spawn);
+  color: #fff; /* white on #4059E5 = 5.56:1; independent of dark-mode brand-1 */
 }
 
 /* ── Feature cards on landing ── */
@@ -60,11 +84,11 @@
   padding: 0.15rem 0.45rem; border-radius: 4px;
   vertical-align: middle;
 }
-.tool-badge.truffle { background: #fffbeb; color: var(--sp-truffle); }
-.tool-badge.spawn   { background: #eff6ff; color: var(--sp-spawn);   }
-.tool-badge.lagotto { background: #ecfdf5; color: var(--sp-lagotto); }
-.tool-badge.bot     { background: #f5f3ff; color: var(--sp-bot);     }
-.tool-badge.mcp     { background: #eef2ff; color: var(--sp-mcp);     }
+.tool-badge.truffle { background: #fffbeb; color: var(--sp-badge-truffle); }
+.tool-badge.spawn   { background: #eff6ff; color: var(--sp-badge-spawn);   }
+.tool-badge.lagotto { background: #ecfdf5; color: var(--sp-badge-lagotto); }
+.tool-badge.bot     { background: #f5f3ff; color: var(--sp-badge-bot);     }
+.tool-badge.mcp     { background: #eef2ff; color: var(--sp-badge-mcp);     }
 
 /* Dark mode tool badges */
 .dark .tool-badge.truffle { background: #1a1200; }

--- a/docs/guides/aws-auth.md
+++ b/docs/guides/aws-auth.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host tools (spawn, truffle, lagotto) act on AWS with your own AWS credentials."
+---
+
 # AWS Authentication
 
 spore.host tools (`spawn`, `truffle`, `lagotto`) act on AWS with **your own AWS credentials**. There is no separate spore.host login — if the AWS CLI can reach your account, so can spore.host. This page is the one place that explains how to authenticate, how profiles work, and how your authentication relates to permissions and to what spore.host does on your behalf.

--- a/docs/guides/batch-queue.md
+++ b/docs/guides/batch-queue.md
@@ -1,3 +1,7 @@
+---
+description: "A batch queue runs a sequence of dependent jobs on a single instance, automatically chaining them in order."
+---
+
 # Batch Job Queues
 
 A batch queue runs a sequence of dependent jobs on a single instance, automatically chaining them in order. Unlike [pipelines](/guides/pipelines), which chain stages across separate instances, a batch queue runs all jobs on the same instance — useful when jobs need to share local data or a common environment.

--- a/docs/guides/discord-setup.md
+++ b/docs/guides/discord-setup.md
@@ -1,3 +1,7 @@
+---
+description: "Connecting spore.host to Discord posts instance lifecycle notifications — TTL warnings, idle stops, spot interruptions, completion — to a channel of your cho…"
+---
+
 # Discord Setup
 
 Connecting spore.host to Discord posts instance lifecycle notifications —

--- a/docs/guides/finding-instances.md
+++ b/docs/guides/finding-instances.md
@@ -1,3 +1,7 @@
+---
+description: "This tutorial walks through the complete workflow for discovering and evaluating EC2 instance types before launching — using truffle find, truffle search, tr…"
+---
+
 # Finding the Right Instance
 
 This tutorial walks through the complete workflow for discovering and evaluating EC2 instance types before launching — using `truffle find`, `truffle search`, `truffle spot`, and `truffle quotas` in sequence.

--- a/docs/guides/first-instance.md
+++ b/docs/guides/first-instance.md
@@ -1,3 +1,7 @@
+---
+description: "A complete walkthrough from a fresh install to a running EC2 instance and back."
+---
+
 # Your First Instance
 
 A complete walkthrough from a fresh install to a running EC2 instance and back. Allow 15–20 minutes.

--- a/docs/guides/go-library.md
+++ b/docs/guides/go-library.md
@@ -1,3 +1,7 @@
+---
+description: "The truffle and spawn packages are clean, importable Go libraries."
+---
+
 # Go Library
 
 The truffle and spawn packages are clean, importable Go libraries. Use them in your own tools, services, or orchestration code without calling CLI subprocesses.

--- a/docs/guides/gpu-training.md
+++ b/docs/guides/gpu-training.md
@@ -1,3 +1,7 @@
+---
+description: "This guide walks through the full workflow for running a GPU training job: finding the right instance, launching it with a TTL and idle timeout, running the…"
+---
+
 # GPU Training Jobs
 
 This guide walks through the full workflow for running a GPU training job: finding the right instance, launching it with a TTL and idle timeout, running the job in tmux so it survives your disconnect, and letting the instance manage its own lifecycle.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,3 +1,7 @@
+---
+description: "Task-oriented guides for common workflows."
+---
+
 # Guides
 
 Task-oriented guides for common workflows. If you're new, start with **Getting Started**. If you know what you want to do, jump directly to the relevant guide.

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,3 +1,7 @@
+---
+description: "Verify:"
+---
+
 # Installation
 
 ## Prerequisites

--- a/docs/guides/job-arrays.md
+++ b/docs/guides/job-arrays.md
@@ -1,3 +1,7 @@
+---
+description: "A job array launches a fixed number of identical instances as a named group."
+---
+
 # Job Arrays
 
 A job array launches a fixed number of identical instances as a named group. Unlike [parameter sweeps](/guides/parameter-sweeps), which vary inputs across instances, job arrays run the same workload on every instance — useful for distributed processing, redundant jobs, or fan-out patterns where each instance handles a chunk of work determined by its own index.

--- a/docs/guides/jupyter.md
+++ b/docs/guides/jupyter.md
@@ -1,3 +1,7 @@
+---
+description: "Interactive compute environments like Jupyter and RStudio have a specific challenge with idle detection: the browser tab maintains a TCP connection to the se…"
+---
+
 # Jupyter Notebooks and RStudio
 
 Interactive compute environments like Jupyter and RStudio have a specific challenge with idle detection: the browser tab maintains a TCP connection to the server even when you haven't touched it in hours. Without careful configuration, the instance would never consider itself idle.

--- a/docs/guides/managing-instances.md
+++ b/docs/guides/managing-instances.md
@@ -1,3 +1,7 @@
+---
+description: "Beyond launching and connecting, spawn has a set of operational commands for moving large data onto instances, keeping the spored agent current, and finding…"
+---
+
 # Managing instances & data
 
 Beyond launching and connecting, spawn has a set of operational commands for

--- a/docs/guides/mcp-setup.md
+++ b/docs/guides/mcp-setup.md
@@ -1,3 +1,7 @@
+---
+description: "The spore.host MCP server lets you manage compute through AI assistants that support the Model Context Protocol — including Claude Desktop and Cursor."
+---
+
 # AI Assistant Integration (MCP)
 
 The spore.host MCP server lets you manage compute through AI assistants that support the Model Context Protocol — including Claude Desktop and Cursor. Instead of running CLI commands, you describe what you need in plain language.

--- a/docs/guides/mpi.md
+++ b/docs/guides/mpi.md
@@ -1,3 +1,7 @@
+---
+description: "For workloads that need to communicate across multiple nodes — large-scale simulations, distributed training, or parallel data processing — spore.host can la…"
+---
+
 # MPI Clusters
 
 For workloads that need to communicate across multiple nodes — large-scale simulations, distributed training, or parallel data processing — spore.host can launch a multi-node MPI cluster as a single command.

--- a/docs/guides/nextflow.md
+++ b/docs/guides/nextflow.md
@@ -1,3 +1,7 @@
+---
+description: "nf-spawn is a Nextflow executor plugin that dispatches each pipeline process step to its own ephemeral EC2 instance — purpose-sized and auto-terminated when…"
+---
+
 # Nextflow Integration (nf-spawn)
 
 [nf-spawn](https://github.com/spore-host/nf-spawn) is a Nextflow executor plugin that dispatches each pipeline process step to its own ephemeral EC2 instance — purpose-sized and auto-terminated when the task completes.

--- a/docs/guides/notifications.md
+++ b/docs/guides/notifications.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host sends notifications when significant things happen to your instances — so you don't have to watch a terminal or poll for status."
+---
+
 # Lifecycle Notifications
 
 spore.host sends notifications when significant things happen to your instances — so you don't have to watch a terminal or poll for status. This guide explains how notifications work and how to configure them.

--- a/docs/guides/parameter-sweeps.md
+++ b/docs/guides/parameter-sweeps.md
@@ -1,3 +1,7 @@
+---
+description: "A parameter sweep runs the same job across many combinations of input parameters, each on its own instance, in parallel."
+---
+
 # Parameter Sweeps
 
 A parameter sweep runs the same job across many combinations of input parameters, each on its own instance, in parallel. It's useful for hyperparameter search, sensitivity analysis, and any scenario where you want to explore a parameter space without waiting for jobs to run sequentially.

--- a/docs/guides/pipelines.md
+++ b/docs/guides/pipelines.md
@@ -1,3 +1,7 @@
+---
+description: "A pipeline chains stages together: when one stage completes, it automatically launches the next."
+---
+
 # Pipelines
 
 A pipeline chains stages together: when one stage completes, it automatically launches the next. This is useful for multi-step workflows — data preparation, training, evaluation, post-processing — where each stage has different compute requirements.

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -1,3 +1,7 @@
+---
+description: "Plugins install and manage software on a running instance — connecting to a private network, mounting data transfer tooling, running a dev server."
+---
+
 # Plugins
 
 Plugins install and manage software on a running instance — connecting to a

--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -1,3 +1,7 @@
+---
+description: "The spore-host Python package lets you discover EC2 instances, check Spot prices, and manage running instances from Python scripts, Jupyter notebooks, and re…"
+---
+
 # Python SDK
 
 ::: tip Two SDKs are available

--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -1,3 +1,7 @@
+---
+description: "This guide covers deploying your own spore.host infrastructure — useful for universities, research institutes, or organizations that want to use their own DN…"
+---
+
 # Self-Hosting spore.host
 
 This guide covers deploying your own spore.host infrastructure — useful for universities, research institutes, or organizations that want to use their own DNS domain, keep data within their own AWS account, and operate independently of the hosted spore.host service.

--- a/docs/guides/slack-setup.md
+++ b/docs/guides/slack-setup.md
@@ -1,3 +1,7 @@
+---
+description: "Connecting spore.host to Slack gives you /spore commands in any channel and direct message notifications when your instances change state — useful whenever y…"
+---
+
 # Slack Setup
 
 Connecting spore.host to Slack gives you `/spore` commands in any channel and direct message notifications when your instances change state — useful whenever you're away from the terminal.

--- a/docs/guides/spot-instances.md
+++ b/docs/guides/spot-instances.md
@@ -1,3 +1,7 @@
+---
+description: "EC2 Spot instances run on AWS's spare capacity at 60–90% below on-demand price."
+---
+
 # Spot Instances
 
 EC2 Spot instances run on AWS's spare capacity at 60–90% below on-demand price. In exchange, AWS can reclaim them with two minutes' notice. For batch workloads, training jobs, and anything that can checkpoint progress, Spot is the right default.

--- a/docs/guides/teams-setup.md
+++ b/docs/guides/teams-setup.md
@@ -1,3 +1,7 @@
+---
+description: "Connecting spore.host to Microsoft Teams gives you /spore commands in any channel and direct message notifications when your instances change state — useful…"
+---
+
 # Teams Setup
 
 Connecting spore.host to Microsoft Teams gives you `/spore` commands in any channel and direct message notifications when your instances change state — useful whenever you're away from the terminal.

--- a/docs/guides/workflow-engines.md
+++ b/docs/guides/workflow-engines.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host is a first-class execution backend for five workflow engines."
+---
+
 # Workflow Engines
 
 spore.host is a first-class execution backend for **five workflow engines**. In

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host is a collection of six tools that cover the full lifecycle of ephemeral compute — from finding the right instance to cleaning it up when the work…"
+---
+
 # How It Works
 
 spore.host is a collection of six tools that cover the full lifecycle of ephemeral compute — from finding the right instance to cleaning it up when the work is done. This page explains how they fit together.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,7 @@
+---
+description: "This guide gets you from zero to a running EC2 instance in about five minutes."
+---
+
 # Quick Start
 
 This guide gets you from zero to a running EC2 instance in about five minutes. You'll need an AWS account with credentials configured — everything else is handled for you.

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -1,3 +1,7 @@
+---
+description: "Quick reference for common commands."
+---
+
 # Cheat Sheet
 
 Quick reference for common commands.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host reads configuration from three sources, in order of precedence (highest first):"
+---
+
 # Configuration
 
 spore.host reads configuration from three sources, in order of precedence (highest first):

--- a/docs/reference/ec2-tags.md
+++ b/docs/reference/ec2-tags.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host tags every instance it launches with spawn: tags."
+---
+
 # EC2 Tags
 
 spore.host tags every instance it launches with `spawn:*` tags. These tags drive lifecycle management, filtering, and cost tracking.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host tools read configuration from environment variables and ~/.spawn/config.yaml."
+---
+
 # Environment Variables
 
 spore.host tools read configuration from environment variables and `~/.spawn/config.yaml`. Environment variables take precedence over config file values.

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host is a set of free, open-source tools for launching ephemeral EC2 instances that manage their own lifecycle."
+---
+
 # Frequently Asked Questions
 
 ## General

--- a/docs/reference/iam-permissions.md
+++ b/docs/reference/iam-permissions.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host tools act on EC2 with your AWS credentials (see AWS Authentication for how those are obtained)."
+---
+
 # IAM Permissions
 
 spore.host tools act on EC2 with **your** AWS credentials (see [AWS Authentication](../guides/aws-auth.md) for how those are obtained). This page is the least-privilege IAM policy those credentials need. Attach it to the IAM role/user you authenticate as, and expand only as your usage grows (Spot, DNS, FSx below).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,7 @@
+---
+description: "Reference material for spore.host: configuration, EC2 tags, IAM permissions, lifecycle events, environment variables, FAQ, and a command cheat sheet."
+---
+
 # Reference
 
 | Page | Contents |

--- a/docs/reference/lifecycle-events.md
+++ b/docs/reference/lifecycle-events.md
@@ -1,3 +1,7 @@
+---
+description: "Spored emits lifecycle events when significant things happen to a running instance."
+---
+
 # Lifecycle Events
 
 Spored emits lifecycle events when significant things happen to a running instance. Events are routed through the spore-bot Lambda to Slack DMs or Teams messages.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,3 +1,7 @@
+---
+description: "spore.host is six tools that work together."
+---
+
 # Tools
 
 spore.host is six tools that work together. Each has exactly one job.

--- a/docs/tools/lagotto.md
+++ b/docs/tools/lagotto.md
@@ -1,3 +1,7 @@
+---
+description: "Lagotto watches for EC2 instance capacity and acts when it appears."
+---
+
 # Lagotto
 
 Lagotto watches for EC2 instance capacity and acts when it appears. It runs as a serverless Lambda function — no always-on server required. Configure a watch, deploy, and Lagotto polls on a schedule until it can launch what you asked for.

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -1,3 +1,7 @@
+---
+description: "The spore.host MCP server exposes truffle and spawn as tools for AI assistants that support the Model Context Protocol — including Claude Desktop and Cursor."
+---
+
 # MCP Server
 
 The spore.host MCP server exposes truffle and spawn as tools for AI assistants that support the [Model Context Protocol](https://modelcontextprotocol.io) — including Claude Desktop and Cursor.

--- a/docs/tools/spawn.md
+++ b/docs/tools/spawn.md
@@ -1,3 +1,7 @@
+---
+description: "Spawn launches EC2 instances and manages their full lifecycle."
+---
+
 # Spawn
 
 Spawn launches EC2 instances and manages their full lifecycle. It provisions the spored daemon on each instance, which handles auto-termination, idle detection, DNS, and lifecycle notifications independently of your laptop.

--- a/docs/tools/spore-bot.md
+++ b/docs/tools/spore-bot.md
@@ -1,3 +1,7 @@
+---
+description: "Spore-bot connects your Slack or Microsoft Teams workspace to your running instances."
+---
+
 # Spore-bot
 
 Spore-bot connects your Slack or Microsoft Teams workspace to your running instances. Any team member you've authorised can control instances from chat — without a terminal, without AWS credentials, from any device.

--- a/docs/tools/spored.md
+++ b/docs/tools/spored.md
@@ -1,3 +1,7 @@
+---
+description: "Spored is the lifecycle daemon that runs on every instance launched by spawn."
+---
+
 # Spored
 
 Spored is the lifecycle daemon that runs on every instance launched by spawn. It's a small binary provisioned automatically at launch — you never install it manually. Its job is to enforce the instance's lifecycle: terminate on TTL, stop or hibernate on idle, act when your workload signals completion, and clean up DNS and notifications before the instance disappears.

--- a/docs/tools/truffle.md
+++ b/docs/tools/truffle.md
@@ -1,3 +1,7 @@
+---
+description: "Truffle finds and compares EC2 instance types."
+---
+
 # Truffle
 
 Truffle finds and compares EC2 instance types. It's read-only — it never launches anything. Use it to research what's available before committing to a launch.


### PR DESCRIPTION
Closes #423, #424, #425 — the findings from the AIRA (AI-readiness + accessibility) review.

## Accessibility (WCAG 2.1 AA) — #423
Tool badges are 0.7rem **bold** = small text, so they need **4.5:1**. Measured fails fixed:
- light mode: truffle 3.07, lagotto 3.50, mcp 4.29 → now darker text, all ≥4.8
- dark mode: spawn 3.11, bot 3.26, mcp 3.91 → now lighter text, all ≥8
- dark-mode links (`#4059E5` on `#1b1b1f`): 3.09 → lightened brand-1 to `#8aa2ff` (7.1). Hero brand button pinned to white on solid blue (5.56).

## AI-readiness — #424
- **`llms.txt`** ([llmstxt.org](https://llmstxt.org)) generated at build time from the sidebar via a `buildEnd` hook — always current, can't drift.

## Discoverability — #425
- **`sitemap.xml`** via `sitemap.hostname: docs.spore.host`.
- **`description:` frontmatter** on ~40 content pages → real `<meta name=description>` + better AI/search snippets.
- Default **OpenGraph/Twitter** head tags.

Verified: `npm run build` clean; `dist/llms.txt` + `dist/sitemap.xml` emitted; meta description + OG tags render; every contrast pair recomputed ≥4.5:1.