### PR TITLE
Wire Zenodo DOI into citation metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **Zenodo DOI**: spore.host is now archived on Zenodo with a citable DOI
+  (concept DOI [10.5281/zenodo.21439339](https://doi.org/10.5281/zenodo.21439339),
+  always latest). Wired into `CITATION.cff`, `codemeta.json`, and a README badge +
+  Citation section.
 - **`codemeta.json`** — CodeMeta (JSON-LD / schema.org) software metadata, for
   software registries and citation tooling; complements `CITATION.cff`.
 - **`CITATION.cff`** — machine-readable citation metadata (GitHub renders a

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,7 @@
 cff-version: 1.2.0
 message: "If you use spore.host in your research, please cite it as below."
 title: "spore.host: ephemeral AWS compute for researchers"
+doi: "10.5281/zenodo.21439339"
 abstract: >-
   spore.host is a suite of tools for ephemeral cloud compute on AWS EC2:
   truffle (instance-type discovery, spot pricing, quotas), spawn (launching and

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <a href="https://codecov.io/gh/spore-host/spore-host"><img src="https://codecov.io/gh/spore-host/spore-host/branch/main/graph/badge.svg" alt="codecov"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License: Apache 2.0"></a>
   <a href="https://spore.host"><img src="https://img.shields.io/badge/docs-spore.host-blue" alt="Documentation"></a>
+  <a href="https://doi.org/10.5281/zenodo.21439339"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.21439339.svg" alt="DOI"></a>
 </p>
 
 **spore.host** is a suite of tools for launching and managing AWS EC2 instances (Linux **and Windows**) — with automatic lifecycle management so instances clean up after themselves.
@@ -123,6 +124,14 @@ Full documentation at **[spore.host](https://spore.host)** or in the `docs/` dir
 - [IAM Permissions](docs/reference/iam-permissions.md)
 
 ---
+
+## Citation
+
+If you use spore.host in your research, please cite it. The concept DOI below
+always resolves to the latest release; see [`CITATION.cff`](CITATION.cff) for
+full metadata (GitHub's "Cite this repository" renders it for you).
+
+> Friedman, S. spore.host: ephemeral AWS compute for researchers. https://doi.org/10.5281/zenodo.21439339
 
 ## License
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -5,6 +5,7 @@
   "description": "A suite of tools for ephemeral cloud compute on AWS EC2: truffle (instance-type discovery, spot pricing, quotas), spawn (launching and lifecycle management with the spored in-instance daemon), and lagotto (a capacity watcher). Instances self-terminate via TTL and idle detection, so researchers can find the right instance, launch it in minutes, and let it clean itself up.",
   "codeRepository": "https://github.com/spore-host/spore-host",
   "url": "https://spore.host",
+  "identifier": "https://doi.org/10.5281/zenodo.21439339",
   "issueTracker": "https://github.com/spore-host/spore-host/issues",
   "license": "https://spdx.org/licenses/Apache-2.0",
   "programmingLanguage": [


### PR DESCRIPTION
spore.host is now on Zenodo with a citable DOI (minted from the v0.35.0 release).

- **Concept DOI** (always latest): [10.5281/zenodo.21439339](https://doi.org/10.5281/zenodo.21439339)
- **v0.35.0 DOI**: 10.5281/zenodo.21439340

Adds `doi:` to `CITATION.cff`, `identifier` to `codemeta.json`, and a DOI badge + Citation section to the README.