### PR TITLE
docs: researcher-facing information-architecture overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **Docs: researcher-facing information-architecture overhaul.** Restructured the
+  docs site around user intent instead of product structure, following an external
+  review. New top-level nav: Introduction → Start Here → Common Workflows → Tools →
+  Automation → Chat & AI Control → Administration → Reference (one global sidebar).
+  New pages: **Security, credentials & data flow** (`/architecture`, "what runs
+  where" trust/data-flow model), **Costs & safety guarantees** (`/safety`,
+  auto-terminate failure boundaries + pre-launch cost estimation), **Waiting for
+  scarce capacity** (a Lagotto first-use tutorial), **Glossary**,
+  **Troubleshooting & common mistakes**, and **Event schemas**. The Guides landing
+  is now three narrative user stories. Each tool page opens with a consistent
+  *What it is / When to use / First commands* trio; Truffle gains a find-vs-search
+  decision box, Spawn a three-tier progressive-disclosure map and a spawn-vs-spored
+  "what runs where" diagram. Added audience/maturity badges (Beginner / Advanced /
+  HPC / Automation / Stable / Beta …) with WCAG-AA colours in light and dark mode.
 - **Docs: heterogeneous parameter sweeps** (spawn#372) — the sweeps guide now
   shows varying `instance_type`/`ami`/`spot` per entry (price-performance
   benchmark example), with the per-entry AMI auto-detection, the one-OS-per-sweep
@@ -35,6 +49,17 @@ own changelogs for CLI releases.
   better AI/search snippets); added default OG/Twitter card `head` tags.
 
 ### Fixed
+- **Site: resolved the "five vs six tools" inconsistency.** The marketing site
+  now says "Six tools" and includes a **Spored** card (it was omitted); the docs
+  already said six. `web/README.md`'s stale tool list updated to match.
+- **Site: consistent HTTP API status.** The API is now labelled **beta / used by
+  the SDK** everywhere — removed "coming soon"/"on the roadmap" framing on
+  `web/library.html` (added an inline **Beta** badge to the endpoint block so it
+  doesn't read as a live public contract) and reconciled the `guides/python-sdk`
+  and `guides/self-hosting` wording.
+- **Copy: clarified spore.host is not itself the host** — the hero, docs home,
+  and How It Works now state up front that it runs on your own AWS account with
+  your own credentials, with no new provider to sign up for.
 - **Docs accessibility: WCAG AA contrast** (#423) — tool badges are small
   (0.7rem) bold text, so they need 4.5:1: several failed in light and/or dark
   mode. Badge text now uses per-mode colors that all clear 4.5:1, and dark-mode

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,37 +7,85 @@ const SITE_URL = 'https://docs.spore.host'
 // Sidebar is a top-level const so the llms.txt generator (buildEnd, below) can
 // walk the exact same structure the site renders — the manifest can't drift from
 // the nav.
+// One global sidebar (keyed on '/') applied to every page, so the whole site
+// reads as a single path: Introduction → Start Here → Common Workflows → Tools →
+// Automation → Administration → Reference. This is deliberate — the docs used to
+// show a different sidebar per top-level section, which fragmented the mental
+// model the reviewer flagged. Every link below points to a page that exists.
 const sidebar = {
   '/': [
-    { text: 'Quick Start', link: '/quickstart' },
-    { text: 'How It Works', link: '/how-it-works' },
-  ],
-  '/guides/': [
     {
-      text: 'Getting Started',
+      text: 'Introduction',
       collapsed: false,
       items: [
-        { text: 'Installation', link: '/guides/installation' },
+        { text: 'What is spore.host?', link: '/' },
+        { text: 'How the pieces fit together', link: '/how-it-works' },
+        { text: 'Security, credentials & data flow', link: '/architecture' },
+        { text: 'Costs & safety guarantees', link: '/safety' },
+      ]
+    },
+    {
+      text: 'Start Here',
+      collapsed: false,
+      items: [
+        { text: 'Quick Start', link: '/quickstart' },
+        { text: 'Install', link: '/guides/installation' },
         { text: 'AWS Authentication', link: '/guides/aws-auth' },
-        { text: 'Your First Instance', link: '/guides/first-instance' },
-        { text: 'Python SDK', link: '/guides/python-sdk' },
-        { text: 'Go Library', link: '/guides/go-library' },
+        { text: 'Required permissions', link: '/reference/iam-permissions' },
+        { text: 'Your first instance', link: '/guides/first-instance' },
+        { text: 'Verify lifecycle protection', link: '/guides/first-instance#verify-lifecycle-protection' },
+        { text: 'Clean up everything', link: '/guides/first-instance#clean-up' },
       ]
     },
     {
-      text: 'Compute',
+      text: 'Common Workflows',
       collapsed: false,
       items: [
-        { text: 'Finding the Right Instance', link: '/guides/finding-instances' },
-        { text: 'GPU Training Jobs', link: '/guides/gpu-training' },
-        { text: 'Jupyter Notebooks', link: '/guides/jupyter' },
-        { text: 'Spot Instances', link: '/guides/spot-instances' },
-        { text: 'Managing Instances & Data', link: '/guides/managing-instances' },
+        { text: 'Overview', link: '/guides/' },
+        { text: 'Finding the right instance', link: '/guides/finding-instances' },
+        { text: 'Interactive workstation', link: '/guides/jupyter' },
+        { text: 'GPU training jobs', link: '/guides/gpu-training' },
+        { text: 'Spot instances', link: '/guides/spot-instances' },
+        { text: 'Managing instances & data', link: '/guides/managing-instances' },
+        { text: 'Parameter sweeps', link: '/guides/parameter-sweeps' },
+        { text: 'Job arrays', link: '/guides/job-arrays' },
+        { text: 'Batch queues', link: '/guides/batch-queue' },
+        { text: 'MPI clusters', link: '/guides/mpi' },
+        { text: 'Pipelines', link: '/guides/pipelines' },
+        { text: 'Waiting for scarce capacity', link: '/guides/waiting-for-capacity' },
       ]
     },
     {
-      text: 'Automation & Control',
+      text: 'Tools',
       collapsed: false,
+      items: [
+        { text: 'Overview', link: '/tools/' },
+        { text: 'Truffle', link: '/tools/truffle' },
+        { text: 'Spawn', link: '/tools/spawn' },
+        { text: 'Spored', link: '/tools/spored' },
+        { text: 'Lagotto', link: '/tools/lagotto' },
+        { text: 'Spore-bot', link: '/tools/spore-bot' },
+        { text: 'MCP Server', link: '/tools/mcp-server' },
+        { text: 'Command reference: truffle', link: '/tools/reference/truffle' },
+        { text: 'Command reference: spawn', link: '/tools/reference/spawn' },
+        { text: 'Command reference: lagotto', link: '/tools/reference/lagotto' },
+      ]
+    },
+    {
+      text: 'Automation',
+      collapsed: true,
+      items: [
+        { text: 'Python SDK', link: '/guides/python-sdk' },
+        { text: 'Go libraries', link: '/guides/go-library' },
+        { text: 'Workflow engines', link: '/guides/workflow-engines' },
+        { text: 'Nextflow (nf-spawn)', link: '/guides/nextflow' },
+        { text: 'Plugins', link: '/guides/plugins' },
+        { text: 'Events & webhooks', link: '/reference/event-schemas' },
+      ]
+    },
+    {
+      text: 'Chat & AI Control',
+      collapsed: true,
       items: [
         { text: 'Slack Setup', link: '/guides/slack-setup' },
         { text: 'Teams Setup', link: '/guides/teams-setup' },
@@ -47,59 +95,25 @@ const sidebar = {
       ]
     },
     {
-      text: 'Advanced',
-      collapsed: false,
-      items: [
-        { text: 'Parameter Sweeps', link: '/guides/parameter-sweeps' },
-        { text: 'Job Arrays', link: '/guides/job-arrays' },
-        { text: 'Batch Queues', link: '/guides/batch-queue' },
-        { text: 'MPI Clusters', link: '/guides/mpi' },
-        { text: 'Pipelines', link: '/guides/pipelines' },
-        { text: 'Plugins', link: '/guides/plugins' },
-        { text: 'Workflow Engines', link: '/guides/workflow-engines' },
-        { text: 'Nextflow (nf-spawn)', link: '/guides/nextflow' },
-      ]
-    },
-    {
-      text: 'Self-Hosting',
+      text: 'Administration',
       collapsed: true,
       items: [
-        { text: 'Overview', link: '/guides/self-hosting' },
+        { text: 'IAM Permissions', link: '/reference/iam-permissions' },
+        { text: 'Self-Hosting', link: '/guides/self-hosting' },
         { text: 'Self-Hosting spore-bot', link: '/spore-bot-self-hosting' },
       ]
     },
-  ],
-  '/tools/': [
-    {
-      text: 'Tools',
-      items: [
-        { text: 'Overview', link: '/tools/' },
-        { text: 'Truffle', link: '/tools/truffle' },
-        { text: 'Spawn', link: '/tools/spawn' },
-        { text: 'Spored', link: '/tools/spored' },
-        { text: 'Lagotto', link: '/tools/lagotto' },
-        { text: 'Spore-bot', link: '/tools/spore-bot' },
-        { text: 'MCP Server', link: '/tools/mcp-server' },
-      ]
-    },
-    {
-      text: 'Command Reference',
-      items: [
-        { text: 'truffle', link: '/tools/reference/truffle' },
-        { text: 'spawn', link: '/tools/reference/spawn' },
-        { text: 'lagotto', link: '/tools/reference/lagotto' },
-      ]
-    },
-  ],
-  '/reference/': [
     {
       text: 'Reference',
+      collapsed: true,
       items: [
         { text: 'Configuration', link: '/reference/configuration' },
         { text: 'EC2 Tags', link: '/reference/ec2-tags' },
-        { text: 'IAM Permissions', link: '/reference/iam-permissions' },
-        { text: 'Lifecycle Events', link: '/reference/lifecycle-events' },
         { text: 'Environment Variables', link: '/reference/environment-variables' },
+        { text: 'Lifecycle Events', link: '/reference/lifecycle-events' },
+        { text: 'Event schemas', link: '/reference/event-schemas' },
+        { text: 'Troubleshooting & common mistakes', link: '/reference/troubleshooting' },
+        { text: 'Glossary', link: '/reference/glossary' },
         { text: 'FAQ', link: '/reference/faq' },
         { text: 'Cheat Sheet', link: '/reference/cheatsheet' },
       ]
@@ -114,31 +128,21 @@ function writeLlmsTxt(outDir: string) {
   const lines: string[] = []
   lines.push('# spore.host documentation')
   lines.push('')
-  lines.push('> Ephemeral compute for researchers and data scientists: find the right EC2 instance (truffle), launch and manage it (spawn), and watch for capacity (lagotto). Instances self-terminate via TTL and idle detection.')
+  lines.push('> Ephemeral compute for researchers and data scientists: find the right EC2 instance (truffle), launch and manage it (spawn), and watch for capacity (lagotto). Instances self-terminate via TTL and idle detection. Runs on your own AWS account.')
   lines.push('')
-  const sections: Array<[string, any[]]> = [
-    ['Start here', sidebar['/']],
-    ['Guides', sidebar['/guides/']],
-    ['Tools & command reference', sidebar['/tools/']],
-    ['Reference', sidebar['/reference/']],
-  ]
+  // Walk the single global sidebar: each top-level entry is a titled group with
+  // an items[] list. One llms.txt section per group keeps the manifest in
+  // lockstep with the rendered nav (only anchor-only, non-root links are skipped).
   const link = (item: any) =>
-    item.link && item.link.startsWith('/')
+    item.link && item.link.startsWith('/') && !item.link.includes('#')
       ? `- [${item.text}](${SITE_URL}${item.link})`
       : null
-  for (const [heading, groups] of sections) {
-    lines.push(`## ${heading}`)
+  for (const group of sidebar['/']) {
+    lines.push(`## ${group.text}`)
     lines.push('')
-    for (const entry of groups) {
-      if (entry.items) {
-        for (const item of entry.items) {
-          const l = link(item)
-          if (l) lines.push(l)
-        }
-      } else {
-        const l = link(entry)
-        if (l) lines.push(l)
-      }
+    for (const item of group.items ?? []) {
+      const l = link(item)
+      if (l) lines.push(l)
     }
     lines.push('')
   }
@@ -182,8 +186,8 @@ export default defineConfig({
     logo: null,
 
     nav: [
-      { text: 'Quick Start', link: '/quickstart' },
-      { text: 'Guides', link: '/guides/' },
+      { text: 'Start Here', link: '/quickstart' },
+      { text: 'Workflows', link: '/guides/' },
       { text: 'Tools', link: '/tools/' },
       { text: 'Reference', link: '/reference/' },
       { text: 'spore.host', link: 'https://spore.host', target: '_blank' },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -97,6 +97,41 @@
 .dark .tool-badge.bot     { background: #160d2e; }
 .dark .tool-badge.mcp     { background: #0f0d2e; }
 
+/* ── Audience / maturity badges (page headers) ──
+   Small pills that signal who a page is for and how mature a feature is.
+   Colours reuse the palette and clear WCAG AA (4.5:1) on their tinted
+   backgrounds, matching the .tool-badge contrast approach above. */
+.doc-badge {
+  display: inline-block;
+  font-size: 0.7rem; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+  padding: 0.15rem 0.45rem; border-radius: 4px;
+  vertical-align: middle; margin-right: 0.35rem;
+}
+/* Audience */
+.doc-badge.beginner  { background: #ecfdf5; color: #047857; }
+.doc-badge.admin     { background: #fef2f2; color: #b91c1c; }
+.doc-badge.advanced  { background: #eff6ff; color: #4059E5; }
+.doc-badge.hpc       { background: #eef2ff; color: #3730a3; }
+.doc-badge.automation{ background: #f5f3ff; color: #6d28d9; }
+.doc-badge.windows   { background: #ecfeff; color: #0e7490; }
+/* Maturity */
+.doc-badge.stable    { background: #ecfdf5; color: #047857; }
+.doc-badge.beta      { background: #fffbeb; color: #b45309; }
+.doc-badge.experimental { background: #fffbeb; color: #b45309; }
+.doc-badge.planned   { background: #f3f4f6; color: #4b5563; }
+.doc-badge.deprecated{ background: #fef2f2; color: #b91c1c; }
+
+/* Dark-mode badge backgrounds (lighten text where needed to keep AA). */
+.dark .doc-badge.beginner,  .dark .doc-badge.stable { background: #0a1f16; color: #34d399; }
+.dark .doc-badge.admin,     .dark .doc-badge.deprecated { background: #2a0a0a; color: #f87171; }
+.dark .doc-badge.advanced   { background: #0d1b2e; color: #93b0ff; }
+.dark .doc-badge.hpc        { background: #0f0d2e; color: #a5b4fc; }
+.dark .doc-badge.automation { background: #160d2e; color: #c4b5fd; }
+.dark .doc-badge.windows    { background: #082030; color: #22d3ee; }
+.dark .doc-badge.beta,      .dark .doc-badge.experimental { background: #1a1200; color: #fbbf24; }
+.dark .doc-badge.planned    { background: #1f2430; color: #9ca3af; }
+
 /* ── Param tables (reference pages) ── */
 .vp-doc table { font-size: 0.875rem; }
 .vp-doc table th { font-weight: 700; }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,110 @@
+---
+description: "Where your credentials stay, what calls AWS, and what runs where — a plain map of spore.host's trust and data-flow model."
+---
+
+# Security, credentials & data flow
+
+The name is *spore.host*, but spore.host is **not** the host. It never holds your
+AWS credentials and never runs your compute. Everything runs on **your own AWS
+account**, using **your own credentials**. This page maps exactly what runs where,
+so you can answer the questions a cautious researcher — or their security team —
+will ask before running it.
+
+## What runs where
+
+```
+┌─ Your computer ────────────────────────────────────────────┐
+│  truffle   queries AWS for instance metadata, prices, quotas │
+│  spawn     calls AWS APIs to launch and provision instances  │
+│            (uses your existing AWS credential chain)         │
+└──────────────────────────────┬──────────────────────────────┘
+                               │  AWS API calls, signed with
+                               │  YOUR credentials
+                               ▼
+┌─ AWS — your account ───────────────────────────────────────┐
+│  EC2 instance                                                │
+│    spored   monitors TTL, idle, completion, cost             │
+│             reads its rules from the instance's EC2 tags     │
+│             ├─ stop / hibernate / terminate                  │
+│             └─ emits lifecycle events                         │
+└──────────────────────────────┬──────────────────────────────┘
+                               │  event callbacks (no credentials)
+                               ▼
+┌─ spore.host-infra account (optional) ──────────────────────┐
+│  Lambdas   route Slack/Teams messages, DNS, notifications    │
+│            assume ONLY the narrow cross-account role you      │
+│            grant — never hold your keys                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## The questions this answers
+
+**Where do my credentials stay?**
+On your machine, in your normal AWS credential chain (`~/.aws/credentials`,
+environment variables, SSO, or instance metadata). truffle and spawn read them the
+same way the AWS CLI does. spore.host never stores, transmits, or sees them.
+
+**Must my laptop stay open?**
+No. Once spawn launches an instance, **spored** takes over lifecycle enforcement
+from *inside* the instance. It reads its rules from the instance's EC2 tags every
+minute, so the TTL and idle rules keep working after you disconnect, close your
+laptop, or lose your network. See [How it works](/how-it-works).
+
+**Who actually terminates the machine?**
+spored, running on the instance itself — not your laptop, not a spore.host server.
+An out-of-band reaper is the backstop if spored can't; see
+[Costs & safety guarantees](/safety).
+
+**Is there a central control plane that runs my compute?**
+No. The only hosted components are optional Lambda functions (chat control, DNS,
+notifications) in the spore.host-infra account. They never run your workloads and
+never hold your credentials — for chat control they **assume a narrow
+cross-account IAM role you explicitly create**, scoped to specific EC2 actions.
+You can run entirely without them (`lagotto poll --daemon`, no chat integration),
+in which case nothing leaves your account at all.
+
+**What metadata leaves my account?**
+Only what you opt into. If you enable Slack/Teams or hosted notifications, spored
+sends lifecycle *events* (instance nickname, state, TTL countdown — no
+credentials, no data from the instance) to the notification Lambda so it can DM
+you. With no integrations enabled, nothing leaves your account.
+
+**Does the HTTP API change this?**
+The [Python SDK](/guides/python-sdk) talks to a beta HTTP API that authenticates
+with your AWS credentials. It's the same trust model — your credentials, your
+account. Direct HTTP use isn't a supported public interface yet.
+
+## How to audit everything it creates
+
+Every resource spore.host creates is tagged. To see exactly what it owns:
+
+```sh
+# Every instance spawn is managing, with its lifecycle tags
+spawn list
+
+# Raw: all spawn:* tags on a specific instance
+aws ec2 describe-tags \
+  --filters "Name=resource-id,Values=i-0abc123def456xyz" \
+  --query 'Tags[?starts_with(Key, `spawn:`)]' --output table
+```
+
+The full tag vocabulary is documented in [EC2 Tags](/reference/ec2-tags), the
+exact IAM permissions in [IAM Permissions](/reference/iam-permissions), and the
+env vars that point the tools at hosted vs. self-hosted infrastructure in
+[Environment Variables](/reference/environment-variables).
+
+## What spore.host doesn't do
+
+- It doesn't manage your SSH keys beyond passing the one you specify at launch.
+- It doesn't modify your AWS account structure, VPCs, or security groups beyond
+  what's needed to launch.
+- It doesn't store your AWS credentials — everything uses your existing chain.
+- It doesn't require always-on infrastructure in your account. spored runs on the
+  instance; the optional Lambdas run in the spore.host-infra account (or your own,
+  if you [self-host](/guides/self-hosting)).
+
+## Next steps
+
+- **[Costs & safety guarantees](/safety)** — the auto-terminate promise and its failure boundaries
+- **[IAM Permissions](/reference/iam-permissions)** — the minimal least-privilege policy
+- **[Self-Hosting](/guides/self-hosting)** — run the Lambdas in your own account

--- a/docs/guides/first-instance.md
+++ b/docs/guides/first-instance.md
@@ -130,7 +130,27 @@ This shows state, IP, type, uptime, and time remaining before auto-termination.
 
 ---
 
-## 7. Clean up
+## Verify lifecycle protection
+
+Before you rely on auto-termination, confirm the instance is actually protecting itself. Two quick checks:
+
+```sh
+spawn status my-first-instance        # from your laptop
+```
+
+The output shows **time remaining before auto-termination** — if you see a TTL countdown, spawn tagged the instance correctly and the deadline is live. On the instance itself:
+
+```sh
+sudo systemctl status spored          # over SSH
+```
+
+`active (running)` means the daemon that enforces the deadline is up. spored reads its rules from the instance's EC2 tags every minute, so the TTL holds even if you close your laptop.
+
+For what happens if any of this *fails* — a missing instance profile, a crashed daemon, changed tags — and the out-of-band backstop that catches it, see [Costs & safety guarantees](/safety).
+
+---
+
+## Clean up
 
 When you're done, permanently terminate it (destroys the instance and its EBS volume):
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,48 +1,104 @@
 ---
-description: "Task-oriented guides for common workflows."
+description: "Complete, end-to-end workflows for the things researchers actually do — start with a story that matches your goal."
 ---
 
-# Guides
+# Common Workflows
 
-Task-oriented guides for common workflows. If you're new, start with **Getting Started**. If you know what you want to do, jump directly to the relevant guide.
+You usually arrive with a goal, not a tool in mind. Start with the story closest to
+what you're trying to do — each is a complete, end-to-end walkthrough — then branch
+into the deeper guides. New to spore.host? Do [Your first
+instance](/guides/first-instance) first; it's the 15-minute backbone the stories
+below build on.
 
-## Getting Started
+## Story A — Interactive research workstation
 
-| Guide | What you'll learn |
-|-------|------------------|
-| [Installation](/guides/installation) | Install truffle, spawn, and optional tools |
-| [Your First Instance](/guides/first-instance) | End-to-end: find, launch, connect, terminate |
+*"I need a big machine for a few hours to explore some data, then it should go
+away."*
 
-## Compute
+```sh
+truffle find "amd genoa 64gb" --region us-east-1     # 1. find a fit
+spawn launch analysis \                              # 2. launch with guards
+  --instance-type m8a.4xlarge \
+  --ttl 8h \
+  --idle-timeout 30m
+spawn connect analysis                               # 3. work on it
+spawn terminate analysis                             # 4. done — tear it down
+```
 
-| Guide | What you'll learn |
-|-------|------------------|
-| [GPU Training Jobs](/guides/gpu-training) | Launch a GPU instance, run a training job, terminate on completion |
-| [Jupyter Notebooks](/guides/jupyter) | RStudio or Jupyter with process-aware idle detection |
-| [Spot Instances](/guides/spot-instances) | Use Spot for up to 90% cost savings, handle interruptions gracefully |
+- **`--ttl 8h`** is the hard deadline — the instance terminates then no matter
+  what, so a forgotten session can't run all weekend.
+- **`--idle-timeout 30m`** stops it early if you wander off; any activity resets
+  the timer. Idle *stops*, TTL *terminates* — see [Costs & safety
+  guarantees](/safety).
+- **Cost:** capped at 8 × the hourly rate; usually far less because idle stops it.
+  Check the rate with `truffle spot m8a.4xlarge` before you launch.
 
-## Automation & Control
+→ Deeper: [Finding the right instance](/guides/finding-instances) ·
+[Jupyter/RStudio](/guides/jupyter) · [Managing instances &
+data](/guides/managing-instances)
 
-| Guide | What you'll learn |
-|-------|------------------|
-| [Slack Setup](/guides/slack-setup) | Connect Slack, use `/spore` commands, get lifecycle DMs |
-| [Teams Setup](/guides/teams-setup) | Connect Microsoft Teams |
-| [AI Assistant (MCP)](/guides/mcp-setup) | Control compute from Claude Desktop or Cursor |
-| [Lifecycle Notifications](/guides/notifications) | Configure what events trigger notifications and where they go |
+## Story B — Unattended batch computation
 
-## Advanced
+*"Run this script on a big box; when it finishes, terminate — I'm not watching."*
 
-| Guide | What you'll learn |
-|-------|------------------|
-| [Parameter Sweeps](/guides/parameter-sweeps) | Run the same job across many parameter combinations in parallel |
-| [MPI Clusters](/guides/mpi) | Launch multi-node clusters for distributed workloads |
-| [Pipelines](/guides/pipelines) | Chain jobs so each stage launches the next |
-| [Plugins](/guides/plugins) | Extend instances with pre-built or custom plugins at launch time |
-| [Job Arrays](/guides/job-arrays) | Launch and manage groups of related instances |
+```sh
+spawn launch simulation \
+  --instance-type c8a.12xlarge \
+  --ttl 12h \
+  --command "./run-model.sh && spored complete --status success" \
+  --on-complete terminate
+```
 
-## Workflow Engines
+What happens in each case:
 
-| Guide | What you'll learn |
-|-------|------------------|
-| [Workflow Engines](/guides/workflow-engines) | Run Nextflow, WDL, CWL, Snakemake, or Airflow with spawn as the execution backend — each task on an ephemeral instance |
-| [Nextflow (nf-spawn)](/guides/nextflow) | Dispatch each Nextflow process to its own ephemeral EC2 instance |
+- **Succeeds** → the `&&` reaches `spored complete`, the completion sentinel
+  appears, and `--on-complete terminate` tears the instance down.
+- **Fails** → `run-model.sh` exits non-zero, `spored complete` never runs, so the
+  instance stays up (for you to debug) until the **TTL** terminates it at 12h.
+- **Hangs** → idle detection won't fire (a running process is activity), but the
+  **TTL** still terminates at 12h. TTL is the backstop that always wins.
+
+The distinction that trips people up: it's the **completion sentinel appearing**
+that triggers `on-complete`, not your command merely exiting — which is why the
+script calls `spored complete` explicitly. See
+[Troubleshooting](/reference/troubleshooting#a-command-finishing-vs-the-completion-sentinel-appearing).
+
+→ Deeper: [GPU training jobs](/guides/gpu-training) · [Parameter
+sweeps](/guides/parameter-sweeps) · [Batch queues](/guides/batch-queue)
+
+## Story C — Scarce GPU capacity
+
+*"I need a p5.48xlarge, but there's never one available when I try."*
+
+1. **[Truffle](/tools/truffle)** confirms the type exists and you have quota.
+2. **[Spawn](/tools/spawn)** tries to launch — and gets
+   `InsufficientInstanceCapacity`.
+3. **[Lagotto](/tools/lagotto)** watches three regions every five minutes.
+4. A notification arrives the moment capacity appears.
+5. Lagotto launches it automatically with a 6-hour TTL — no one awake required.
+
+This is the one workflow the "find → launch" path can't do alone, because *quota*
+and *capacity* are different things. Full walkthrough: [Waiting for scarce
+capacity](/guides/waiting-for-capacity).
+
+---
+
+## Choose what to learn next
+
+| I want to… | Go to |
+|------------|-------|
+| Find the right instance type & compare prices | [Finding the right instance](/guides/finding-instances) |
+| Run Jupyter or RStudio in the browser | [Interactive workstation](/guides/jupyter) |
+| Train a model on a GPU | [GPU training jobs](/guides/gpu-training) |
+| Save up to 90% with Spot | [Spot instances](/guides/spot-instances) |
+| Move data on and off instances | [Managing instances & data](/guides/managing-instances) |
+| Run one job across many parameters | [Parameter sweeps](/guides/parameter-sweeps) |
+| Manage a group of related instances | [Job arrays](/guides/job-arrays) |
+| Queue more work than fits at once | [Batch queues](/guides/batch-queue) |
+| Run tightly-coupled multi-node jobs | [MPI clusters](/guides/mpi) |
+| Chain jobs so each stage launches the next | [Pipelines](/guides/pipelines) |
+| Wait for a hard-to-find GPU | [Waiting for scarce capacity](/guides/waiting-for-capacity) |
+| Control instances from Slack/Teams | [Slack Setup](/guides/slack-setup) |
+| Drive compute from an AI assistant | [AI Assistant (MCP)](/guides/mcp-setup) |
+| Automate from Python | [Python SDK](/guides/python-sdk) |
+| Run Nextflow / WDL / CWL / Snakemake / Airflow | [Workflow engines](/guides/workflow-engines) |

--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -12,7 +12,7 @@ description: "The spore-host Python package lets you discover EC2 instances, che
 
 The `spore-host` Python package lets you discover EC2 instances, check Spot prices, and manage running instances from Python scripts, Jupyter notebooks, and reactive notebooks like marimo.
 
-The SDK talks to the spore.host REST API. AWS credentials are used for authentication — no separate login is required.
+The SDK talks to the spore.host HTTP API on your behalf, authenticating with your existing AWS credentials — no separate login is required. The HTTP API itself is currently in beta and the SDK is its supported entry point; you don't call the endpoints directly.
 
 ```sh
 pip install spore-host

--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -270,8 +270,8 @@ All spore.host components read from environment variables and config file (`~/.s
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `SPORE_ENV` | Deployment environment: `integ` or `prod` | `prod` |
-| `SPORE_API_URL` | REST API Lambda URL | hosted spore.host |
-| `SPORE_API_KEY` | API key for REST API | — |
+| `SPORE_API_URL` | HTTP API Lambda URL (beta; used by the Python SDK) | hosted spore.host |
+| `SPORE_API_KEY` | API key for the HTTP API | — |
 | `SPORE_NOTIFY_URL` | Notification Lambda callback URL | hosted spore.host |
 | `SPORE_DNS_URL` | DNS updater Lambda URL | hosted spore.host |
 | `SPORE_BOT_LAMBDA_ROLE_ARN` | Cross-account trust target for bot | hosted spore.host |

--- a/docs/guides/waiting-for-capacity.md
+++ b/docs/guides/waiting-for-capacity.md
@@ -1,0 +1,162 @@
+---
+description: "A complete walkthrough: use Lagotto to wait for a scarce GPU instance and act the moment capacity appears."
+---
+
+# Waiting for scarce capacity
+
+A complete walkthrough for the case where the instance you want isn't available
+right now — a scarce GPU family like `p5.48xlarge`. Instead of re-running a launch
+by hand, you'll set [Lagotto](/tools/lagotto) to watch for capacity and act the
+moment it appears. Allow about 15 minutes.
+
+## What you'll accomplish
+
+- A Lagotto watcher deployed in your own AWS account
+- A watch that checks three regions every five minutes
+- A notification the moment capacity is found — with no automatic launch
+- Then: the same watch upgraded to **launch automatically** with a TTL
+
+## Prerequisites
+
+- [truffle and spawn installed and working](/guides/first-instance) and AWS
+  credentials verified
+- lagotto installed: `brew install spore-host/tap/lagotto`
+- Confirm you're actually allowed to launch the type you want *before* you wait for
+  it — see the four questions below
+
+## First, know which question you're answering
+
+Capacity is the last of four different questions, and only Lagotto answers it.
+Don't skip the first three — waiting for capacity you have no quota for is wasted
+time:
+
+| Question | Answered by |
+|----------|-------------|
+| Does this EC2 type exist in this region? | [Truffle](/tools/truffle) — `truffle find` / `truffle az` |
+| Am I allowed to launch it under my quota? | [Truffle](/tools/truffle) — `truffle quotas` |
+| Can AWS actually place one *right now*? | [Spawn](/tools/spawn) launch attempt / Lagotto |
+| Should I keep checking until placement succeeds? | **[Lagotto](/tools/lagotto)** |
+
+```sh
+truffle quotas --regions us-east-1,us-west-2,us-east-2 --family P
+```
+
+If quota is zero, request an increase first — Lagotto can't launch what your quota
+forbids (that's a *terminal* failure, not a capacity wait).
+
+---
+
+## 1. Deploy the watcher
+
+Lagotto runs as a serverless poller **in your own account**. Stand it up once:
+
+```sh
+lagotto deploy
+```
+
+This deploys a Lambda + EventBridge schedule + DynamoDB + IAM via CloudFormation.
+The schedule deploys **disabled** — your first watch arms it, and it tears itself
+down when no watches remain.
+
+---
+
+## 2. Create a notify-only watch
+
+Start conservatively: watch three regions, check every five minutes, and just
+**tell me** when capacity appears — don't launch anything yet.
+
+```sh
+lagotto watch "p5.48xlarge" \
+  --regions us-east-1,us-west-2,us-east-2 \
+  --action notify \
+  --notify email:you@example.com \
+  --ttl 7d
+```
+
+- `--action notify` — alert only; nothing launches
+- `--ttl 7d` — give up after a week if capacity never appears (the TTL is the only
+  time limit; there's no max-retry count)
+
+Confirm it's active:
+
+```sh
+lagotto list
+lagotto status <watch-id>
+```
+
+Lagotto now polls every ~5 minutes. When it finds capacity, you get an email and
+the watch is marked `matched`.
+
+---
+
+## 3. Upgrade it to launch automatically
+
+Once you trust the watch, replace "notify me" with "launch it for me." Write a
+spawn config describing the instance you want, with a TTL so the launched instance
+still self-terminates:
+
+```yaml
+# gpu-job.yaml
+name: training
+instance_type: p5.48xlarge
+ttl: 6h
+on_complete: terminate
+command: ./run-training.sh && spored complete --status success
+```
+
+Then create the auto-launch watch:
+
+```sh
+lagotto watch "p5.48xlarge" \
+  --regions us-east-1,us-west-2,us-east-2 \
+  --action spawn \
+  --spawn-config gpu-job.yaml \
+  --notify email:you@example.com \
+  --ttl 7d
+```
+
+Now when capacity appears, Lagotto launches the instance with a 6-hour TTL, runs
+your job, and the instance terminates on completion — the whole chain fires with
+no one awake to run it.
+
+::: tip The launch attempt *is* the capacity test
+There's no AWS API that reports "capacity is available now." For a `spawn` watch,
+Lagotto's launch attempt is the real test: if AWS returns
+`InsufficientInstanceCapacity` the watch stays `active` and retries next poll. A
+*terminal* error (bad AMI, exhausted quota) marks the watch `failed` instead of
+retrying forever.
+:::
+
+---
+
+## 4. Clean up
+
+A watch ends on its own when it matches, fails, or its TTL expires. To stop one
+early:
+
+```sh
+lagotto cancel <watch-id>
+```
+
+When no watches remain, the poller disables its own schedule automatically. To
+remove the whole stack:
+
+```sh
+lagotto deploy --teardown
+```
+
+---
+
+## What just happened
+
+You turned "keep manually re-trying a launch for a scarce GPU" into a
+fire-and-forget watch running in your own account. Lagotto did the tedious
+retrying, respected your quota, and — in the auto-launch version — handed off to
+spawn, which launched an instance that manages its own lifecycle via
+[spored](/tools/spored).
+
+## Next steps
+
+- **[Lagotto](/tools/lagotto)** — every action, SageMaker watches, and Capacity Blocks for ML
+- **[Scheduled launches](/tools/lagotto#lagotto-launch)** — launch by clock time (e.g. into a Capacity Block)
+- **[GPU Training Jobs](/guides/gpu-training)** — what to run once you have the instance

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -4,7 +4,11 @@ description: "spore.host is a collection of six tools that cover the full lifecy
 
 # How It Works
 
-spore.host is a collection of six tools that cover the full lifecycle of ephemeral compute — from finding the right instance to cleaning it up when the work is done. This page explains how they fit together.
+spore.host is an open-source toolkit for temporary AWS compute. Use **truffle** to find an EC2 instance that fits your workload and budget, use **spawn** to launch it with a hard time limit, idle shutdown, and completion rules, and let **spored** — a small agent on the instance — keep enforcing those rules after you disconnect. When scarce capacity is unavailable, **lagotto** can keep checking and notify you or launch automatically when it appears.
+
+The tools use your existing AWS account and credentials. There's no new compute provider to sign up for, and you pay AWS only for the resources you use. spore.host is not itself the host — despite the name, it never holds your credentials or runs your compute for you. See [Security, credentials & data flow](/architecture) for exactly what runs where.
+
+This page explains how the six tools fit together.
 
 ## The core idea
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: spore.host
   text: Ephemeral compute for researchers
-  tagline: Find the right EC2 instance, launch it in minutes, and let it manage itself. Auto-termination, idle detection, Slack and Teams control, and AI-assistant integration — so you can focus on your work, not your infrastructure.
+  tagline: An open-source toolkit for temporary AWS compute. Find the right EC2 instance, launch it with a hard time limit and idle shutdown, and let it manage itself — on your own AWS account. There's no new provider to sign up for, and you pay AWS only for what you use.
   actions:
     - theme: brand
       text: Quick Start

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -123,6 +123,8 @@ spawn stop my-first-instance       # stopped, can be restarted with spawn start
 ## Next steps
 
 - **[How It Works](/how-it-works)** — understand the full lifecycle and how the tools connect
+- **[Security, credentials & data flow](/architecture)** — what runs where, and why spore.host never holds your keys
+- **[Costs & safety guarantees](/safety)** — the auto-terminate promise, its limits, and estimating cost up front
+- **[Common Workflows](/guides/)** — end-to-end stories for real research tasks
 - **[GPU Training](/guides/gpu-training)** — launch a GPU instance for a training job
-- **[Slack Setup](/guides/slack-setup)** — control instances from Slack, get notifications when jobs finish
 - **[spawn launch reference](/tools/reference/spawn)** — every flag explained

--- a/docs/reference/event-schemas.md
+++ b/docs/reference/event-schemas.md
@@ -1,0 +1,74 @@
+---
+description: "The payload shape of spored's lifecycle events — for building webhooks and automation on top of spore.host."
+---
+
+# Event schemas
+
+spored emits a lifecycle event when something significant happens to an instance
+(TTL warning, completion, Spot interruption, …). Events are delivered as an HTTP
+`POST` to the notification endpoint (`spawn:notify-url`), which routes them to
+Slack/Teams. This page documents the payload shape so you can build automation on
+top of it.
+
+For *when* each event fires and its human-readable message, see
+[Lifecycle Events](/reference/lifecycle-events). For enabling delivery to Slack or
+a channel webhook, see [Lifecycle Notifications](/guides/notifications).
+
+## Notification payload
+
+Each event is a JSON object with these fields:
+
+| Field | Type | Always present | Description |
+|-------|------|----------------|-------------|
+| `event_type` | string | yes | The event, e.g. `ttl_warning`, `completion`, `spot_interrupt`. See the [event type list](/reference/lifecycle-events#event-types). |
+| `instance_name` | string | yes | The instance nickname (or ID if unnamed). |
+| `instance_id` | string | yes | The EC2 instance ID. |
+| `region` | string | yes | AWS region of the instance. |
+| `platform` | string | yes | Delivery platform: `slack` or `teams`. |
+| `workspace_id` | string | yes | Target Slack/Teams workspace for routing. |
+| `command` | string | no | Slash-command app to route to (e.g. `/spore`) — disambiguates multiple registered apps. |
+| `dns_name` | string | no | The instance's spore.host FQDN, when DNS registration is enabled. |
+| `detail` | string | no | Free-text detail for the event (e.g. completion status/message). |
+| `instance_identity_document` / `instance_identity_signature` / `pkcs7` | string | no | AWS instance identity attestation — proves the event genuinely originates from the named instance. |
+
+```json
+{
+  "event_type": "completion",
+  "instance_name": "bert-finetune",
+  "instance_id": "i-0abc123def456xyz",
+  "region": "us-east-1",
+  "platform": "slack",
+  "workspace_id": "T03ABCDEF",
+  "command": "/spore",
+  "dns_name": "bert-finetune.5k0zfnmq.spore.host",
+  "detail": "1000 parameter combinations done"
+}
+```
+
+::: tip Fire-and-forget delivery
+Notifications are sent fire-and-forget: a slow or unavailable endpoint **never**
+delays or cancels the underlying lifecycle action. Don't rely on a notification
+being received as a precondition for a stop/terminate having happened.
+:::
+
+## Channel webhooks
+
+Beyond the routed Slack/Teams DMs, you can post events to a shared Slack channel
+webhook — set it with `spawn notify --webhook-url https://hooks.slack.com/...` (or
+captured automatically during the Add-to-Slack OAuth flow). All events for any
+instance in that workspace post to the channel. Today there is no per-event filter;
+all events route to all subscribers. See
+[Lifecycle Notifications](/guides/notifications).
+
+## Verifying event authenticity
+
+When present, the `instance_identity_document` + `instance_identity_signature`
+(and `pkcs7`) fields carry AWS's signed EC2 instance identity, letting the receiver
+confirm the event really came from the instance it names rather than a spoofed
+caller. The hosted spore-bot Lambda verifies these before acting.
+
+## Related
+
+- **[Lifecycle Events](/reference/lifecycle-events)** — triggers, timing, messages
+- **[Lifecycle Notifications](/guides/notifications)** — enabling delivery
+- **[EC2 Tags](/reference/ec2-tags)** — the `spawn:notify-*` tags that configure delivery

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,57 @@
+---
+description: "Definitions of the core spore.host terms — and the one canonical noun for a managed machine."
+---
+
+# Glossary
+
+spore.host's names are deliberately close (spore, spawn, spored, spore-bot), which
+makes the family cohere but can blur which word means what. This page fixes the
+vocabulary.
+
+## The canonical noun
+
+**instance** — the canonical word for a machine spore.host manages. When you need
+to disambiguate from a raw EC2 instance you launched some other way, say
+**spore.host-managed instance** (or *managed instance*). Prefer "instance"
+throughout; avoid using "spore" as a noun for a machine.
+
+## Tools
+
+| Term | What it is |
+|------|-----------|
+| **spore.host** | The project and the toolkit as a whole. Also the domain. Not a hosted service — see [Security, credentials & data flow](/architecture). |
+| **truffle** | The discovery CLI: find instance types, compare prices, check quotas. Read-only. |
+| **spawn** | The launcher CLI: launches instances and provisions spored onto them; manages their lifecycle from your laptop. |
+| **spored** | The lifecycle *daemon* that runs on each launched instance and enforces its rules from the inside. You never install it — spawn provisions it. |
+| **spore-bot** | The Slack/Teams integration for controlling instances from chat. |
+| **lagotto** | The capacity watcher: waits for scarce capacity and notifies or launches when it appears. |
+| **spore-host-mcp** | The MCP server exposing truffle and spawn to AI assistants. |
+
+## Lifecycle concepts
+
+| Term | Definition |
+|------|-----------|
+| **TTL** (time to live) | The absolute deadline, set once at launch, at which the instance terminates. It never resets across stop/wake cycles; only `spawn extend` moves it, and only forward. The hard backstop. See [Costs & safety guarantees](/safety). |
+| **idle timeout** | A *soft* rule: stop or hibernate after a period with no activity. Any activity resets it. Idle never terminates — it only stops/hibernates. Not the same as the TTL. |
+| **completion signal** | An explicit "my work is done" marker — a sentinel file (default `/tmp/SPAWN_COMPLETE`) or `spored complete`. Triggers the configured `on-complete` action. |
+| **completion sentinel** | The file spored watches for the completion signal. Its *appearance* — not your command merely finishing — is what triggers the action. |
+| **pre-stop hook** | A shell command spored runs before any lifecycle-triggered stop or terminate, to save work (e.g. `aws s3 sync /results s3://…`). |
+| **cost limit** | An optional spend ceiling; spored terminates when accumulated cost crosses it. |
+| **reaper** | The out-of-band backstop that terminates managed instances past their TTL even if spored is unhealthy. See [Costs & safety guarantees](/safety). |
+
+## Compute-shape concepts
+
+| Term | Definition |
+|------|-----------|
+| **job array** | A group of related instances launched and managed together. See [Job arrays](/guides/job-arrays). |
+| **parameter sweep** | Running the same job across many parameter combinations in parallel. See [Parameter sweeps](/guides/parameter-sweeps). |
+| **MPI cluster** | Multiple tightly-coupled nodes launched together for distributed workloads. See [MPI clusters](/guides/mpi). |
+| **Capacity Block for ML** | A pre-purchased, time-boxed reservation of scarce GPU capacity. Launch into it at its start time with `lagotto launch --at`. See [Lagotto](/tools/lagotto#capacity-blocks-for-ml). |
+| **watch** | A Lagotto request to wait for capacity for a given instance type and act (notify/spawn/hold) when it appears. |
+
+## Common confusions
+
+For the pitfalls these terms cause — TTL vs idle timeout, `find` vs `search`,
+region vs AZ, quota vs actual capacity, stop vs hibernate vs terminate, a command
+finishing vs the completion sentinel appearing — see
+[Troubleshooting & common mistakes](/reference/troubleshooting).

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,0 +1,101 @@
+---
+description: "The distinctions that trip people up — find vs search, TTL vs idle, quota vs capacity — and how to get them right."
+---
+
+# Troubleshooting & common mistakes
+
+Most spore.host surprises come from a handful of pairs that look interchangeable
+but aren't. Each entry below is a mistake, why it happens, and the fix.
+
+## `truffle find` vs `truffle search`
+
+**Mistake:** expecting `--min-vcpu`/`--min-memory` to work on `find`, or expecting
+`find` and `search` to be synonyms.
+
+- **`find`** is *natural-language discovery* — put specs **in the query string**:
+  `truffle find "epyc genoa 16 cores"`. It does **not** accept `--min-vcpu` etc.
+- **`search`** is *exact filtering* over a pattern — flags work here:
+  `truffle search "m8a.*" --min-vcpu 16 --min-memory 64`.
+
+Use `find` when you know what you need in human terms; use `search` when you know
+the exact technical filters. See [Truffle](/tools/truffle).
+
+## Region vs Availability Zone
+
+**Mistake:** treating a region and an AZ as the same scope. Capacity, and some
+launches (Capacity Blocks), are **AZ-specific**. A type available in `us-east-1`
+generally may still be unplaceable in `us-east-1a`. Use `truffle az` to inspect
+per-AZ offerings and pass `--az` when placement must be pinned.
+
+## Quota vs actual capacity
+
+**Mistake:** assuming that because `truffle quotas` shows headroom, AWS will place
+the instance. Quota is *permission* to launch; capacity is *availability right
+now*. They're independent — you can be within quota and still get
+`InsufficientInstanceCapacity`. That's exactly the gap [Lagotto](/tools/lagotto)
+fills. See [Waiting for scarce capacity](/guides/waiting-for-capacity).
+
+## stop vs hibernate vs terminate
+
+| Action | Compute billing | EBS kept | RAM preserved | Reversible |
+|--------|-----------------|----------|---------------|-----------|
+| **stop** | stops | yes | no | `spawn start` |
+| **hibernate** | stops | yes | yes (restored on start) | `spawn start` |
+| **terminate** | stops | **no** — volume destroyed | no | no |
+
+**Mistake:** `terminate` to "pause" a job — it destroys the EBS volume and its
+data. Use `stop`/`hibernate` to pause; `terminate` only when you're done.
+
+## TTL vs idle timeout
+
+**Mistake:** thinking either one alone will save you. **TTL** is the absolute,
+non-resettable deadline (the hard guarantee). **Idle timeout** is a soft early
+stop that any activity resets, and it never *terminates* — only stops/hibernates.
+You typically want both. See [Costs & safety guarantees](/safety).
+
+## Spot interruption vs idle shutdown
+
+**Mistake:** conflating the two. A **Spot interruption** is AWS reclaiming the
+instance (a 2-minute notice, outside your control); **idle shutdown** is spored
+stopping an instance *you* left inactive. Different triggers, different handling —
+set a `pre-stop` hook to save work for both.
+
+## Restarting a stopped instance whose TTL already passed
+
+**Mistake:** stopping an instance to "bank" its remaining time. The TTL is an
+*absolute* deadline — if it elapsed while the instance was stopped, starting it
+again will terminate it shortly after. Run `spawn extend` **before** starting if
+you need more time.
+
+## A command finishing vs the completion sentinel appearing
+
+**Mistake:** expecting `on-complete` to fire because your script exited. spored
+acts on the **completion sentinel** (`/tmp/SPAWN_COMPLETE` or `spored complete`) —
+*not* on your process exiting. Your job script must create it explicitly:
+
+```sh
+./run-job.sh && spored complete --status success
+```
+
+## Instance role vs your user credentials
+
+**Mistake:** assuming a launched instance inherits your laptop's AWS permissions.
+It doesn't — it uses its **instance profile** (IAM role). If spored can't manage
+the instance (e.g. call `ec2:TerminateInstances` on itself) or your job can't
+reach S3, the instance profile is usually the missing piece. See
+[IAM Permissions](/reference/iam-permissions).
+
+## Local CLI vs remote spored timing
+
+**Mistake:** expecting a tag or config change to take effect instantly. Some
+actions are immediate API calls from spawn; others (idle, TTL, completion) are
+enforced by **spored, which re-reads the instance's tags about once a minute**. A
+`spawn instance-config` change can take up to a minute to be observed on the
+instance. Use `spored reload` on the instance to force an immediate re-read.
+
+## Still stuck?
+
+- **[FAQ](/reference/faq)** — higher-level questions
+- **[Glossary](/reference/glossary)** — precise definitions
+- **[Lifecycle Events](/reference/lifecycle-events)** — what warnings fire and when
+- Logs on the instance: `journalctl -u spored -f`

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,0 +1,106 @@
+---
+description: "The auto-terminate promise, its failure boundaries, and how to estimate what a run will cost before you launch."
+---
+
+# Costs & safety guarantees
+
+The core promise of spore.host is consequential: **every instance manages its own
+lifecycle and stops when it should**. This page states exactly what that guarantee
+covers, where it can fail, how the failure is caught, and how to estimate the cost
+of a run *before* you launch it.
+
+## The guarantee, precisely
+
+Three independent rules can end an instance's life, in strict priority:
+
+| Rule | What it is | Can it be reset? |
+|------|-----------|------------------|
+| **TTL** | An absolute deadline set once at launch. | **No.** It never moves across stop/wake cycles. Only `spawn extend` changes it, and only forward. |
+| **Cost limit** | Terminate when accumulated spend crosses a ceiling. | Set at launch; advisory guard. |
+| **Idle timeout** | Stop or hibernate after a period of no activity. | Yes — any activity resets the timer. Idle **never terminates**; it only stops/hibernates. |
+
+The key invariant: **TTL always wins.** Idle detection is a soft, early
+cost-saver; the TTL is the hard backstop that guarantees the instance dies even if
+idle detection is misconfigured, disabled, or fooled by a busy-looping process.
+
+::: tip Restarting a stopped instance whose TTL already passed
+Because the TTL is an absolute deadline, a stopped instance whose deadline elapsed
+while it was stopped will terminate shortly after you start it again — starting it
+does not grant fresh time. Use `spawn extend` first if you need more.
+:::
+
+## Where it can fail — and the backstop
+
+spored enforces the lifecycle from inside the instance. That's robust (it survives
+your laptop closing), but it means the guarantee has boundaries. Here's each
+failure mode and what catches it:
+
+| If… | …then | Caught by |
+|-----|-------|-----------|
+| spored fails to install at launch | the instance may not self-manage | spawn reports provisioning failure; the **reaper** still enforces TTL from the tags |
+| the instance can't reach AWS APIs | spored can't update cost tags or send events | TTL still fires locally; reaper is the backstop |
+| the instance profile / IAM role is missing | spored can't call `ec2:TerminateInstances` on itself | the out-of-band **reaper** terminates it |
+| the tags are changed or removed | lifecycle rules are lost | reaper flags instances missing required `spawn:*` tags |
+| the spored daemon crashes | no in-instance enforcement | reaper enforces the deadline from the tags |
+
+The **reaper** is an out-of-band backstop that reads the same `spawn:ttl-deadline`
+tag and terminates any managed instance past its deadline, independent of whether
+spored is healthy. This is why lifecycle enforcement doesn't depend on a single
+point of failure: the instance enforces its own deadline *and* an external sweep
+enforces it too.
+
+## Verify enforcement is healthy
+
+Don't take it on faith — confirm it, especially the first few times:
+
+```sh
+# From your laptop: TTL countdown proves the deadline tag is set and live
+spawn status my-instance
+
+# On the instance (over SSH): the enforcing daemon is up
+sudo systemctl status spored     # want: active (running)
+spored status                    # shows TTL, idle, cost, pre-stop hook
+```
+
+To find instances that are **not** being managed correctly — no `spawn:*` tags, or
+missing a deadline — audit with `spawn list` and the tag query in
+[Security, credentials & data flow](/architecture#how-to-audit-everything-it-creates).
+
+## Estimating cost before you launch
+
+The safety promise is ultimately about money. You can bound the worst case up
+front, because the TTL caps compute time and truffle knows the rate.
+
+**Worked example — an 8-hour analysis box:**
+
+```sh
+truffle spot m8a.4xlarge --regions us-east-1   # get the rate
+spawn launch analysis --instance-type m8a.4xlarge --ttl 8h --idle-timeout 30m
+```
+
+| Quantity | Value |
+|----------|-------|
+| Instance | `m8a.4xlarge` |
+| On-demand rate | ~$0.77/hr (example — check `truffle spot`) |
+| TTL | 8h |
+| **Maximum compute charge** (before storage/network) | **8 × $0.77 ≈ $6.16** |
+| Idle timeout | 30m |
+| Likely charge if work finishes in ~2h | ~2.5h × $0.77 ≈ **$1.93** |
+
+The TTL is the ceiling you *cannot* exceed; the idle timeout is what usually stops
+you well below it. Storage (EBS) and data transfer are billed separately and are
+typically small next to compute for short runs — see `spawn cost` for the running
+breakdown once an instance is live:
+
+```sh
+spawn cost analysis        # compute + storage + network, effective rate, budget status
+```
+
+Set a hard money ceiling with `--cost-limit` at launch if you want spend, not just
+time, to be the terminating rule.
+
+## Next steps
+
+- **[Security, credentials & data flow](/architecture)** — what runs where
+- **[Spored](/tools/spored)** — the daemon that enforces all of this
+- **[Lifecycle Events](/reference/lifecycle-events)** — the warnings you get before anything stops

--- a/docs/tools/lagotto.md
+++ b/docs/tools/lagotto.md
@@ -2,9 +2,26 @@
 description: "Lagotto watches for EC2 instance capacity and acts when it appears."
 ---
 
-# Lagotto
+# Lagotto <span class="doc-badge advanced">Advanced</span> <span class="doc-badge stable">Stable</span>
 
-Lagotto watches for EC2 instance capacity and acts when it appears. It runs as a serverless Lambda function — no always-on server required. Configure a watch, deploy, and Lagotto polls on a schedule until it can launch what you asked for.
+**What it is.** Lagotto watches for EC2 instance capacity and acts when it appears.
+It runs as a serverless Lambda in **your own account** — no always-on server.
+
+**When to use it.** When the type you want is within quota but has no capacity
+*right now* (scarce GPU families like `p5.48xlarge`), or when you need a launch to
+fire at a future clock time (e.g. into a Capacity Block). Answers the question
+truffle and a one-shot spawn can't: *"should I keep checking until it's placeable?"*
+
+**First commands:**
+
+```sh
+lagotto deploy                                   # stand up the watcher (once)
+lagotto watch "p5.48xlarge" --regions us-east-1,us-west-2 --action notify --ttl 7d
+lagotto list                                     # see active watches
+lagotto status <watch-id>
+```
+
+New to it? Walk through [Waiting for scarce capacity](/guides/waiting-for-capacity).
 
 There is no AWS API that reports "capacity is available right now" — the only true test is an actual launch. So for `spawn` watches **the launch attempt is the capacity test**: Lagotto tries to launch, and if AWS returns `InsufficientInstanceCapacity` it simply keeps the watch active and tries again on the next poll. It does the tedious retrying for you instead of you sitting there re-running a launch by hand, until it succeeds or the watch's TTL expires.
 

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -2,9 +2,16 @@
 description: "The spore.host MCP server exposes truffle and spawn as tools for AI assistants that support the Model Context Protocol — including Claude Desktop and Cursor."
 ---
 
-# MCP Server
+# MCP Server <span class="doc-badge automation">Automation</span> <span class="doc-badge stable">Stable</span>
 
-The spore.host MCP server exposes truffle and spawn as tools for AI assistants that support the [Model Context Protocol](https://modelcontextprotocol.io) — including Claude Desktop and Cursor.
+**What it is.** The spore.host MCP server exposes truffle and spawn as tools for AI
+assistants that support the [Model Context Protocol](https://modelcontextprotocol.io)
+— including Claude Desktop and Cursor.
+
+**When to use it.** When you'd rather describe what you need in plain language —
+*"find the cheapest A100 in us-east-1 and launch one with a 4-hour limit"* — and
+let the assistant run the commands, instead of typing them yourself. It runs
+locally with your AWS credentials, the same trust model as the CLIs.
 
 ## Install
 

--- a/docs/tools/spawn.md
+++ b/docs/tools/spawn.md
@@ -2,9 +2,63 @@
 description: "Spawn launches EC2 instances and manages their full lifecycle."
 ---
 
-# Spawn
+# Spawn <span class="doc-badge beginner">Beginner</span> <span class="doc-badge stable">Stable</span>
 
-Spawn launches EC2 instances and manages their full lifecycle. It provisions the spored daemon on each instance, which handles auto-termination, idle detection, DNS, and lifecycle notifications independently of your laptop.
+**What it is.** Spawn launches EC2 instances and manages their full lifecycle. It
+provisions the [spored](/tools/spored) daemon onto each instance, which then
+enforces auto-termination, idle detection, DNS, and notifications **independently
+of your laptop**.
+
+**When to use it.** Whenever you want to actually *run* something — from a single
+scratch box to a production-scale sweep. Start with one machine; the same tool
+scales up when you need it.
+
+**First commands:**
+
+```sh
+spawn                                  # interactive wizard (no flags needed)
+spawn launch analysis --instance-type m8a.4xlarge --ttl 8h
+spawn connect analysis                 # SSH in
+spawn status analysis                  # state, cost, TTL countdown
+spawn terminate analysis               # tear it down
+```
+
+## Spawn vs spored — what runs where
+
+Spawn is the **client** on your laptop; spored is the **agent** on the instance.
+Some actions are immediate API calls from spawn; others happen later because
+spored re-reads the instance's EC2 tags about once a minute.
+
+```
+Your computer                     AWS EC2 instance
+  spawn  ── launch/provision ──▶   spored (reads spawn:* tags every ~1 min)
+         ── extend / config ──▶      ├─ TTL, idle, completion, cost
+                                     └─ stop / hibernate / terminate + notify
+```
+
+So `spawn extend` changes the deadline *immediately* (an API/tag write), but an
+idle-timeout or completion action is enforced by spored on its next check. Full
+picture: [Security, credentials & data flow](/architecture).
+
+## The three tiers of spawn
+
+Spawn is far more capable than "launch one instance." Learn it in tiers — you only
+need Tier 1 to be productive:
+
+**Tier 1 — One machine** <span class="doc-badge beginner">Beginner</span>
+: `launch` → `connect` → run → `status` → `extend` → `stop`/`terminate`. Start at
+[Your first instance](/guides/first-instance).
+
+**Tier 2 — Managed workload** <span class="doc-badge automation">Automation</span>
+: add `--command`, a completion signal, `--idle-timeout`, `--cost-limit`, and
+lifecycle notifications so a job runs and cleans up unattended (Story B in [Common
+Workflows](/guides/)).
+
+**Tier 3 — Parallel & production scale** <span class="doc-badge advanced">Advanced</span> <span class="doc-badge hpc">HPC</span>
+: [job arrays](/guides/job-arrays), [parameter sweeps](/guides/parameter-sweeps),
+[MPI clusters](/guides/mpi), autoscaling, [workflow engines](/guides/workflow-engines),
+images/snapshots, and Capacity Blocks. The [command reference](/tools/reference/spawn)
+is the exhaustive map of this tier.
 
 ## Install
 
@@ -229,6 +283,22 @@ single instance and, via `spawn sweep status --check-complete`, for sweeps):
 # Exit 0=complete, 1=failed, 2=running, 3=error
 while spawn status my-job --check-complete; [ $? -eq 2 ]; do sleep 30; done
 ```
+
+## Common mistakes
+
+- **`terminate` to "pause" a job.** Terminate destroys the EBS volume and its data — use `stop`/`hibernate` to pause. See [stop vs hibernate vs terminate](/reference/troubleshooting#stop-vs-hibernate-vs-terminate).
+- **Expecting `--on-complete` to fire when your command exits.** spored acts on the *completion sentinel*, not on your process exiting — call `spored complete` (or `touch /tmp/SPAWN_COMPLETE`) explicitly.
+- **Restarting a stopped instance whose TTL already passed.** The TTL is absolute; `spawn extend` first if you need more time.
+- **`--region` vs `--regions`.** spawn takes one `--region`; truffle takes plural `--regions` (see above).
+
+Full list: [Troubleshooting & common mistakes](/reference/troubleshooting).
+
+## How it connects
+
+[Truffle](/tools/truffle) tells spawn *what* to launch; spawn launches it and
+provisions [spored](/tools/spored), which enforces the lifecycle from the instance.
+[Lagotto](/tools/lagotto) can drive `spawn` when it's waiting on capacity, and
+[spore-bot](/tools/spore-bot) lets you control spawn-launched instances from chat.
 
 ## Full command reference
 

--- a/docs/tools/spore-bot.md
+++ b/docs/tools/spore-bot.md
@@ -2,9 +2,19 @@
 description: "Spore-bot connects your Slack or Microsoft Teams workspace to your running instances."
 ---
 
-# Spore-bot
+# Spore-bot <span class="doc-badge automation">Automation</span> <span class="doc-badge stable">Stable</span>
 
-Spore-bot connects your Slack or Microsoft Teams workspace to your running instances. Any team member you've authorised can control instances from chat — without a terminal, without AWS credentials, from any device.
+**What it is.** Spore-bot connects your Slack or Microsoft Teams workspace to your
+running instances.
+
+**When to use it.** When you (or a collaborator) want to check on or control an
+instance without opening a terminal or holding AWS credentials — from a phone, a
+shared channel, or mid-meeting. Also how lifecycle notifications reach you as DMs.
+
+Any team member you've authorised can control instances from chat — without a
+terminal, without AWS credentials, from any device. Setup lives in the [Slack Setup
+guide](/guides/slack-setup); the trust model (cross-account role, per-user access)
+is in [Security, credentials & data flow](/architecture).
 
 ## What it does
 

--- a/docs/tools/spored.md
+++ b/docs/tools/spored.md
@@ -2,9 +2,22 @@
 description: "Spored is the lifecycle daemon that runs on every instance launched by spawn."
 ---
 
-# Spored
+# Spored <span class="doc-badge stable">Stable</span>
 
-Spored is the lifecycle daemon that runs on every instance launched by spawn. It's a small binary provisioned automatically at launch — you never install it manually. Its job is to enforce the instance's lifecycle: terminate on TTL, stop or hibernate on idle, act when your workload signals completion, and clean up DNS and notifications before the instance disappears.
+**What it is.** Spored is the lifecycle daemon that runs on every instance launched
+by spawn. It's a small binary provisioned automatically at launch — **you never
+install or run it manually**.
+
+**When you meet it.** You don't invoke spored from your laptop; spawn provisions it
+and it works on its own. You only interact with it directly when debugging *on* an
+instance (`sudo systemctl status spored`, `spored status`, `spored complete`).
+
+**Why it matters.** It's the reason auto-termination survives your laptop closing:
+spored enforces the lifecycle from *inside* the instance — terminate on TTL, stop
+or hibernate on idle, act on a completion signal, and clean up DNS/notifications
+before the instance disappears. Its rules come from the instance's EC2 tags, which
+it re-reads about once a minute. See [Costs & safety guarantees](/safety) for what
+happens if spored itself fails.
 
 ## What spored does
 

--- a/docs/tools/truffle.md
+++ b/docs/tools/truffle.md
@@ -2,9 +2,33 @@
 description: "Truffle finds and compares EC2 instance types."
 ---
 
-# Truffle
+# Truffle <span class="doc-badge beginner">Beginner</span> <span class="doc-badge stable">Stable</span>
 
-Truffle finds and compares EC2 instance types. It's read-only — it never launches anything. Use it to research what's available before committing to a launch.
+**What it is.** Truffle finds and compares EC2 instance types. It's read-only — it
+never launches anything.
+
+**When to use it.** Any time *before* a launch, to answer "what should I run and
+what will it cost?" — discover a family, filter by exact specs, compare Spot
+prices, and confirm your quota so a launch doesn't fail after you've waited.
+
+**First commands:**
+
+```sh
+truffle find "amd genoa 64gb"          # discover a family in plain language
+truffle search "m8a.*" --min-vcpu 16   # filter by exact specs
+truffle spot m8a.4xlarge               # compare Spot prices across regions
+truffle quotas --regions us-east-1 --family M   # confirm you can launch it
+truffle az p5.48xlarge                 # check per-AZ availability
+```
+
+::: tip Which command? find vs search vs spot vs quotas
+- **`find`** — you know what you need *in human terms* ("amd genoa 64gb"). Put specs in the query string; filter flags like `--min-vcpu` don't apply here.
+- **`search`** — you know the *exact technical filters*: `search "m8a.*" --min-vcpu 16 --min-memory 64`.
+- **`spot`** — you've picked a type and want to compare purchase options / regions.
+- **`quotas`** — run immediately before launch, so you don't wait for capacity you're not allowed to use.
+
+`find` and `search` are **not** synonyms — see [Common mistakes](#common-mistakes).
+:::
 
 ## Install
 
@@ -161,6 +185,21 @@ lagotto launch --at <block-start> --az <block-az> --spawn-config block.yaml
 ```
 
 Truffle stays read-only throughout — the purchase (a real-money, non-refundable write) lives in spawn behind its confirmation gates.
+
+## Common mistakes
+
+- **Treating `find` and `search` as synonyms.** `find` is natural-language (specs go *in the query*); `search` is pattern + flags (`--min-vcpu`). Filter flags don't exist on `find`.
+- **Confusing region and AZ.** A type available in a region generally can still be unplaceable in a specific AZ — use `truffle az` and pin with `--az` when it matters.
+- **Assuming quota means capacity.** `truffle quotas` shows *permission* to launch, not *availability right now*. You can be within quota and still get `InsufficientInstanceCapacity` — that's what [Lagotto](/tools/lagotto) is for.
+
+See [Troubleshooting & common mistakes](/reference/troubleshooting) for the full list.
+
+## How it connects
+
+Truffle is the read-only front of the workflow: it tells you *what to run*.
+[Spawn](/tools/spawn) takes that and launches it (pipe with `--pick-first`, above).
+When the type you want has no capacity right now, [Lagotto](/tools/lagotto) waits
+for it. Truffle never launches or spends money.
 
 ## Full command reference
 

--- a/web/README.md
+++ b/web/README.md
@@ -20,7 +20,7 @@ web/
 ### Landing Page
 - Hero section with adaptive logo
 - Installation instructions (Homebrew, Scoop, Manual)
-- Feature showcase for Truffle, Spawn, Spored
+- Feature showcase for all six tools: Truffle, Spawn, Spored, Lagotto, Spore-bot, and the MCP server
 - Key features grid
 - Usage examples
 - Coming Soon section for web dashboard

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -30,6 +30,8 @@
   --bot-bg:       #f5f3ff;
   --mcp:          #4264F5;   /* brand blue variant               */
   --mcp-bg:       #eef0ff;
+  --spored:       #059669;   /* emerald — lifecycle / self-healing */
+  --spored-bg:    #ecfdf5;
 
   --code-bg:      #f3f4f6;
   --terminal-bg:  #f3f4f6;
@@ -65,6 +67,7 @@
   --lagotto-bg:   #082030;
   --bot-bg:       #1a0d30;
   --mcp-bg:       #12103a;
+  --spored-bg:    #052e22;
 
   --code-bg:      #1a0e28;
   --terminal-bg:  #1a0e28;
@@ -328,6 +331,8 @@ h2.section-title {
 .tool-bot     .tool-link { color: var(--bot); }
 .tool-mcp     .tool-tag { background: var(--mcp-bg);     color: var(--mcp);     }
 .tool-mcp     .tool-link { color: var(--mcp); }
+.tool-spored  .tool-tag { background: var(--spored-bg); color: var(--spored); }
+.tool-spored  .tool-link { color: var(--spored); }
 
 /* ── Demo ── */
 #demo-player { border-radius: var(--radius); overflow: hidden; max-width: 900px; margin-top: 0.5rem; margin-bottom: 0; }
@@ -369,8 +374,17 @@ code { font-size: 0.875em; }
   align-items: start;
 }
 .dev-block { display: flex; flex-direction: column; gap: 1rem; }
-.dev-block h3 { font-size: 1.05rem; font-weight: 700; }
+.dev-block h3 { font-size: 1.05rem; font-weight: 700; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
 .dev-block p { font-size: 0.9rem; color: var(--text-muted); line-height: 1.6; }
+
+/* Status badge for dev-block headings (e.g. Beta on the HTTP API). Amber tint
+   distinguishes not-yet-public surfaces from the "Available now" library/SDK. */
+.dev-badge {
+  display: inline-block; font-size: 0.65rem; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  padding: 0.15rem 0.45rem; border-radius: 4px; white-space: nowrap;
+}
+.dev-badge.beta { background: var(--truffle-bg); color: var(--truffle); }
 
 .coming-soon-card {
   border: 1px dashed var(--border-strong);

--- a/web/index.html
+++ b/web/index.html
@@ -49,6 +49,7 @@
         <p class="hero-sub">
           Find the right EC2 instance. Launch it in minutes. Auto-terminate when your job is done.
           Built for researchers and data scientists, not ops engineers.
+          It runs on <strong>your own AWS account</strong> — there's no new compute provider to sign up for, and you pay AWS only for what you use.
         </p>
         <div class="hero-props">
           <span>Avoid surprise bills</span>
@@ -73,7 +74,7 @@
     <section id="tools">
       <div class="container">
         <p class="section-label">The tool suite</p>
-        <h2 class="section-title">Five tools. One workflow.</h2>
+        <h2 class="section-title">Six tools. One workflow.</h2>
         <p class="section-sub">Each tool has exactly one job. Together they cover the full lifecycle of ephemeral compute.</p>
 
         <div class="tool-grid">
@@ -102,6 +103,19 @@
               <li>Spot, GPU, MPI clusters, parameter sweeps</li>
             </ul>
             <a href="https://github.com/spore-host/spawn" class="tool-link" target="_blank" rel="noopener">spawn docs</a>
+          </div>
+
+          <div class="tool-card tool-spored">
+            <span class="tool-tag">Lifecycle daemon</span>
+            <h3>Spored</h3>
+            <p>The small agent that runs on every launched instance and enforces its lifecycle from the inside — so nothing depends on your laptop staying open. You never install it: spawn provisions it automatically.</p>
+            <ul class="tool-features">
+              <li>Enforces the TTL hard deadline</li>
+              <li>Idle detection — CPU, network, processes, sessions</li>
+              <li>Fires completion, TTL-warning, and idle events</li>
+              <li>Runs pre-stop hooks to save work before shutdown</li>
+            </ul>
+            <a href="https://docs.spore.host/tools/spored" class="tool-link" target="_blank" rel="noopener">spored docs</a>
           </div>
 
           <div class="tool-card tool-lagotto">

--- a/web/library.html
+++ b/web/library.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>For Developers — spore.host</title>
-  <meta name="description" content="Use spore.host as a Go library, the Python SDK (pip install spore-host), or via the MCP server. Hosted REST API coming soon.">
+  <meta name="description" content="Use spore.host as a Go library, the Python SDK (pip install spore-host), or via the MCP server. The HTTP API is in beta and used by the SDK.">
   <script>(function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}());</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -45,7 +45,7 @@
           The truffle and spawn packages are clean, importable Go libraries. Use them in your own tools,
           scripts, or services — no CLI subprocess calls required.
           The MCP server ships as a ready-to-use integration for AI assistants.
-          The Python SDK is available now (<code>pip install spore-host</code>); the hosted REST API is on the roadmap.
+          The Python SDK is available now (<code>pip install spore-host</code>) and talks to spore.host's HTTP API, which is currently in beta — the SDK is the supported entry point; direct HTTP access is not yet a supported public interface.
         </p>
       </div>
     </div>
@@ -228,8 +228,8 @@ inst.wait("terminated", on_status=lambda i: print(i.state))</code></pre>
           </div>
 
           <div class="dev-block">
-            <h3>REST API</h3>
-            <p>A language-agnostic HTTP API over truffle and spawn — the foundation for the Python SDK and future R/Julia bindings.</p>
+            <h3>HTTP API <span class="dev-badge beta">Beta</span></h3>
+            <p>A language-agnostic HTTP API over truffle and spawn — the foundation the Python SDK builds on, and the basis for future R/Julia bindings. It's in beta and used through the SDK; the endpoints below are shown for orientation, not as a stable public contract yet. Use the <a href="https://docs.spore.host/guides/python-sdk">Python SDK</a> for supported programmatic access today.</p>
 <pre><code>GET  /v1/instances              # list
 POST /v1/instances              # launch
 GET  /v1/instances/{id}         # status


### PR DESCRIPTION
Implements an external reviewer's feedback: the docs had grown into a broad research-compute platform but were still organized like three small CLIs, organized by product structure rather than user intent, with several site-level inconsistencies that eroded trust.

## What changed

**Cross-cutting fixes**
- **Five → six tools:** marketing site now says "Six tools" and includes a **Spored** card (new `.tool-spored` accent). `web/README.md` destaled.
- **HTTP API = beta, consistently:** dropped "coming soon / on the roadmap" from `web/library.html`, added an inline **Beta** badge to the endpoint block, reconciled `guides/python-sdk` + `guides/self-hosting`.
- **"Not itself the host":** hero, docs home, and How It Works now state up front that it runs on your own AWS account with your own credentials.

**Nav restructure** (`.vitepress/config.mts`): one global sidebar — Introduction → Start Here → Common Workflows → Tools → Automation → Chat & AI Control → Administration → Reference. `writeLlmsTxt` rewritten to walk it, so `llms.txt` stays in lockstep.

**New pages**
- `architecture.md` — what-runs-where trust/data-flow model
- `safety.md` — auto-terminate failure boundaries + pre-launch cost estimation
- `guides/waiting-for-capacity.md` — the missing Lagotto first-use tutorial
- `reference/glossary.md`, `reference/troubleshooting.md`, `reference/event-schemas.md`
- `guides/index.md` reframed as three narrative user stories

**Per-tool upgrades:** consistent *What it is / When to use / First commands* trio on all six tool pages; Truffle find-vs-search decision box; Spawn three-tier map + spawn-vs-spored "what runs where" diagram; new WCAG-AA `.doc-badge.*` audience/maturity badges (light + dark).

## Verification
- `npx vitepress build` is clean — VitePress fails on dead links, so all internal links resolve.
- `llms.txt` regenerates with the new IA; `grep` confirms no "five tools" and no "coming soon"/"roadmap" remain.
- Commands/flags in new prose checked against the vendored generated reference; event-schema page grounded in the real `notifyRequest` struct.

Docs/site-only — no code, no AWS actions.

> Worth a human sanity-check before merge: the exact `--spawn-config` YAML keys in the Lagotto tutorial against a live run.