### PR TITLE
docs: restructure extension/workflow docs as an execution fabric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,48 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **Docs: execution-fabric restructure (plugins & workflow adapters).** Following a
+  second review of the extension subsystem, regrouped the docs so spawn reads as an
+  execution substrate with four extension layers — **Extend an instance** (instance
+  plugins), **Run many jobs** (sweeps, arrays), **Coordinate multiple steps**
+  (instance queues, pipelines, MPI), and **Workflow adapters** — instead of a flat
+  "Advanced" list. New page **[Which execution tool?](https://docs.spore.host/guides/choosing-execution)**
+  with two decision matrices (layer→question, need→tool) plus per-task-EC2 fit
+  guidance. Renamed "Plugins"→"Instance plugins" and "Workflow Engines"→"Workflow
+  adapters" (CLI flags unchanged).
+- **Docs: parameter-sweeps now document existing concurrency/recovery controls** —
+  `--max-concurrent`, `--budget`, `spawn sweep resume` (checkpoint), and
+  `spawn sweep collect`, which the guide previously omitted.
+- **Docs: instance-queue operational detail** — per-job `retry`/`env`/`result_paths`
+  fields, per-job log paths, resume-skips-completed behavior, and Spot-interruption
+  guidance, all verified against the spored queue runner.
+
+### Changed
+- **Docs: corrected workflow-adapter maturity.** The overview no longer calls the
+  five engine integrations "first-class"; it now leads with a **status &
+  compatibility matrix** (nf-spawn = experimental prototype; miniwdl = early,
+  validation in progress; CWL/Snakemake/Airflow = v0.1.0 initial releases) and
+  distinguishes "native adapter" from "production-ready." Experimental badges added
+  to the Nextflow guide.
+- **Docs: job-array `--min-viable` semantics clarified** — `{total}`/`JOB_ARRAY_SIZE`
+  is the *requested* count and partial launches leave *sparse* indexes; shard
+  schemes must not assume a dense range.
+
+### Fixed
+- **Docs: pipeline manual example was misleading** — clarified that `--on-complete`
+  does not launch the next stage and that running `spawn launch` commands by hand
+  is not a pipeline (the Lambda orchestrator chains stages from the DAG definition).
+  Scoped `spawn pipeline` to coarse DAGs (not a scientific workflow engine) and
+  marked stream mode (tcp/grpc/zmq) Experimental with its operational caveats.
+- **Docs: instance-queue (batch-queue) sequencing contradiction** — stated plainly
+  that jobs run strictly one at a time in topological order and `depends_on` is
+  ordering only, not concurrency.
+- **Docs: added a plugin Trust & permissions section** — installing a plugin runs
+  its author's code locally and as root on the instance; documents what `github:`
+  refs resolve to, the minimal-env/`env_passthrough` limit, `spawn plugin validate`,
+  and links the tracked inspect/permissions gaps.
+
+### Added
 - **Docs: researcher-facing information-architecture overhaul.** Restructured the
   docs site around user intent instead of product structure, following an external
   review. New top-level nav: Introduction → Start Here → Common Workflows → Tools →

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -42,17 +42,47 @@ const sidebar = {
       collapsed: false,
       items: [
         { text: 'Overview', link: '/guides/' },
+        { text: 'Which execution tool?', link: '/guides/choosing-execution' },
         { text: 'Finding the right instance', link: '/guides/finding-instances' },
         { text: 'Interactive workstation', link: '/guides/jupyter' },
         { text: 'GPU training jobs', link: '/guides/gpu-training' },
         { text: 'Spot instances', link: '/guides/spot-instances' },
         { text: 'Managing instances & data', link: '/guides/managing-instances' },
+        { text: 'Waiting for scarce capacity', link: '/guides/waiting-for-capacity' },
+      ]
+    },
+    // The extension/execution-fabric layers, in the order a user climbs them:
+    // customize one instance → run many → coordinate steps → hand off to an engine.
+    {
+      text: 'Extend an instance',
+      collapsed: false,
+      items: [
+        { text: 'Instance plugins', link: '/guides/plugins' },
+      ]
+    },
+    {
+      text: 'Run many jobs',
+      collapsed: false,
+      items: [
         { text: 'Parameter sweeps', link: '/guides/parameter-sweeps' },
         { text: 'Job arrays', link: '/guides/job-arrays' },
-        { text: 'Batch queues', link: '/guides/batch-queue' },
+      ]
+    },
+    {
+      text: 'Coordinate multiple steps',
+      collapsed: false,
+      items: [
+        { text: 'Instance queues', link: '/guides/batch-queue' },
+        { text: 'Spawn pipelines', link: '/guides/pipelines' },
         { text: 'MPI clusters', link: '/guides/mpi' },
-        { text: 'Pipelines', link: '/guides/pipelines' },
-        { text: 'Waiting for scarce capacity', link: '/guides/waiting-for-capacity' },
+      ]
+    },
+    {
+      text: 'Workflow adapters',
+      collapsed: false,
+      items: [
+        { text: 'Overview & maturity', link: '/guides/workflow-engines' },
+        { text: 'Nextflow (nf-spawn)', link: '/guides/nextflow' },
       ]
     },
     {
@@ -77,9 +107,6 @@ const sidebar = {
       items: [
         { text: 'Python SDK', link: '/guides/python-sdk' },
         { text: 'Go libraries', link: '/guides/go-library' },
-        { text: 'Workflow engines', link: '/guides/workflow-engines' },
-        { text: 'Nextflow (nf-spawn)', link: '/guides/nextflow' },
-        { text: 'Plugins', link: '/guides/plugins' },
         { text: 'Events & webhooks', link: '/reference/event-schemas' },
       ]
     },

--- a/docs/guides/batch-queue.md
+++ b/docs/guides/batch-queue.md
@@ -1,18 +1,37 @@
 ---
-description: "A batch queue runs a sequence of dependent jobs on a single instance, automatically chaining them in order."
+description: "An instance queue runs a sequence of dependent jobs on a single instance, one at a time in dependency order. Launched with --batch-queue."
 ---
 
-# Batch Job Queues
+# Instance queues
 
-A batch queue runs a sequence of dependent jobs on a single instance, automatically chaining them in order. Unlike [pipelines](/guides/pipelines), which chain stages across separate instances, a batch queue runs all jobs on the same instance — useful when jobs need to share local data or a common environment.
+An **instance queue** runs several dependent jobs **on one instance, one at a time,
+in dependency order**. Unlike [pipelines](/guides/pipelines), which chain stages
+across *separate* instances, an instance queue keeps everything on the same
+machine — ideal when the steps share large local data, packages, model weights, or
+cached indexes and you don't want to pay to boot (and re-stage) a machine per step.
 
-## When to use a batch queue
+::: tip Name vs. flag
+This feature is launched with the `--batch-queue` flag and its config uses
+`queue_name` — we call the *concept* an "instance queue" because everything runs on
+one already-selected instance, not on a pool of workers waiting for jobs (which is
+what "batch queue" usually implies elsewhere). The flag name is unchanged.
+:::
+
+## Sequential, not parallel
+
+Jobs run **strictly one at a time**, in a topological order derived from
+`depends_on`. `depends_on` therefore controls *ordering* (and validates there are
+no cycles); it does **not** enable concurrency — two jobs never run at the same
+time on the instance, even if their dependencies would allow it. If you need stages
+to run concurrently on different machines, use a [pipeline](/guides/pipelines).
+
+## When to use an instance queue
 
 - Jobs that share large local datasets (avoid re-staging between instances)
 - Sequential steps where each step depends on the previous one's output
 - Workflows where spinning up a new instance per step is too slow or costly
 
-For jobs that can run in parallel or need different instance types per step, use [pipelines](/guides/pipelines) or [parameter sweeps](/guides/parameter-sweeps) instead.
+For stages that can run in parallel or need different instance types per step, use [pipelines](/guides/pipelines) or [parameter sweeps](/guides/parameter-sweeps) instead. Not sure? See [Which execution tool?](/guides/choosing-execution).
 
 ## Queue file format
 
@@ -54,9 +73,30 @@ Create a JSON file describing your jobs:
 | `job_id` | yes | Unique identifier for this job |
 | `command` | yes | Shell command to run |
 | `timeout` | no | Per-job timeout (e.g. `30m`, `4h`) |
-| `depends_on` | no | List of `job_id`s that must complete first |
+| `depends_on` | no | List of `job_id`s that must complete first (ordering only) |
+| `env` | no | Per-job environment variables (map) |
+| `retry` | no | Per-job retry policy (see below) |
+| `result_paths` | no | Files/globs to upload to S3 after the job succeeds |
 | `global_timeout` | no | Total timeout for the entire queue |
 | `on_failure` | no | `stop` (default) or `continue` on job failure |
+| `result_s3_bucket` / `result_s3_prefix` | no | Where per-job outputs and logs are uploaded |
+
+**Per-job `retry`:**
+
+```json
+"retry": {
+  "max_attempts": 3,
+  "backoff": "exponential-jitter",
+  "base_delay": "2s",
+  "max_delay": "5m",
+  "retry_on_codes": [1, 137],
+  "dont_retry_on_codes": [2]
+}
+```
+
+`backoff` is `fixed`, `exponential`, or `exponential-jitter`. Use `retry_on_codes`
+to retry only specific exit codes, or `dont_retry_on_codes` to never retry certain
+ones.
 
 ## Launch
 
@@ -67,19 +107,36 @@ spawn launch my-job \
   --ttl 8h
 ```
 
-spawn uploads the queue config to S3, launches the instance, and the spored daemon picks up and executes the jobs sequentially according to the dependency graph.
+spawn uploads the queue config to S3, launches the instance, and the spored daemon picks up and runs the jobs one at a time in dependency order.
 
-## Monitoring
+## Monitoring, logs, and recovery
+
+Each job's stdout and stderr are captured **per job** on the instance and uploaded
+to S3 alongside the queue's results:
 
 ```sh
-# Check instance status
-spawn status my-job
+spawn status my-job                                    # instance state
+spawn connect my-job -- tail -f /var/log/spored.log    # overall daemon log
 
-# Connect and watch logs
-spawn connect my-job -- tail -f /var/log/spored.log
-
-# The instance auto-terminates (or stops) when the queue completes
+# On the instance, per-job logs live at:
+#   /var/log/spored/jobs/<job_id>-stdout.log
+#   /var/log/spored/jobs/<job_id>-stderr.log
+# and (with result_s3_prefix set) upload to <prefix>/jobs/<job_id>/stdout.log
 ```
+
+The queue tracks per-job completion state, so a queue that was interrupted resumes
+from where it left off — **already-completed jobs are skipped** rather than re-run.
+On a job failure, `on_failure: stop` halts the queue (default) while `continue`
+moves on to the next job. The instance auto-terminates (or stops) when the queue
+completes.
+
+::: warning Spot interruption mid-queue
+On a Spot instance, an interruption ends the *machine* mid-queue. Because the whole
+queue runs on one instance, in-progress local state is lost unless a
+[`--pre-stop`](/guides/plugins#data-movement-patterns) hook or per-job
+`result_paths` has already synced it out. For work that must survive interruption,
+either run on-demand or checkpoint each job's outputs to S3 via `result_paths`.
+:::
 
 ## Example: ML training pipeline
 

--- a/docs/guides/choosing-execution.md
+++ b/docs/guides/choosing-execution.md
@@ -1,0 +1,75 @@
+---
+description: "spore.host has several ways to run more than one thing — plugins, sweeps, arrays, queues, pipelines, MPI, and workflow adapters. This page picks the right one."
+---
+
+# Which execution tool?
+
+Spawn is an execution substrate with several extension layers, and they solve
+**different** problems — they aren't ranked alternatives. Start here before diving
+into any individual guide; then follow the link.
+
+## The layers at a glance
+
+| Layer | The question it answers |
+|-------|-------------------------|
+| **[Instance plugin](/guides/plugins)** | What software or service should exist on an instance? |
+| **[Parameter sweep](/guides/parameter-sweeps)** | How do I run one command over varying parameters? |
+| **[Job array](/guides/job-arrays)** | How do I run indexed copies of the same workload? |
+| **[Instance queue](/guides/batch-queue)** | How do I run several dependent steps *sequentially on one machine*? |
+| **[Spawn pipeline](/guides/pipelines)** | How do I run a DAG of coarse stages *across different machines*? |
+| **[MPI cluster](/guides/mpi)** | How do I run tightly-coupled code across many nodes at once? |
+| **[Workflow adapter](/guides/workflow-engines)** | How does my existing workflow engine use spawn as its executor? |
+
+## By what you're trying to do
+
+| I want to… | Use |
+|------------|-----|
+| Install RStudio, Tailscale, or Globus on an instance | [Instance plugin](/guides/plugins) |
+| Run one command over several parameter values | [Parameter sweep](/guides/parameter-sweeps) |
+| Divide one dataset into indexed shards | [Job array](/guides/job-arrays) |
+| Run several steps on one instance (shared local data/env) | [Instance queue](/guides/batch-queue) |
+| Use different machines for a few coarse stages | [Spawn pipeline](/guides/pipelines) |
+| Run tightly-coupled parallel code (one job, many nodes) | [MPI cluster](/guides/mpi) |
+| Already have a Nextflow / WDL / CWL / Snakemake workflow | The [matching adapter](/guides/workflow-engines) |
+| Add one heavy compute step to a business/ETL DAG | [Airflow operator](/guides/workflow-engines) |
+| Run a large, complex scientific DAG | An established workflow engine via its [adapter](/guides/workflow-engines) — **not** a spawn pipeline |
+
+## The two easy-to-confuse pairs
+
+**Sweep vs. array.** A [sweep](/guides/parameter-sweeps) runs the same command over
+*different declared parameter values* (one instance per combination). An
+[array](/guides/job-arrays) runs the *same workload* with *index-based
+partitioning* — each member gets `{index}` and `{total}` and processes its own
+shard.
+
+**Instance queue vs. pipeline.** An [instance queue](/guides/batch-queue) runs
+multiple dependent steps **sequentially on one machine** — ideal when the steps
+share large local files, packages, or model weights and you don't want to pay to
+boot (and re-stage) a machine per step. A [pipeline](/guides/pipelines) runs a
+**DAG across separate machines**, so each stage can use different (and
+differently-sized) compute, with data handed off through S3.
+
+## When *not* to use a spawn pipeline
+
+`spawn pipeline` is a compact orchestrator for **small, coarse, infrastructure-shaped
+DAGs** — tens of stages, not millions of tasks. It deliberately does not do
+advanced caching, dynamic DAG generation, nested workflows, or a rich conditional
+language. For complex scientific pipelines (per-sample fan-out, scatter/gather,
+resume/caching semantics), use a real workflow engine through its
+[adapter](/guides/workflow-engines) and let spawn be the executor underneath.
+
+## When per-task ephemeral instances fit — and when they don't
+
+Every layer here launches (and pays to boot) at least one EC2 instance per unit of
+work. That's a great fit for some shapes and a poor one for others:
+
+- **Good fit:** tasks lasting tens of minutes to hours; heterogeneous resource
+  needs per task; full-VM requirements; expensive accelerators you only want for
+  the duration of the work.
+- **Poor fit:** thousands of sub-minute tasks; extremely chatty workflows; tasks
+  needing shared POSIX state; pipelines dominated by repeated environment setup.
+  For those, prefer an [instance queue](/guides/batch-queue) (batch the steps onto
+  one machine) or a standing cluster / AWS Batch.
+
+See also [Costs & safety guarantees](/safety) for how the TTL bounds the cost of
+any of these.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -10,6 +10,12 @@ into the deeper guides. New to spore.host? Do [Your first
 instance](/guides/first-instance) first; it's the 15-minute backbone the stories
 below build on.
 
+::: tip Running more than one thing?
+spore.host has several ways to run work at scale — instance plugins, sweeps,
+arrays, instance queues, pipelines, MPI, and workflow-engine adapters. If you're
+not sure which fits, start with **[Which execution tool?](/guides/choosing-execution)**.
+:::
+
 ## Story A — Interactive research workstation
 
 *"I need a big machine for a few hours to explore some data, then it should go

--- a/docs/guides/job-arrays.md
+++ b/docs/guides/job-arrays.md
@@ -62,6 +62,21 @@ complete. Because the members that *did* launch are cleaned up on failure, size
 defaults to `1` and is ignored for `--mpi` clusters (which need all ranks — see
 the [MPI guide](/guides/mpi)).
 
+::: warning `{total}` is the requested count, and indexes can be sparse
+`{total}` / `JOB_ARRAY_SIZE` is always the count you **requested** (`--count`), not
+the number that actually launched. If you ask for 8 with `--min-viable 6` and only
+6 land, each surviving member still sees `{total}` = 8, and the launched indexes
+are whatever subset succeeded (e.g. 0,1,2,4,5,7) — **there can be gaps**. So a
+shard scheme that assumes a dense `0…{total}-1` will skip the work of the missing
+indexes. If your job must cover every shard, either don't rely on `--min-viable`,
+or have the surviving members detect and redistribute the missing indexes.
+
+There isn't yet a first-class way to list which requested indexes failed, retry
+only those, or pull per-index logs (you manage members today via the generic
+`spawn list/status --job-array-name` shown above). That reporting is tracked in
+[spawn#389](https://github.com/spore-host/spawn/issues/389).
+:::
+
 ## Available template variables and environment variables
 
 Inside `--command`, you can use template substitutions:

--- a/docs/guides/nextflow.md
+++ b/docs/guides/nextflow.md
@@ -2,14 +2,20 @@
 description: "nf-spawn is a Nextflow executor plugin that dispatches each pipeline process step to its own ephemeral EC2 instance — purpose-sized and auto-terminated when…"
 ---
 
-# Nextflow Integration (nf-spawn)
+# Nextflow Adapter (nf-spawn) <span class="doc-badge experimental">Experimental</span>
 
 [nf-spawn](https://github.com/spore-host/nf-spawn) is a Nextflow executor plugin that dispatches each pipeline process step to its own ephemeral EC2 instance — purpose-sized and auto-terminated when the task completes.
 
 This lets you run bioinformatics pipelines (including [nf-core](https://nf-co.re) pipelines) without AWS Batch, ECS, or any queue infrastructure.
 
-nf-spawn is one of five [workflow-engine integrations](/guides/workflow-engines)
-on spore.host; it's under active development with its own roadmap.
+::: warning Early prototype
+nf-spawn is an **early prototype — not production-ready** (per its
+[README](https://github.com/spore-host/nf-spawn)). It's one of five
+[workflow adapters](/guides/workflow-engines), each early-stage; see the
+[maturity matrix](/guides/workflow-engines#maturity-compatibility). Install today
+requires cloning and building the plugin (below), not a drop-in registry install.
+Validate against your own pipeline before relying on it.
+:::
 
 ## How it works
 

--- a/docs/guides/parameter-sweeps.md
+++ b/docs/guides/parameter-sweeps.md
@@ -41,7 +41,9 @@ Add `--estimate-only` to see the instance count and cost estimate without launch
 
 ## Every combination of several lists
 
-List each parameter's values under `defaults` isn't how it works — instead enumerate the combinations you want in `params`. To sweep the full grid of several lists, generate the `params` list with a few lines of your own script (any language) and write it to the YAML/JSON file:
+You enumerate the combinations you want in `params` — spawn does not expand a grid
+for you. To sweep the full grid of several lists, generate the `params` list with a
+few lines of your own script (any language) and write it to the YAML/JSON file:
 
 ```python
 # gen-sweep.py — write every learning_rate × batch_size combination
@@ -58,7 +60,7 @@ python gen-sweep.py && spawn launch grid-search --param-file sweep.yaml   # 9 in
 ```
 
 ::: info Inline `--params` / auto-expanded ranges
-Passing parameters inline (`--params …`) and auto-generating ranges/cartesian products from the CLI are not yet available — the CLI returns *"inline --params not yet implemented, use --param-file for now."* Generate the `params` list into a file as shown above.
+Passing parameters inline (`--params …`) and auto-generating ranges/cartesian products from the CLI are not yet available — the CLI returns *"inline --params not yet implemented, use --param-file for now."* Generate the `params` list into a file as shown above. Native `grid:`/matrix expansion is tracked in [spawn#390](https://github.com/spore-host/spawn/issues/390).
 :::
 
 ## Heterogeneous sweeps — vary the instance type per entry
@@ -104,6 +106,44 @@ spawn sweep cancel <sweep-id>         # terminate all remaining instances
 ```
 
 With Slack connected, you'll get a DM when the sweep finishes (all instances have terminated).
+
+## Controlling concurrency and cost
+
+A large sweep does not have to launch every instance at once. Two launch flags cap
+how wide and how expensive it gets:
+
+```sh
+spawn launch hp-search --param-file sweep.yaml \
+  --max-concurrent 8 \      # at most 8 instances running at a time (0 = unlimited)
+  --budget 200 \            # stop launching once projected spend hits $200 (0 = no limit)
+  --ttl 4h
+```
+
+`--max-concurrent` (or `--max-concurrent-per-region`) queues the remaining entries
+and starts them as running ones finish — useful for staying under an instance-family
+quota. `--budget` is a spend ceiling for the whole sweep.
+
+## Resuming an interrupted sweep
+
+Sweeps checkpoint their progress, so a sweep that was cancelled or partially
+launched can be resumed without re-running the entries that already completed:
+
+```sh
+spawn sweep resume <sweep-id>                     # continue from checkpoint
+spawn sweep resume <sweep-id> --max-concurrent 5  # optionally re-cap concurrency
+```
+
+Gather the results of a finished sweep into one place with:
+
+```sh
+spawn sweep collect <sweep-id> --output results.json
+```
+
+::: info Re-running only the failed entries
+There isn't yet a one-flag "retry only the failed entries" for sweeps; `resume`
+continues incomplete work from the checkpoint. First-class failed-subset rerun is
+part of the array/sweep reporting work in [spawn#389](https://github.com/spore-host/spawn/issues/389).
+:::
 
 ## Alerts on completion, failure, or cost
 

--- a/docs/guides/pipelines.md
+++ b/docs/guides/pipelines.md
@@ -6,36 +6,34 @@ description: "A pipeline chains stages together: when one stage completes, it au
 
 A pipeline chains stages together: when one stage completes, it automatically launches the next. This is useful for multi-step workflows — data preparation, training, evaluation, post-processing — where each stage has different compute requirements.
 
-## The basic pattern
+## What each stage looks like
 
-Each stage uses `--on-complete` to trigger the next stage. The completion file (`/tmp/SPAWN_COMPLETE`) is the handoff signal.
+A pipeline is a DAG of stages, each of which is one ephemeral instance with its own
+instance type, TTL, and completion behavior. On its own, a single stage is just a
+`spawn launch` that terminates when it writes the completion file
+(`/tmp/SPAWN_COMPLETE`):
 
 ```sh
-# Stage 1: data preparation (cheap CPU instance)
+# One stage in isolation — data prep on a cheap CPU instance
 spawn launch \
   --name pipeline-prep \
   --instance-type c6i.4xlarge \
   --ttl 4h \
   --on-complete terminate \
-  --completion-file /tmp/SPAWN_COMPLETE \
   --command "python prepare_data.py --output s3://my-bucket/prepared/ && touch /tmp/SPAWN_COMPLETE"
 ```
 
-Stage 1 terminates when it writes the completion file. Stage 2 runs on whatever compute you want:
-
-```sh
-# Stage 2: training (GPU instance)
-spawn launch \
-  --name pipeline-train \
-  --instance-type p4d.24xlarge \
-  --ttl 24h \
-  --on-complete terminate \
-  --command "python train.py --data s3://my-bucket/prepared/ && touch /tmp/SPAWN_COMPLETE"
-```
+::: warning Running stages by hand does **not** create a pipeline
+`--on-complete` controls what happens to *this* instance when it finishes
+(terminate/stop/hibernate) — it does **not** launch the next stage. Chaining
+between stages is done by the orchestrator from a pipeline definition (below), not
+by `--on-complete`. Launching two `spawn launch` commands manually just gives you
+two independent instances.
+:::
 
 ## Automated pipeline definition
 
-Instead of launching stages by hand, define the whole DAG in a **pipeline definition file** and let a Lambda orchestrator manage the handoffs. `spawn pipeline launch` uploads the definition to S3 and starts the orchestrator, which launches each stage when its dependencies complete.
+To actually chain stages, define the whole DAG in a **pipeline definition file** and let a Lambda orchestrator manage the handoffs. `spawn pipeline launch` uploads the definition to S3 and starts the orchestrator, which launches each stage when its dependencies complete.
 
 The definition is JSON. Stages declare their dependencies with `depends_on`, so the pipeline is a DAG — independent stages run in parallel, dependent ones wait:
 
@@ -80,6 +78,16 @@ spawn pipeline launch pipeline.json --wait   # block until the pipeline finishes
 
 Each stage launches automatically once every stage in its `depends_on` list has succeeded. Set `"on_failure": "continue"` at the top level to keep running independent branches when one stage fails (the default, `"stop"`, halts the pipeline).
 
+::: tip Scope: coarse DAGs, not a scientific workflow engine
+`spawn pipeline` is a compact orchestrator for **small, coarse, infrastructure-shaped
+DAGs** — on the order of tens of stages, each a substantial chunk of compute. It
+deliberately does **not** do per-sample fan-out, dynamic DAG generation, nested
+workflows, advanced caching, or a rich conditional language. For complex scientific
+pipelines (scatter/gather over thousands of samples, resume/caching semantics), use
+a real workflow engine through its [adapter](/guides/workflow-engines) and let spawn
+be the executor underneath. See [Which execution tool?](/guides/choosing-execution).
+:::
+
 ## Passing data between stages
 
 Stages hand data off through S3. Give a stage a `data_output` block to publish its results, and a downstream stage a `data_input` block naming the source stage — the orchestrator wires the S3 locations so the consumer downloads them before its command runs:
@@ -100,7 +108,19 @@ Stages hand data off through S3. Give a stage a `data_output` block to publish i
 }
 ```
 
-For tightly-coupled stages that stream rather than stage through S3, use `"mode": "stream"` with a `protocol` (`tcp`, `grpc`, or `zmq`) and `port`; the orchestrator discovers peer addresses across stages.
+### Streaming between stages <span class="doc-badge experimental">Experimental</span>
+
+For tightly-coupled stages that stream rather than stage through S3, use
+`"mode": "stream"` with a `protocol` (`tcp`, `grpc`, or `zmq`) and `port`; the
+orchestrator discovers peer addresses across stages.
+
+::: warning Streaming is operationally involved
+Unlike the S3 handoff, streaming couples two live instances directly: it depends on
+security-group rules, service startup ordering and readiness, reconnect behavior,
+private-vs-public addressing/VPC, and how a Spot interruption mid-stream is handled.
+Treat it as experimental and test it end-to-end for your topology before relying on
+it; most pipelines should prefer the S3 `data_input`/`data_output` handoff above.
+:::
 
 ## Error handling
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -1,13 +1,20 @@
 ---
-description: "Plugins install and manage software on a running instance — connecting to a private network, mounting data transfer tooling, running a dev server."
+description: "Instance plugins install and manage software on a running instance — connecting to a private network, mounting data transfer tooling, running a dev server."
 ---
 
-# Plugins
+# Instance plugins
 
-Plugins install and manage software on a running instance — connecting to a
-private network, mounting data transfer tooling, running a dev server. A plugin
-is a declarative `plugin.yaml` spec describing lifecycle steps (install,
-configure, start, health-check, stop) that spawn runs on the instance.
+**Instance plugins** install and manage software on a running instance —
+connecting to a private network, mounting data transfer tooling, running a dev
+server. A plugin is a declarative `plugin.yaml` spec describing lifecycle steps
+(install, configure, start, health-check, stop) that spawn runs on the instance.
+
+::: tip Not the same as a workflow-engine plugin
+An *instance* plugin (this page) adds software to a machine. A *workflow-engine*
+plugin — like the Nextflow `nf-spawn` executor — is a
+[workflow adapter](/guides/workflow-engines) that plugs into an engine, not into an
+instance. Different systems, despite both being called "plugins."
+:::
 
 ## Available plugins
 
@@ -20,6 +27,43 @@ The official registry lives at
 | `rstudio-server` | Browser-based R development environment |
 | `globus-personal-endpoint` | High-speed data transfer via Globus Connect Personal |
 | `spore-sync` | Live bidirectional directory sync |
+
+## Trust & permissions
+
+::: warning Installing a plugin runs its author's code
+A plugin can run commands **on your local machine** (the controller) and, on the
+EC2 instance, **as root**. Installing one is equivalent to running code from its
+author in both places. Review a third-party `plugin.yaml` before installing it,
+and **pin production use to a version or commit** rather than a moving reference.
+:::
+
+What the install sources resolve to:
+
+- `name` / `name@version` — the official [registry](https://github.com/spore-host/spore-plugins); a version is a published registry release.
+- `github:org/repo/path[@ref]` — a plugin from any GitHub repo. The `@ref` is a git ref (tag, branch, or commit); pin to a **tag or commit** so the definition can't change under you. A bare `github:` ref (no `@`) tracks the default branch and can move.
+- `./path.yaml` — a local file, for development.
+
+Two things limit what a plugin can reach:
+
+- **Local steps run with a minimal environment.** A plugin's controller-side steps
+  see only `PATH` + `HOME` unless the plugin explicitly allowlists variables via
+  `env_passthrough` (see the [field reference](#plugin-yaml-field-reference)). So a
+  plugin can't silently scoop up your AWS or other credentials — it must name each
+  variable it needs (e.g. Tailscale's `TS_API_CLIENT_SECRET`), and you can see that
+  list in the spec before installing.
+- **`spawn plugin validate`** statically checks a spec offline (schema, semver,
+  step/condition types, undeclared template refs) without contacting AWS or an
+  instance — run it on any third-party spec before installing.
+
+::: info Known limitation: no pre-install inspection yet
+There is not yet a `spawn plugin inspect` / `install --dry-run` that renders a
+plugin's resolved source, local vs. remote commands, requested env, opened ports,
+and root usage before you run it — today the pre-install check is reading the
+`plugin.yaml` plus `spawn plugin validate`. Tracked in
+[spawn#387](https://github.com/spore-host/spawn/issues/387) (inspection) and
+[spawn#388](https://github.com/spore-host/spawn/issues/388) (an explicit
+`permissions:` block).
+:::
 
 ## Installing a plugin
 
@@ -183,6 +227,33 @@ Tailscale's `TS_API_CLIENT_SECRET`) lists it here and spawn injects only those.
 
 **`outputs.<name>.source`** is `local_capture` (captured by a `local` step) or
 `pushed` (delivered via the push API).
+
+#### Surfacing outputs
+
+A plugin declares the values worth reporting in its `outputs:` block — for a
+service, typically its URL and login user:
+
+```yaml
+outputs:
+  url:
+    description: "Service endpoint"
+    source: local_capture
+  username:
+    description: "Login user"
+    source: pushed
+```
+
+After the plugin provisions, those values are reported for the instance:
+
+```sh
+spawn plugin status rstudio-server --instance analysis
+```
+
+```
+Plugin rstudio-server — healthy
+  url:      https://analysis.abc123.spore.host
+  username: ec2-user
+```
 
 ### Validate before you ship
 

--- a/docs/guides/workflow-engines.md
+++ b/docs/guides/workflow-engines.md
@@ -1,34 +1,51 @@
 ---
-description: "spore.host is a first-class execution backend for five workflow engines."
+description: "spore.host provides native execution adapters for five workflow engines — run each task on its own ephemeral EC2 instance. All are early / experimental."
 ---
 
-# Workflow Engines
+# Workflow Adapters
 
-spore.host is a first-class execution backend for **five workflow engines**. In
+spore.host provides **native execution adapters** for five workflow engines. In
 every case the model is the same: each task/step/job/rule runs on its own
 **purpose-sized, ephemeral EC2 instance** that auto-terminates when it finishes —
 no cluster, no queue, no standing capacity. You keep writing your workflow in the
 engine you already use; spawn just runs the work.
 
-Each integration is a small, versioned, released package that plugs into the
-engine's own extension point and reuses the same spawn machinery (truffle
-auto-sizing, `--on-complete terminate` + TTL, a durable `.exitcode`-in-S3
-completion signal).
+Each adapter is a small, versioned package that plugs into the engine's own
+extension point and reuses the same spawn machinery (truffle auto-sizing,
+`--on-complete terminate` + TTL, a durable `.exitcode`-in-S3 completion signal).
 
-## The five integrations
+::: warning These adapters are early — read the maturity matrix first
+"Native adapter" means **we build and maintain it**; it does **not** mean
+production-ready. All five are early-stage: two are pre-1.0 prototypes and three
+are two-week-old `v0.1.0` initial releases. Validate against your own workflow and
+budget before relying on one. The shared execution model (staging, retries,
+completion) is still evolving — see [spawn#386](https://github.com/spore-host/spawn/issues/386).
+:::
 
-| Engine | Package | How you enable it | Repo |
-|--------|---------|-------------------|------|
-| **Nextflow** | `nf-spawn` | `executor = 'spawn'` in `nextflow.config` | [spore-host/nf-spawn](https://github.com/spore-host/nf-spawn) |
-| **WDL** | `miniwdl-spawn` | `MINIWDL__SCHEDULER__CONTAINER_BACKEND=spawn` | [spore-host/miniwdl-spawn](https://github.com/spore-host/miniwdl-spawn) |
-| **CWL** | `cwl-spawn` | `cwl-spawn workflow.cwl inputs.yml` | [spore-host/cwl-spawn](https://github.com/spore-host/cwl-spawn) |
-| **Snakemake** | `snakemake-executor-plugin-spawn` | `snakemake --executor spawn` | [spore-host/snakemake-executor-plugin-spawn](https://github.com/spore-host/snakemake-executor-plugin-spawn) |
-| **Apache Airflow** | `spawn-airflow` | `SpawnRunTaskOperator(...)` in a DAG | [spore-host/spawn-airflow](https://github.com/spore-host/spawn-airflow) |
+## Maturity & compatibility
+
+| Engine (adapter) | Status | Latest | Real-AWS validation | Enable it with |
+|------------------|--------|--------|---------------------|----------------|
+| **Nextflow** (`nf-spawn`) | <span class="doc-badge experimental">Experimental</span> prototype — not production-ready | v0.8.0 | unit/integration | `executor = 'spawn'` in `nextflow.config` |
+| **WDL** (`miniwdl-spawn`) | <span class="doc-badge experimental">Experimental</span> early | v0.1.0 | in progress ([#395](https://github.com/spore-host/spore-host/issues/395)) | `MINIWDL__SCHEDULER__CONTAINER_BACKEND=spawn` |
+| **CWL** (`cwl-spawn`) | <span class="doc-badge experimental">Experimental</span> early (v0.1) | v0.1.0 | verified end-to-end, leak-checked | `cwl-spawn workflow.cwl inputs.yml` |
+| **Snakemake** (`snakemake-executor-plugin-spawn`) | <span class="doc-badge experimental">Experimental</span> early (v0.1) | v0.1.0 | verified end-to-end, leak-checked | `snakemake --executor spawn` |
+| **Apache Airflow** (`spawn-airflow`) | <span class="doc-badge experimental">Experimental</span> early (v0.1) | v0.1.0 | verified end-to-end, leak-checked | `SpawnRunTaskOperator(...)` in a DAG |
+
+Repos: [nf-spawn](https://github.com/spore-host/nf-spawn) ·
+[miniwdl-spawn](https://github.com/spore-host/miniwdl-spawn) ·
+[cwl-spawn](https://github.com/spore-host/cwl-spawn) ·
+[snakemake-executor-plugin-spawn](https://github.com/spore-host/snakemake-executor-plugin-spawn) ·
+[spawn-airflow](https://github.com/spore-host/spawn-airflow). Each repo's README and
+CHANGELOG are the authoritative status; the table above summarizes them.
 
 The three [AWS HealthOmics](https://aws.amazon.com/healthomics/)-supported
 languages — **Nextflow, WDL, CWL** — were prioritized first for life-sciences
 relevance (spore.host is a cost-efficient alternative to HealthOmics, not a client
 of it). **Snakemake** and **Airflow** followed on demand.
+
+Not sure a workflow engine is the right layer at all? See
+[Which execution tool?](/guides/choosing-execution).
 
 ## Which one?
 
@@ -67,16 +84,25 @@ Where the engine declares resources, spawn sizes the instance automatically via
 Every task launches with a **TTL backstop** and `--on-complete terminate`, so a
 run can't leak billable instances even if a step is interrupted.
 
-## Not yet first-class
+## No native adapter yet
 
-Snakemake and Airflow were promoted from the "integration pattern" tier on
-demand. Others — Prefect, Argo Workflows, Dagster, Luigi, Temporal, AWS Step
-Functions — currently have example patterns (spawn invoked as a launcher via
-`spawn pipeline` / `spawn queue`) rather than a native plugin. If you need one of
-those promoted to first-class, open an issue.
+Snakemake and Airflow gained native adapters on demand. Others — Prefect, Argo
+Workflows, Dagster, Luigi, Temporal, AWS Step Functions — currently have example
+patterns (spawn invoked as a launcher via `spawn pipeline` / `spawn queue`) rather
+than a native adapter. If you need one, open an issue.
+
+## Building a new adapter
+
+All five adapters reimplement the same machinery (resource→instance sizing, S3
+staging, launch, polling, `.exitcode` interpretation, cancellation). A shared
+task-execution protocol / adapter library is proposed in
+[spawn#386](https://github.com/spore-host/spawn/issues/386) so new adapters
+translate their native task object into one common spec rather than rebuilding it.
+Start there if you're writing one.
 
 ## See also
 
-- [Nextflow integration guide](/guides/nextflow)
+- [Which execution tool?](/guides/choosing-execution) — adapter vs. sweep vs. pipeline vs. native engine
+- [Nextflow adapter guide](/guides/nextflow)
 - [Pipelines](/guides/pipelines) — the engine-agnostic `spawn pipeline` / `spawn queue`
 - [Instance sizing with truffle](/tools/truffle)


### PR DESCRIPTION
Second reviewer pass, focused on the extension subsystem (plugins, sweeps, arrays, queues, pipelines, and the five workflow-engine adapters). Every claim was fact-checked against the docs, the generated CLI reference (`docs/gen/`), and the actual `spawn`/`spored` source and the five workflow repos.

## Highest-priority fix: maturity accuracy
The workflow overview called all five adapters "first-class" while the repos say otherwise (nf-spawn = "early prototype, not production-ready"; miniwdl = early/validation-in-progress; CWL/Snakemake/Airflow = v0.1.0 initial releases). Replaced with a **status & compatibility matrix**, distinguished "native adapter" from "production-ready", and added Experimental badges.

## Restructure into four extension layers
`Extend an instance` (instance plugins) → `Run many jobs` (sweeps, arrays) → `Coordinate multiple steps` (instance queues, pipelines, MPI) → `Workflow adapters`. Renamed **Plugins → Instance plugins** and **Workflow Engines → Workflow adapters** (CLI flags unchanged). New **[Which execution tool?](https://docs.spore.host/guides/choosing-execution)** page with two decision matrices + per-task-EC2 fit guidance.

## Content fixes (all source-verified)
- **Plugins:** added Trust & permissions (what `github:` refs resolve to, minimal-env/`env_passthrough`, `validate`); documented outputs surfacing.
- **Sweeps:** surfaced existing-but-undocumented `--max-concurrent`, `--budget`, `spawn sweep resume`/`collect`.
- **Job arrays:** clarified `{total}` = *requested* count and that `--min-viable` partial launches leave *sparse* indexes (verified in `cmd/launch_jobarray.go`).
- **Instance queues:** resolved the "sequential vs dependency-graph" contradiction (verified single-threaded topological execution in `pkg/agent/queue_runner.go`); documented verified `retry`/`env`/`result_paths`, per-job log paths, resume-skips-completed, and a Spot caveat.
- **Pipelines:** fixed the misleading manual example (`--on-complete` does **not** chain stages); scoped `spawn pipeline` to coarse DAGs; marked stream mode Experimental with its operational caveats.

## Engineering proposals → tracked issues
The review's non-doc proposals were filed as issues and linked from the docs where a gap is mentioned: spawn **#386** (shared task-execution protocol / adapter library + capacity broker + instance reuse), **#387** (`plugin inspect`/`--dry-run`), **#388** (plugin `permissions:` block), **#389** (first-class `spawn array` reporting), **#390** (sweep grid expansion), **#391** (`spawn task diagnose`); spore-plugins **#8** (registry signing/pinning + expansion).

## Verification
- `npx vitepress build` clean (dead-link gated); `llms.txt` reflects the new four-layer groups + the new page.
- Behavioral claims (job-array `{total}`, queue sequencing, queue retry/log fields) verified against `spawn`/`spored` source, not assumed.

Docs + issues only — no product code, no AWS actions.