### PR TITLE
docs: correct --cost-limit description (compute-only, persists across restart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Fixed
+- **Docs: corrected `--cost-limit` description** (safety, glossary, spored, EC2
+  tags). It's a **compute-only** ceiling (excludes EBS/storage), accumulates
+  across stop/resume rather than resetting, **terminates** the instance, and fires
+  independently of the TTL (first ceiling to fire wins). Matches the spored fix in
+  spawn PR #400 (enforcement was resetting the cost clock on each restart).
+
 ### Added
 - **Docs: execution-fabric restructure (plugins & workflow adapters).** Following a
   second review of the extension subsystem, regrouped the docs so spawn reads as an

--- a/docs/reference/ec2-tags.md
+++ b/docs/reference/ec2-tags.md
@@ -26,7 +26,7 @@ spore.host tags every instance it launches with `spawn:*` tags. These tags drive
 | `spawn:idle-timeout` | `30m` | Terminate/stop if idle for this duration. |
 | `spawn:hibernate-on-idle` | `true` | Hibernate instead of stopping when idle. |
 | `spawn:session-timeout` | `2h` | Terminate if no SSH session for this duration. |
-| `spawn:cost-limit` | `50.00` | Stop/terminate when cumulative cost exceeds this amount (USD). |
+| `spawn:cost-limit` | `50.00` | Terminate when cumulative **compute** cost exceeds this amount (USD). Compute-only (excludes storage); accumulates across stop/resume. |
 
 ## Naming and purpose
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -36,7 +36,7 @@ throughout; avoid using "spore" as a noun for a machine.
 | **completion signal** | An explicit "my work is done" marker — a sentinel file (default `/tmp/SPAWN_COMPLETE`) or `spored complete`. Triggers the configured `on-complete` action. |
 | **completion sentinel** | The file spored watches for the completion signal. Its *appearance* — not your command merely finishing — is what triggers the action. |
 | **pre-stop hook** | A shell command spored runs before any lifecycle-triggered stop or terminate, to save work (e.g. `aws s3 sync /results s3://…`). |
-| **cost limit** | An optional spend ceiling; spored terminates when accumulated cost crosses it. |
+| **cost limit** | An optional **compute** spend ceiling (instance rate × total compute time, carried across stop/resume); spored terminates when it's crossed. Independent of the TTL — first ceiling to fire wins. |
 | **reaper** | The out-of-band backstop that terminates managed instances past their TTL even if spored is unhealthy. See [Costs & safety guarantees](/safety). |
 
 ## Compute-shape concepts

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -16,7 +16,7 @@ Three independent rules can end an instance's life, in strict priority:
 | Rule | What it is | Can it be reset? |
 |------|-----------|------------------|
 | **TTL** | An absolute deadline set once at launch. | **No.** It never moves across stop/wake cycles. Only `spawn extend` changes it, and only forward. |
-| **Cost limit** | Terminate when accumulated spend crosses a ceiling. | Set at launch; advisory guard. |
+| **Cost limit** | Terminate when accumulated **compute** spend crosses a ceiling. | Set at launch; tracks total compute across stop/resume (doesn't reset). |
 | **Idle timeout** | Stop or hibernate after a period of no activity. | Yes — any activity resets the timer. Idle **never terminates**; it only stops/hibernates. |
 
 The key invariant: **TTL always wins.** Idle detection is a soft, early
@@ -97,7 +97,11 @@ spawn cost analysis        # compute + storage + network, effective rate, budget
 ```
 
 Set a hard money ceiling with `--cost-limit` at launch if you want spend, not just
-time, to be the terminating rule.
+time, to be the terminating rule. It's measured on **compute cost only**
+(instance rate × total compute time, accumulated across stop/resume — it doesn't
+reset when you restart), warns at 90%, and **terminates** the instance when
+crossed. It fires independently of the TTL — whichever ceiling is reached first
+ends the instance.
 
 ## Next steps
 

--- a/docs/tools/spored.md
+++ b/docs/tools/spored.md
@@ -25,7 +25,7 @@ Once started, spored runs a check every minute:
 
 1. **TTL** — if the absolute deadline (`spawn:ttl-deadline` tag) has passed, terminate.
 2. **Completion signal** — if the sentinel file (`/tmp/SPAWN_COMPLETE` by default) exists, take the configured action.
-3. **Cost limit** — if accumulated spend has exceeded `spawn:cost-limit`, terminate.
+3. **Cost limit** — if accumulated **compute** spend (rate × total compute time, carried across stop/resume) has exceeded `spawn:cost-limit`, terminate.
 4. **Idle detection** — if all activity signals have been quiet for `spawn:idle-timeout`, stop (or hibernate).
 
 Spot interruption notices are polled separately every 5 seconds and acted on immediately.
@@ -72,7 +72,7 @@ Shows the current lifecycle state of the instance:
   Storage cost:     $0.18  (1h 30m × $0.1200/hr EBS)
   Cumulative cost:  $1.62
   Effective rate:   $0.2496/hr  (4% lower than continuous on-demand)
-  Cost limit:       $50.00  ($1.62 used, 3% — $48.38 remaining)
+  Cost limit:       $50.00  ($1.44 compute used, 3% — $48.56 remaining; compute-only)
 
   CPU:              2.5%
   Network:          45 B/min
@@ -145,7 +145,7 @@ All spored configuration is stored as EC2 tags. Spawn writes them at launch; you
 | `spawn:price-per-hour` | float | On-demand hourly rate — written at launch for cost display. |
 | `spawn:ebs-hourly-cost` | float | EBS volume cost/hr — looked up once by spored on first start and cached here. |
 | `spawn:compute-seconds` | int | Cumulative compute seconds — updated by spored every few minutes. |
-| `spawn:cost-limit` | float | Terminate when total spend reaches this amount (USD). |
+| `spawn:cost-limit` | float | Terminate when total **compute** spend reaches this amount (USD). Compute-only (excludes EBS/storage); accumulates across stop/resume. |
 
 ### Notifications and DNS
 


### PR DESCRIPTION
Companion to spawn PR #400 (which fixes the enforcement bug). Corrects the docs, which described `--cost-limit` inaccurately.

## What was wrong
- safety.md / glossary.md / spored.md / ec2-tags.md said the limit fires on "accumulated spend" / "cumulative cost" — implying total (compute + storage).
- The `spored status` sample line showed "% used" against a compute **+ EBS** total, which is not what triggers termination.
- Nothing said the limit accumulates across stop/resume.

## Corrected to
- **Compute-only** (instance rate × total compute time; excludes EBS/storage).
- **Accumulates across stop/resume** — doesn't reset (matches the spawn #400 fix).
- **Terminates** the instance, warns at 90%, and fires **independently of the TTL** (first ceiling to fire wins).
- Updated the `spored status` sample to the new "compute used … compute-only" wording.

Dead-link-clean VitePress build. Pairs with spore-host/spawn#400.