### PR TITLE
docs: fix cross-page contradictions from the review

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,45 @@
-# Security Overview for spore-host (truffle + spawn)
+# Security Overview for spore.host
 
 **Audience:** CISOs, Cloud Administrators, Security Engineers
 
-**Purpose:** Comprehensive security assessment and operational guidance for deploying spore-host tools in enterprise AWS environments.
+**Purpose:** Security assessment and operational guidance for deploying spore.host tools in AWS environments.
+
+> **The name is spore.host, but spore.host is not the host.** It never holds your
+> AWS credentials and never runs your compute. Everything runs in **your own AWS
+> account** with **your own credentials**. For the full trust/data-flow map, see
+> [Security, credentials & data flow](docs/architecture.md).
 
 ---
 
 ## Executive Summary
 
-**spore-host** is a command-line toolset for AWS EC2 instance discovery and ephemeral compute provisioning. It consists of two components:
+**spore.host** is a suite of command-line tools (plus one in-instance agent) for
+AWS EC2 instance discovery and ephemeral, self-terminating compute. Its
+components:
 
-- **truffle**: EC2 instance type search tool (read-only)
-- **spawn**: EC2 instance launcher with auto-termination (read/write)
+- **truffle** — EC2 instance-type / price / quota search (read-only).
+- **spawn** — EC2 instance launcher and lifecycle manager (read/write).
+- **spored** — the in-instance agent spawn installs on every instance; enforces
+  TTL, idle, completion, and cost rules from *inside* the instance.
+- **lagotto** — capacity watcher that waits for scarce instance types and launches
+  when they appear.
+- **spore-bot** — optional chat control (Slack/Teams) via a hosted Lambda.
+- **MCP server** — exposes a read-mostly subset of operations to AI assistants
+  (search, status, stop, terminate, extend — **no launch**).
+- **plugin registry** ([spore-plugins](https://github.com/spore-host/spore-plugins)) —
+  optional post-launch software installers; official plugins are **cosign-signed**
+  and verified by spawn before install (see §4).
 
-**Security Model:** Least-privilege IAM permissions, explicit resource tagging, and automatic cleanup of ephemeral resources.
+**Security Model:** your credentials never leave your machine; least-privilege
+IAM; explicit resource tagging; in-instance lifecycle enforcement with an
+out-of-band backstop; automatic cleanup of ephemeral resources.
 
-**Risk Profile:** Medium - requires EC2 launch permissions and limited IAM role creation
+**Risk Profile:** Medium — requires EC2 launch permissions and one-time IAM role
+creation for the spored instance profile.
 
-**Compliance:** Supports AWS best practices, CloudTrail auditing, and resource tagging for cost allocation
+**Compliance:** spore.host does not centrally receive or store workload data.
+Supports CloudTrail auditing and resource tagging; compliance obligations remain
+with the user's AWS environment, configuration, and controls (see §5).
 
 ---
 
@@ -235,7 +257,7 @@ All instances launched by spawn are tagged:
 spawn:managed = true
 spawn:root = true
 spawn:created-by = spawn
-spawn:version = 0.1.0
+spawn:version = <spawn version that launched it>
 spawn:ttl = <duration>           (if specified)
 spawn:idle-timeout = <duration>  (if specified)
 ```
@@ -250,35 +272,46 @@ spawn:idle-timeout = <duration>  (if specified)
 
 ### Binary Distribution Security
 
-**Problem:** How to securely distribute spored binary to instances?
+**How spored reaches an instance:** at boot, the instance's user-data downloads
+the spored binary and a `.sha256` checksum from a public, regional S3 bucket
+(`spawn-binaries-<region>`), verifies the checksum, then installs and runs it.
 
-**Solution:** Public S3 with SHA256 verification (industry standard)
+**What the SHA-256 check does — and does not — provide:**
 
-**Implementation:**
-1. spored binaries stored in public S3 buckets (one per region)
-2. Each binary has corresponding `.sha256` checksum file
-3. Instance user-data downloads both binary and checksum
-4. SHA256 verified before execution: `sha256sum --check spored-linux-amd64.sha256`
-5. Installation fails if checksum mismatch
+- ✅ **Corruption detection.** It catches an incomplete or corrupted download
+  (truncated transfer, storage bit-rot). If the bytes don't match, the install
+  fails and the instance does not run a damaged binary.
+- ❌ **It does NOT authenticate the publisher.** The checksum is served from the
+  **same bucket** (same trust domain) as the binary. An attacker who could modify
+  the binary in the bucket could also replace the `.sha256` — the check would then
+  pass. A same-origin checksum guards against accidental corruption, **not**
+  against compromise of the artifact-publishing account or bucket. HTTPS protects
+  the transport, not the origin.
 
-**Why Public S3?**
-- Same model as apt/yum/pip repositories
-- No AWS credentials in user-data (reduces attack surface)
-- Fast downloads (regional buckets, <20ms latency)
-- Tamper detection via cryptographic checksums
+**This is a known limitation with signing in progress.** Publisher
+authentication for spored binaries is tracked at
+[spore-host#440](https://github.com/spore-host/spore-host/issues/440): the target
+design signs each spored binary with a spore.host-held key, publishes the
+signature alongside the binary, and has the bootstrap verify that signature
+against a public key **compiled into spawn** (whose own release is independently
+trusted via Homebrew / GitHub Releases) — moving the trust root out of the S3
+bucket. Until that ships, treat the S3 SHA-256 as an integrity (not authenticity)
+control and rely on the S3 bucket policy + account controls below to limit who can
+write to the bucket.
 
-**Threat Model:**
-- ❌ **Compromised S3 Bucket:** Attacker cannot upload malicious binary without SHA256 key
-- ❌ **Man-in-the-Middle:** HTTPS + SHA256 verification prevents tampering
-- ✅ **Authorized Updates:** Only spawn maintainers can update binaries (S3 bucket policy)
+> **Note — this is distinct from plugin signing, which *is* shipped.** Official
+> **plugins** in the registry are cryptographically signed with cosign/sigstore
+> (keyless, via a GitHub Actions OIDC identity) and their signature is verified by
+> spawn before install (§4, *Plugin supply chain*). That covers plugin manifests,
+> not the spored/spawn release binaries, which are the subject of #440 above.
 
-**S3 Bucket Policy:**
+**S3 Bucket Policy (public read, restricted write):**
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "PublicReadSpawndBinaries",
+      "Sid": "PublicReadSporedBinaries",
       "Effect": "Allow",
       "Principal": "*",
       "Action": "s3:GetObject",
@@ -287,6 +320,27 @@ spawn:idle-timeout = <duration>  (if specified)
   ]
 }
 ```
+Write access to the bucket is restricted to the release pipeline; public access
+is read-only for the binary objects.
+
+---
+
+### Plugin supply chain
+
+Optional plugins (post-launch software installers) are resolved and, for official
+plugins, cryptographically verified before anything runs:
+
+- Official plugin releases are **cosign-signed keyless** in CI (a GitHub Actions
+  OIDC identity → Fulcio certificate + Rekor transparency-log entry).
+- `spawn` verifies the signature by default for an official versioned reference,
+  pinning the signing identity to the spore-plugins release workflow. A missing or
+  invalid signature is a hard failure (`--insecure` bypasses it for local dev).
+- Each plugin also ships a checksum manifest verified against the fetched
+  `plugin.yaml`, and a plugin's declared `permissions:` block is enforced against
+  its steps at publish time.
+
+This closes the "who authored this code that runs on my instance" question for
+plugins. See the [registry supply-chain design](https://github.com/spore-host/spore-plugins).
 
 ---
 
@@ -397,20 +451,57 @@ aws budgets create-budget \
 
 ### Compliance Considerations
 
+**The key fact:** spore.host does **not** centrally receive, process, or store
+your workload data. Instances run in your VPC, under your account, with your
+credentials; any data on them is placed there by you. spore.host therefore cannot
+confer compliance — compliance obligations remain with your AWS environment, the
+services you enable, your configuration, your data handling, and your
+institutional controls. Do not assume a workload is compliant merely because the
+instance runs in your own VPC.
+
+What spore.host *does* provide that supports a compliance program:
+
 **GDPR / Data Residency:**
-- spawn respects regional boundaries (no cross-region data transfer)
-- Users control region via `--region` flag
-- AMI selection automatic per region
+- spawn respects the region you choose (`--region`); no cross-region movement of
+  your data by spore.host.
 
 **PCI-DSS / HIPAA:**
-- spawn does not handle sensitive data
-- Instances launched in user's VPC (user controls network security)
-- Encryption at rest supported (EBS encryption via instance type requirements)
+- No workload data flows to spore.host; instances run in your VPC under your
+  network controls. EBS encryption is supported. Meeting these frameworks depends
+  on *your* configuration and BAAs/controls, not on spore.host.
 
 **SOC 2 / ISO 27001:**
-- Audit trail via CloudTrail
-- Resource tagging for inventory management
-- Automatic cleanup reduces security surface area
+- CloudTrail captures all spawn operations; resource tagging supports inventory;
+  automatic cleanup reduces standing surface area. These are inputs to your
+  controls, not attestations by spore.host.
+
+---
+
+### Lifecycle guarantee by deployment mode
+
+The TTL guarantee ("every protected instance has a hard termination deadline") is
+enforced in two layers: **spored** inside the instance, and an optional
+**out-of-band reaper** that acts as a backstop if spored can't. What you get
+depends on which you deploy:
+
+| Mode | spored (in-instance) | Out-of-band reaper | Workload data leaves account | Failure guarantee |
+|------|:---:|:---:|:---:|---|
+| **CLI only** (default) | Yes | No | No | Instance-local enforcement: spored terminates at TTL. If spored itself is disabled/killed, only your AWS-side controls (Budgets/SCPs) remain. |
+| **Self-hosted backstop** | Yes | Yes (in your account) | No | Dual enforcement: the reaper terminates past-deadline instances even if spored fails. |
+| **Hosted integrations** | Yes | Yes / optional | Selected metadata only (never credentials or workload data) | Dual enforcement when the reaper is enabled. |
+
+Notes on the reaper (see
+[spawn/lambda/ttl-reaper](https://github.com/spore-host/spawn/tree/main/lambda/ttl-reaper)):
+
+- It is **not enabled by default** and ships in **dry-run** (logs "would reap" +
+  notifies; does not terminate) until an operator flips it to enforce mode after
+  verification.
+- It assumes a **narrow per-account cross-account role you grant** (scoped to
+  terminating past-deadline `spawn:managed` instances) — it never holds your
+  credentials.
+- With **no reaper configured**, the hard guarantee is provided by spored alone;
+  the reaper is the backstop for the case where spored can't act. Verify spored is
+  running and the deadline is set with `spawn status`.
 
 ---
 
@@ -422,7 +513,8 @@ aws budgets create-budget \
 |------|----------|------------|
 | Excessive instance launches | Medium | AWS Budgets, SCPs, `--ttl` requirement |
 | IAM role privilege escalation | Low | Role scoped to `spawn:managed=true` only |
-| Binary tampering | Low | SHA256 verification, HTTPS |
+| spored binary corruption | Low | SHA256 verification, HTTPS |
+| spored binary tampering (bucket compromise) | Medium | S3 bucket write-access controls today; publisher signing in progress (#440) — same-bucket SHA256 does **not** mitigate this |
 | Forgotten instances | Low | TTL enforcement, idle detection |
 | Insider threat (malicious user) | Medium | CloudTrail auditing, IAM least privilege |
 | Credential exposure | Medium | No credentials in user-data, IMDSv2 supported |
@@ -434,7 +526,9 @@ aws budgets create-budget \
 ✅ **Automatic Cleanup:** TTL/idle detection prevents resource leaks
 ✅ **Audit Trail:** CloudTrail captures all operations
 ✅ **Cost Controls:** Budgets, SCPs, Spot instances
-✅ **Binary Integrity:** SHA256 verification
+✅ **Binary Integrity (corruption):** SHA256 verification of spored downloads
+✅ **Plugin Authenticity:** official plugins cosign-signed + verified by spawn
+⏳ **spored Binary Authenticity:** publisher signing in progress (#440); today's same-bucket SHA256 detects corruption, not compromise
 ✅ **Network Security:** User controls VPC, security groups, subnets
 
 ---
@@ -580,7 +674,7 @@ aws cloudtrail lookup-events \
 
 ---
 
-## 10. Code-Level Security Hardening (v0.13.0)
+## 10. Code-Level Security Hardening
 
 ### Command Injection Protection
 
@@ -609,7 +703,8 @@ spawn implements comprehensive protection against shell command injection attack
    - Mount paths validated and escaped
    - Filesystem DNS names escaped in mount commands
 
-**Test Coverage**: 78.4% with attack pattern fuzzing
+**Test Coverage**: security-critical paths are covered by unit tests with
+attack-pattern fuzzing; current coverage is reported by CI on each repo.
 
 ---
 
@@ -694,7 +789,7 @@ logger := audit.NewLoggerFromContext(ctx)
 - Correlation IDs for distributed tracing
 - User attribution for compliance
 
-**Test Coverage**: 79.2%
+**Test Coverage**: audit paths are unit-tested; current coverage is reported by CI.
 
 ---
 
@@ -716,9 +811,8 @@ logger := audit.NewLoggerFromContext(ctx)
    - Context propagation
    - Error logging
 
-**Coverage Targets**:
-- Security package: 78.4% (target: 80%)
-- Audit package: 79.2% (target: 80%)
+**Coverage Targets**: security and audit packages target ≥80% coverage, enforced
+by a CI ratchet floor; current figures are shown by each repo's coverage badge.
 
 ---
 
@@ -769,7 +863,16 @@ It cannot access S3, RDS, DynamoDB, or any other AWS services.
 
 ### Q: What if someone modifies the spored binary on S3?
 
-**A:** The instance will fail to launch. User-data verifies SHA256 checksum before executing spored. If the binary is tampered, the checksum won't match and installation aborts.
+**A:** Be precise about the two cases. **Accidental corruption** (truncated
+download, bit-rot) is caught: user-data verifies the SHA-256 before executing, and
+a mismatch aborts installation. **Malicious replacement by an attacker who has
+write access to the bucket** is *not* caught today, because the `.sha256` is served
+from the same bucket — an attacker who can replace the binary can also replace its
+checksum. That gap is mitigated by restricting bucket write access to the release
+pipeline, and is being closed by publisher signing
+([#440](https://github.com/spore-host/spore-host/issues/440)), which verifies a
+signature against a key compiled into spawn rather than a checksum from the same
+bucket. See §4, *Binary Distribution Security*.
 
 ---
 
@@ -811,9 +914,13 @@ aws ce get-cost-and-usage \
 **Security Issues:** Report to project maintainers (see CONTRIBUTING.md)
 
 **Documentation:**
-- Full IAM policy: `spawn/IAM_PERMISSIONS.md`
-- User guide: `spawn/README.md`
-- Validation script: `scripts/validate-permissions.sh`
+- IAM permissions reference: [docs/reference/iam-permissions.md](docs/reference/iam-permissions.md)
+- Security, credentials & data flow: [docs/architecture.md](docs/architecture.md)
+- Costs & safety guarantees: [docs/safety.md](docs/safety.md)
+
+**Reporting a vulnerability:** please use the private
+[GitHub Security Advisory](https://github.com/spore-host/spore-host/security/advisories/new)
+rather than a public issue.
 
 **References:**
 - [AWS IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
@@ -822,6 +929,5 @@ aws ce get-cost-and-usage \
 
 ---
 
-**Document Version:** 1.0
-**Last Updated:** December 21, 2025
-**Next Review:** January 21, 2026
+This document tracks the current design; it is not pinned to a specific release.
+Component behavior is versioned in each repo's `CHANGELOG.md`.

--- a/docs/guides/aws-auth.md
+++ b/docs/guides/aws-auth.md
@@ -8,7 +8,7 @@ spore.host tools (`spawn`, `truffle`, `lagotto`) act on AWS with **your own AWS 
 
 ## Sign in with `aws login`
 
-The recommended way to authenticate is **`aws login`** (AWS CLI **v2.34+**), which signs you in and manages **short-lived, auto-refreshing** credentials:
+The recommended way to authenticate is **`aws login`** (AWS CLI **v2.32.0+**), which signs you in and manages **short-lived, auto-refreshing** credentials:
 
 ```sh
 aws login                     # opens your browser to sign in
@@ -20,6 +20,21 @@ That's it — `spawn`, `truffle`, and `lagotto` pick these credentials up automa
 ::: tip Why `aws login` over static keys
 `aws login` credentials expire and refresh, so there's no long-lived secret to leak. Prefer it. Static access keys (`aws configure`) still work as a fallback — see below — but treat them as legacy/CI-only.
 :::
+
+### IAM Identity Center (SSO)
+
+If your institution uses **AWS IAM Identity Center** (formerly AWS SSO) — common
+at universities and larger organizations — configure a profile once and sign in
+through it:
+
+```sh
+aws configure sso                 # one-time: set SSO start URL, region, account, role
+aws sso login --profile research  # sign in (opens your browser); refresh when it expires
+```
+
+Then point the spore.host tools at that profile (`AWS_PROFILE=research`, or
+`--profile research`, or the `sporeconfig` layer below). These are short-lived
+credentials, same as `aws login`.
 
 ### Static keys (fallback)
 

--- a/docs/guides/first-instance.md
+++ b/docs/guides/first-instance.md
@@ -16,7 +16,7 @@ A complete walkthrough from a fresh install to a running EC2 instance and back. 
 
 ## Prerequisites
 
-- An AWS account (free tier works fine)
+- An AWS account (a small instance costs a few cents for this walkthrough)
 - macOS, Linux, or Windows with WSL2
 - Basic comfort with the command line
 
@@ -56,7 +56,7 @@ Expected output:
 }
 ```
 
-If this fails, sign in with **`aws login`** (AWS CLI v2.34+; static `aws configure` keys also work). spore.host uses the same credentials as the AWS CLI — nothing extra to configure. See [AWS Authentication](/guides/aws-auth) for profiles and how auth relates to permissions.
+If this fails, sign in with **`aws login`** (AWS CLI v2.32.0+; static `aws configure` keys also work). spore.host uses the same credentials as the AWS CLI — nothing extra to configure. See [AWS Authentication](/guides/aws-auth) for profiles and how auth relates to permissions.
 
 ---
 
@@ -68,7 +68,7 @@ Before launching, see what's available and what it costs:
 truffle find "t3 medium" --region us-east-1
 ```
 
-You'll see a table with vCPUs, memory, and on-demand price. For this walkthrough we'll use a `t3.micro` — free tier eligible.
+You'll see a table with vCPUs, memory, and on-demand price. For this walkthrough we'll use a `t3.micro` — cheap, and marked Free Tier eligible in many accounts (eligibility and credits vary by account age/plan, so check the price Truffle shows before launching).
 
 ---
 
@@ -86,11 +86,11 @@ After about 60–90 seconds:
 ```
 ✓ Instance i-0a1b2c3d4e5f running
 ✓ my-first-instance.abc123.spore.host
-✓ SSH: ssh ec2-user@54.123.45.67
+✓ Connect: spawn connect my-first-instance
 ✓ Auto-terminates in 1h
 ```
 
-spawn automatically found the latest Amazon Linux 2023 AMI, created an SSH key, configured networking, and installed spored on the instance.
+spawn automatically found the latest Amazon Linux 2023 AMI, imported your existing SSH public key (or generated a managed one if you had none), created a Linux user matching your local login, configured networking, and installed spored on the instance.
 
 ---
 
@@ -100,11 +100,9 @@ spawn automatically found the latest Amazon Linux 2023 AMI, created an SSH key, 
 spawn connect my-first-instance
 ```
 
-This prints the SSH command. Or connect directly:
-
-```sh
-ssh ec2-user@54.123.45.67
-```
+This logs you in **as your own username** (the Linux user spawn created to match
+your local login), using the key it imported — you don't need to know the address,
+key path, or username. Raw `ssh <you>@<public-ip>` works too if you prefer.
 
 ::: tip
 If you get "Connection refused", the instance is still booting. Wait 30 seconds and try again.
@@ -158,7 +156,7 @@ When you're done, permanently terminate it (destroys the instance and its EBS vo
 spawn terminate my-first-instance       # confirms first; add -y to skip
 ```
 
-Or `spawn stop my-first-instance` to keep the EBS volume and resume later — or just leave it, since it auto-terminates after 1 hour (the default idle timeout).
+Or `spawn stop my-first-instance` to keep the EBS volume and resume later (the volume still bills until you terminate) — or just leave it, since it auto-terminates at the **1-hour TTL you set** with `--ttl 1h`. (TTL is a hard deadline that *terminates*; idle timeout is a separate, opt-in setting that *stops*.)
 
 ---
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -77,7 +77,7 @@ Then add to `~/.claude/claude_desktop_config.json`:
 
 ## AWS credentials
 
-spore.host uses whichever credentials are active in your shell — the same ones the AWS CLI uses. The recommended way to obtain them is **`aws login`** (AWS CLI v2.34+), which manages short-lived credentials for you; static `aws configure` keys also work.
+spore.host uses whichever credentials are active in your shell — the same ones the AWS CLI uses. The recommended way to obtain them is **`aws login`** (AWS CLI v2.32.0+), which manages short-lived credentials for you; static `aws configure` keys also work.
 
 ```sh
 aws login                       # sign in

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,10 +21,15 @@ scoop install truffle spawn
 ```
 
 ```sh [Manual]
-# Download from GitHub Releases
-# https://github.com/spore-host/spore-host/releases/latest
-tar -xzf spawn_*_$(uname -s)_$(uname -m).tar.gz
-tar -xzf truffle_*_$(uname -s)_$(uname -m).tar.gz
+# Download the latest release assets for your OS/arch, then extract onto PATH.
+OS=$(uname -s); ARCH=$(uname -m)
+for tool in spawn truffle; do
+  url=$(curl -fsSL "https://api.github.com/repos/spore-host/${tool}/releases/latest" \
+    | grep -o "https://[^\"]*_${OS}_${ARCH}.tar.gz" | head -1)
+  curl -fsSL "$url" -o "${tool}.tar.gz"
+  tar -xzf "${tool}.tar.gz" "$tool"
+  sudo install "$tool" /usr/local/bin/
+done
 ```
 
 :::
@@ -38,14 +43,18 @@ spawn --version
 
 ## Authenticate with AWS
 
-spore.host uses whatever AWS credentials your shell already has. The recommended way to get them is **`aws login`** (AWS CLI v2.34+), which signs you in and refreshes short-lived credentials automatically:
+spore.host uses whatever AWS credentials your shell already has. The recommended way to get them is **`aws login`** (AWS CLI v2.32.0+), which signs you in and refreshes short-lived credentials automatically:
 
 ```sh
 aws login                       # sign in (opens your browser)
 aws sts get-caller-identity     # confirm you're authenticated
 ```
 
-If your organization issues static keys instead, `aws configure` (Access Key ID / Secret Access Key / region) also works — `aws login` is preferred because the credentials are short-lived.
+Other paths work too — pick whichever matches your organization:
+- **IAM Identity Center (SSO):** `aws configure sso` then `aws sso login --profile <name>` (set `AWS_PROFILE` or `--profile`).
+- **Static keys / CI / assumed roles:** any credential your shell already resolves (env vars, `~/.aws/credentials`, instance role) is used as-is.
+
+`aws login` is preferred where available because the credentials are short-lived.
 
 Your credentials need permission to launch and manage EC2 instances; see the [minimal IAM policy](/reference/iam-permissions). For the full picture — profiles, `SPORE_*` config, and how your auth relates to what spore.host does on your behalf — see [AWS Authentication](/guides/aws-auth).
 
@@ -82,22 +91,27 @@ spawn launch \
   --ttl 4h
 ```
 
-Once running, you'll see the instance ID, public IP, and SSH command:
+Once running, you'll see the instance ID, hostname, and how to connect:
 
 ```
 ✓ Instance i-0a1b2c3d4e5f running
 ✓ my-first-instance.abc123.spore.host
-✓ SSH: ssh ec2-user@3.84.123.45
+✓ Connect: spawn connect my-first-instance
 ✓ Auto-terminates in 4h
 ```
 
 ## Connect
 
 ```sh
-ssh ec2-user@<public-ip>
+spawn connect my-first-instance
 ```
 
-The SSH key used is whichever key you specified at launch. By default, spawn uses your `~/.ssh/id_rsa` or prompts you to select one.
+`spawn connect` is the canonical way in — it resolves the instance, uses the
+right key, and logs you in as **your own username** (spawn creates a Linux user
+matching your local login and imports your existing public key —
+`~/.ssh/id_ed25519` or `~/.ssh/id_rsa` — generating a managed key only if you have
+neither). Raw `ssh <you>@<public-ip>` works too, but prefer `spawn connect` so you
+don't have to track the address, key, or username yourself.
 
 ## Check status
 
@@ -114,11 +128,24 @@ If you need more time before the instance terminates:
 spawn extend my-first-instance 8h
 ```
 
-## Stop or terminate
+## Clean up
+
+When you're done, **terminate** — this deletes the instance and its EBS volume,
+so nothing keeps billing:
 
 ```sh
-spawn stop my-first-instance       # stopped, can be restarted with spawn start
+spawn terminate my-first-instance
 ```
+
+Prefer to pause and resume later? **Stop** instead — but note a stopped instance
+still bills for its EBS storage until you terminate it:
+
+```sh
+spawn stop my-first-instance       # resumable with `spawn start`; EBS still bills
+```
+
+(You didn't have to remember this: the `--ttl` you set means the instance
+self-terminates at its deadline regardless.)
 
 ## Next steps
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -8,7 +8,7 @@ spore.host tools read configuration from environment variables and `~/.spawn/con
 
 ## AWS credentials
 
-spore.host uses the standard AWS credential chain — no custom variables required. The recommended way to populate it is [`aws login`](/guides/aws-auth) (AWS CLI v2.34+); the variables below are for profile selection or the static-key fallback.
+spore.host uses the standard AWS credential chain — no custom variables required. The recommended way to populate it is [`aws login`](/guides/aws-auth) (AWS CLI v2.32.0+); the variables below are for profile selection or the static-key fallback.
 
 | Variable | Description |
 |----------|-------------|

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -38,7 +38,7 @@ Yes. Use `AWS_PROFILE=my-profile spawn launch ...` or `spawn launch --profile my
 
 ### What AWS permissions does spore.host need?
 
-The minimum policy is documented at [IAM Permissions](/reference/iam-permissions). In brief: EC2 describe, run, stop, terminate, tag, and create tags; IAM pass-role for the spored instance profile; Route53 for DNS registration.
+The baseline policy is documented at [IAM Permissions](/reference/iam-permissions). In brief the **core** permissions are: EC2 describe, run, stop, terminate, tag, and create tags; and IAM pass-role for the spored instance profile. **Optional features** add their own permissions only when you use them — e.g. Route 53 is needed only with `--dns` (subdomain assignment), not for a normal launch.
 
 ---
 
@@ -53,7 +53,7 @@ All EC2 instance types. Common choices for research:
 - **Memory-intensive**: r7i.2xlarge, r6i.8xlarge
 - **GPU (training)**: p4d.24xlarge, g5.2xlarge
 - **GPU (inference)**: g5.xlarge, g4dn.xlarge
-- **Free tier**: t3.micro, t2.micro
+- **Smallest / cheapest**: t3.micro, t2.micro (often Free Tier eligible, but eligibility varies by account — check the price Truffle shows)
 
 ### Can I use a custom AMI?
 

--- a/docs/reference/iam-permissions.md
+++ b/docs/reference/iam-permissions.md
@@ -6,9 +6,12 @@ description: "spore.host tools act on EC2 with your AWS credentials (see AWS Aut
 
 spore.host tools act on EC2 with **your** AWS credentials (see [AWS Authentication](../guides/aws-auth.md) for how those are obtained). This page is the least-privilege IAM policy those credentials need. Attach it to the IAM role/user you authenticate as, and expand only as your usage grows (Spot, DNS, FSx below).
 
-## Minimal policy
+## Recommended least-privilege baseline
 
-This is the complete set required for the core flow — **`spawn launch` → connect → manage → terminate**. It is verified against the actual AWS API calls spawn makes; a smaller policy will fail at launch (see the callout below).
+This is the recommended least-privilege policy for the core flow — **`spawn launch`
+→ connect → manage → terminate**. It's verified against the actual AWS API calls
+spawn makes; dropping a core action will fail at launch (see the callout below).
+Optional features (Spot, DNS, FSx) add their own permissions, listed further down.
 
 ```json
 {
@@ -102,6 +105,14 @@ A launch does more than `RunInstances`. spawn **imports your SSH public key** (`
 
 ::: tip Scope on tags
 `EC2Manage` is conditioned on `spawn:managed=true`, so you can only start/stop/terminate instances spawn created — never unrelated ones. The read (`Describe*`) and launch statements can't be tag-scoped (the resources don't exist yet at describe/launch time).
+:::
+
+::: tip Note on `sts:GetCallerIdentity`
+The `Identity` statement is included for completeness because spawn calls
+`sts:GetCallerIdentity` to confirm which account/identity you're operating as. AWS
+returns identity from this call even without an explicit `Allow` (and even under an
+explicit `Deny`), so you can omit this statement with no functional change — it's
+listed so the policy mirrors every call spawn makes.
 :::
 
 ## Spot instances

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -9,9 +9,19 @@ assistants that support the [Model Context Protocol](https://modelcontextprotoco
 — including Claude Desktop and Cursor.
 
 **When to use it.** When you'd rather describe what you need in plain language —
-*"find the cheapest A100 in us-east-1 and launch one with a 4-hour limit"* — and
-let the assistant run the commands, instead of typing them yourself. It runs
-locally with your AWS credentials, the same trust model as the CLIs.
+*"find the cheapest A100 in us-east-1, then give me the spawn command to launch it
+with a 4-hour limit"* — and let the assistant do the search and manage running
+instances, instead of typing every command yourself. It runs locally with your
+AWS credentials, the same trust model as the CLIs.
+
+::: warning The MCP server cannot launch instances — by design
+The exposed tools are **read + manage-existing** only: search / spot prices /
+quotas (truffle) and list / status / stop / terminate / extend (spawn). There is
+**no `launch` tool**, deliberately: creating billable infrastructure from an AI
+assistant is a boundary we don't cross automatically. The assistant helps you find
+the right instance and *construct* the `spawn launch` command; you run it. See the
+full tool list below.
+:::
 
 ## Install
 

--- a/web/index.html
+++ b/web/index.html
@@ -151,7 +151,7 @@
             <ul class="tool-features">
               <li>Works with Claude Desktop, Cursor, and more</li>
               <li>Natural language instance search via truffle</li>
-              <li>Full instance lifecycle via spawn</li>
+              <li>Manage running instances via spawn (status, stop, terminate, extend — no launch, by design)</li>
               <li>Install via Homebrew — one config line</li>
             </ul>
             <a href="https://github.com/spore-host/spore-host-mcp" class="tool-link" target="_blank" rel="noopener">MCP server docs</a>


### PR DESCRIPTION
Closes #442. Surgical corrections to the cross-page factual contradictions the review found (all concerning expensive/auto-deleting resources): TTL-vs-idle, terminate-not-stop cleanup, canonical `spawn connect` + correct key story, MCP no-launch-by-design, Route 53 optional, AWS CLI 2.32.0 + IAM Identity Center path, Free Tier hedge, IAM 'least-privilege baseline' + sts note, real manual-install download command. Docs build passes.