### PR TITLE
docs: add contributor path + surface support channels

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,29 @@
+name: Documentation issue
+description: Report an error, gap, or confusing wording in the docs or website
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the spore.host docs. For a broken or incorrect
+        statement, please link the exact page.
+  - type: input
+    id: page
+    attributes:
+      label: Page / URL
+      description: The docs page or website URL with the problem.
+      placeholder: "e.g. https://docs.spore.host/quickstart"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+      description: What does it say (or fail to say), and why is that a problem?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix (optional)
+      description: If you know what it should say, tell us here.

--- a/.github/ISSUE_TEMPLATE/security_report.yml
+++ b/.github/ISSUE_TEMPLATE/security_report.yml
@@ -1,0 +1,27 @@
+name: Security vulnerability
+description: PLEASE DON'T — report vulnerabilities privately (see below)
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 🔒 Do not report security vulnerabilities in a public issue
+
+        Please **stop** and report privately instead, so the issue isn't disclosed
+        before a fix is available:
+
+        **→ [Open a private security advisory](https://github.com/spore-host/spore-host/security/advisories/new)**
+
+        This reaches the maintainers privately. See [SECURITY.md](https://github.com/spore-host/spore-host/blob/main/SECURITY.md)
+        for scope and what to include.
+
+        If your report is **not** a vulnerability (e.g. a general hardening
+        suggestion or a docs clarification), use the Bug report or Documentation
+        issue template instead.
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I understand vulnerabilities should be reported via the private advisory link above, not here.
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,69 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement in the
+[community Discord](https://discord.gg/2deGRFCW) or via a private
+[GitHub Security Advisory](https://github.com/spore-host/spore-host/security/advisories/new)
+for sensitive reports. All complaints will be reviewed and investigated promptly
+and fairly.
+
+Community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to spore.host
+
+Thanks for your interest in improving spore.host. This repo (`spore-host`) is the
+umbrella: it holds the documentation site, the hosted API/dashboard, deployment
+automation, and this project-wide guidance. The individual tools live in their own
+repositories.
+
+## Where things live (open issues in the right repo)
+
+| You want to… | Repo |
+|--------------|------|
+| Report a docs problem, or a website/dashboard/API issue | [spore-host](https://github.com/spore-host/spore-host) (this repo) |
+| File a bug or request a feature in **spawn** (launch/lifecycle) | [spawn](https://github.com/spore-host/spawn) |
+| …in **truffle** (discovery/pricing/quotas) | [truffle](https://github.com/spore-host/truffle) |
+| …in **lagotto** (capacity watching) | [lagotto](https://github.com/spore-host/lagotto) |
+| …in the **MCP server** | [spore-host-mcp](https://github.com/spore-host/spore-host-mcp) |
+| Add or fix an official **plugin** | [spore-plugins](https://github.com/spore-host/spore-plugins) |
+| A **workflow adapter** (Nextflow/Snakemake/CWL/WDL/Airflow) | its own `*-spawn` / `*-executor-plugin-spawn` repo |
+
+Not sure which repo? Open it here and we'll route it, or ask in
+[Discord](https://discord.gg/2deGRFCW).
+
+## Getting help vs. reporting
+
+- **Question or usage help:** [Discord](https://discord.gg/2deGRFCW) is faster than an issue.
+- **Bug / feature:** open an issue in the relevant repo (templates provided).
+- **Security vulnerability:** do **not** open a public issue — use the private
+  [security advisory form](https://github.com/spore-host/spore-host/security/advisories/new).
+  See [SECURITY.md](SECURITY.md).
+
+## Development
+
+Each Go tool follows the same conventions (see the repo's `CLAUDE.md` / `Makefile`):
+
+- **Build/test:** `make check` (fmt, vet, lint, short tests) before every commit;
+  `make test` for full coverage; `make build` to build.
+- **Style:** `gofmt`/`goimports`; pass `go vet` + `staticcheck` + `golangci-lint`;
+  godoc comments on exported identifiers; wrap errors with `fmt.Errorf("op: %w", err)`.
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`), branch prefixes `feat/` `fix/`
+  `docs/`, one PR per change, link the issue.
+- **Versioning:** [SemVer 2.0.0](https://semver.org) + a Keep-a-Changelog
+  `CHANGELOG.md`; update `## [Unreleased]` in the **same PR** as any user-facing change.
+- **Docs:** the site is VitePress under `docs/`. `cd docs && npm install && npm run
+  docs:dev` to preview; `npm run build` must pass. CLI references are generated —
+  don't hand-edit generated pages.
+
+## Cost safety (important)
+
+Several tools launch **real, billable** AWS resources. Any test that touches AWS
+must set a TTL, terminate explicitly when done, and be independently leak-checked
+(no orphaned instances). Never commit changes that could leave resources running.
+
+## Code of Conduct
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+Contributions are accepted under the project's [Apache 2.0 license](LICENSE).

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -217,6 +217,14 @@ export default defineConfig({
       { text: 'Workflows', link: '/guides/' },
       { text: 'Tools', link: '/tools/' },
       { text: 'Reference', link: '/reference/' },
+      {
+        text: 'Get help',
+        items: [
+          { text: '💬 Community chat (Discord)', link: 'https://discord.gg/2deGRFCW' },
+          { text: '🐛 Report a problem', link: 'https://github.com/spore-host/spore-host/issues/new/choose' },
+          { text: '🔒 Report a vulnerability (private)', link: 'https://github.com/spore-host/spore-host/security/advisories/new' },
+        ],
+      },
       { text: 'spore.host', link: 'https://spore.host', target: '_blank' },
     ],
 
@@ -224,6 +232,7 @@ export default defineConfig({
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/spore-host/spore-host' },
+      { icon: 'discord', link: 'https://discord.gg/2deGRFCW' },
     ],
 
     editLink: {
@@ -232,7 +241,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: 'Released under the <a href="https://github.com/spore-host/spore-host/blob/main/LICENSE">Apache 2.0 License</a>.',
+      message: 'Get help on <a href="https://discord.gg/2deGRFCW">Discord</a> · <a href="https://github.com/spore-host/spore-host/issues/new/choose">Report a problem</a> · <a href="https://github.com/spore-host/spore-host/security/advisories/new">Report a vulnerability</a> · Released under the <a href="https://github.com/spore-host/spore-host/blob/main/LICENSE">Apache 2.0 License</a>.',
       copyright: '© 2026 Scott Friedman',
     },
 


### PR DESCRIPTION
Closes #443. Addresses the review's 'dead end' (docs say open an issue, but no CONTRIBUTING/CoC and no help link in the docs chrome). Adds CONTRIBUTING.md (which repo owns which issue + dev conventions), CODE_OF_CONDUCT.md (Contributor Covenant 2.1), a 'Get help' nav menu + footer strip + Discord icon in the VitePress config, and docs + security issue templates (security one redirects to the private advisory). Docs build passes.