### PR TITLE
docs: rebuild onboarding around permissions + goals

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -126,6 +126,7 @@ const sidebar = {
       collapsed: true,
       items: [
         { text: 'IAM Permissions', link: '/reference/iam-permissions' },
+        { text: 'Deployment packet (for admins)', link: '/reference/deployment-packet' },
         { text: 'Self-Hosting', link: '/guides/self-hosting' },
         { text: 'Self-Hosting spore-bot', link: '/spore-bot-self-hosting' },
       ]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,31 @@
 ---
-description: "This guide gets you from zero to a running EC2 instance in about five minutes."
+description: "Install spore.host, confirm your AWS permissions, and launch your first self-terminating instance."
 ---
 
 # Quick Start
 
-This guide gets you from zero to a running EC2 instance in about five minutes. You'll need an AWS account with credentials configured — everything else is handled for you.
+Once your AWS access **and the required permissions** are in place, your first
+protected instance takes about five minutes to launch. The permissions are the
+one part that isn't automatic — so start by figuring out which situation you're in.
+
+## First: which AWS account are you using?
+
+::: tip Personal or admin-managed account
+You can create IAM roles yourself, so you can install the required policy and go.
+Follow this page top to bottom.
+:::
+
+::: warning Institution-managed account (most university / company accounts)
+You can probably authenticate and launch some EC2, but you likely **cannot create
+IAM roles or attach policies** — spawn needs both (once) for the spored instance
+profile. You'll need your cloud/security administrator to apply the policy. Send
+them the **[deployment packet](/reference/deployment-packet)** (the exact
+least-privilege policy, what spawn creates, what it audits, and how to remove it),
+then come back and continue from [Authenticate](#authenticate-with-aws).
+:::
+
+Not sure whether you have the permissions? After installing, run
+[`spawn doctor`](#preflight-spawn-doctor) — it tells you exactly what's missing.
 
 ## Install
 
@@ -56,7 +77,28 @@ Other paths work too — pick whichever matches your organization:
 
 `aws login` is preferred where available because the credentials are short-lived.
 
-Your credentials need permission to launch and manage EC2 instances; see the [minimal IAM policy](/reference/iam-permissions). For the full picture — profiles, `SPORE_*` config, and how your auth relates to what spore.host does on your behalf — see [AWS Authentication](/guides/aws-auth).
+Your credentials need permission to launch and manage EC2 instances; see the [recommended least-privilege baseline](/reference/iam-permissions). For the full picture — profiles, `SPORE_*` config, and how your auth relates to what spore.host does on your behalf — see [AWS Authentication](/guides/aws-auth).
+
+## Preflight: `spawn doctor`
+
+Before launching anything, confirm your environment is actually ready:
+
+```sh
+spawn doctor
+```
+
+It runs read-only checks — credentials, the resolved account and region, the EC2
+and IAM permissions spawn needs, a usable VPC/subnet, an SSH key, Session Manager —
+and reports **✓ / ⚠ / ✗** for each. It launches nothing.
+
+- **All ✓ (or only ⚠):** you're ready — continue below.
+- **Any ✗ on an IAM/permission check:** that's the permissions cliff. On a personal
+  account, apply the [IAM baseline](/reference/iam-permissions). On an
+  institution-managed account, send your admin the
+  [deployment packet](/reference/deployment-packet) — the failing checks are
+  exactly what they need to grant.
+
+If `spawn doctor` passes, the rest of this Quick Start should work as written.
 
 ## Find an instance
 

--- a/docs/reference/deployment-packet.md
+++ b/docs/reference/deployment-packet.md
@@ -1,0 +1,113 @@
+---
+description: "Everything a cloud/security administrator needs to approve spore.host for a researcher on an institution-managed AWS account — in one page."
+---
+
+# Deployment packet (for AWS administrators)
+
+A researcher on your team wants to use **spore.host** to launch short-lived,
+self-terminating EC2 instances in your AWS account. This page is the one thing
+they need to hand you: what it is, exactly what permissions it needs and why,
+what it creates, what it audits, what (if anything) leaves the account, and how to
+remove it.
+
+**One-line summary:** spore.host is a set of CLI tools that run on the
+researcher's machine with *their* AWS credentials and launch EC2 in *your*
+account. It never receives your credentials or workload data. Its whole purpose is
+to bound cost — every instance gets a hard termination deadline. See
+[Security, credentials & data flow](/architecture) for the full trust map and
+[Security Overview](https://github.com/spore-host/spore-host/blob/main/SECURITY.md)
+for the CISO-oriented assessment.
+
+## 1. The least-privilege policy to grant
+
+The complete, verified baseline policy is on the
+**[IAM Permissions](/reference/iam-permissions)** page — apply that policy to the
+IAM role/user the researcher authenticates as. It grants:
+
+- **EC2** describe + `RunInstances` + tag + start/stop/terminate (the last three
+  **conditioned on `spawn:managed=true`**, so it can only act on instances spawn
+  created — never anything else in the account).
+- **EC2** `ImportKeyPair`, `CreateSecurityGroup`, `AuthorizeSecurityGroupIngress`
+  (to install the user's SSH key and open SSH to the instance).
+- **IAM** create-role / instance-profile / `PassRole` **scoped to `spored*` names
+  only** — so it cannot create or touch any role that isn't named `spored*`.
+
+Optional feature permissions (Spot, Route 53 DNS, FSx) are listed separately on
+that page and are only needed if the researcher uses those flags.
+
+## 2. What spawn creates in your account
+
+| Resource | When | Notes |
+|----------|------|-------|
+| `spored-instance-role` + `spored-instance-profile` | Once per account, on first launch | Scoped so the instance can read its own tags and stop/terminate itself only |
+| EC2 instances | Per `spawn launch` | Tagged `spawn:managed=true`, `spawn:ttl`, `spawn:created-by=spawn`, etc. |
+| A security group | Per launch (if none supplied) | Opens SSH (22) to the launching user; you can supply your own instead |
+| An imported EC2 key pair | Per user | The researcher's **public** key only |
+
+The `spored` role/profile is the only standing resource; everything else is
+ephemeral and self-terminates.
+
+## 3. What it audits
+
+Every action spawn takes is a normal AWS API call by the researcher's identity,
+so it all lands in **CloudTrail** under their principal: `RunInstances`,
+`TerminateInstances`, `CreateRole`/`CreateInstanceProfile` (first launch),
+`ImportKeyPair`, `CreateSecurityGroup`, and the tagging calls. You can build a
+Cost Allocation report from the `spawn:*` tags. See the
+[Security Overview](https://github.com/spore-host/spore-host/blob/main/SECURITY.md#5-audit-and-compliance)
+for example CloudTrail queries.
+
+## 4. What leaves the account
+
+**By default: nothing.** The CLI and the in-instance `spored` daemon run entirely
+within your account. Optional hosted integrations (Slack/Teams notifications, DNS
+subdomains) call out to spore.host's own AWS account over HTTPS and receive
+**selected metadata only** (instance id, state, tags) — never credentials or
+workload data — and only if the researcher enables them. Those can also be
+[self-hosted](/guides/self-hosting) so nothing leaves the account at all. See the
+["guarantee by deployment mode" table](https://github.com/spore-host/spore-host/blob/main/SECURITY.md#lifecycle-guarantee-by-deployment-mode).
+
+## 5. Cost-safety posture (why this reduces risk)
+
+spore.host exists to prevent forgotten instances. Every launch has a **TTL** — a
+hard deadline enforced from inside the instance by `spored`, independent of the
+researcher's laptop. You can additionally require budgets/SCPs as usual; spore.host
+complements them. See [Costs & safety guarantees](/safety).
+
+## 6. Predeployment validation
+
+Before (and after) you grant the policy, the researcher can run:
+
+```sh
+spawn doctor
+```
+
+It performs read-only checks and reports exactly which permissions are present or
+missing — so you can confirm the grant is correct without launching anything. If
+`spawn doctor` reports all-clear, they're ready.
+
+## 7. Removal / cleanup
+
+To fully remove spore.host's footprint:
+
+```sh
+# terminate any managed instances
+spawn terminate --all            # or: aws ec2 terminate-instances --instance-ids …
+                                 #     (filter on tag:spawn:managed=true)
+
+# then delete the standing IAM role + instance profile
+aws iam remove-role-from-instance-profile --instance-profile-name spored-instance-profile --role-name spored-instance-role
+aws iam delete-instance-profile --instance-profile-name spored-instance-profile
+aws iam delete-role --role-name spored-instance-role
+```
+
+Detach the least-privilege policy from the researcher's identity to revoke access.
+`spawn orphans` / `spawn cleanup` (run by the researcher) find and remove any
+stragglers.
+
+---
+
+**Questions?** The [Security Overview](https://github.com/spore-host/spore-host/blob/main/SECURITY.md)
+answers most security-team questions; for anything else, reach the maintainers via
+[Discord](https://discord.gg/2deGRFCW) or a
+[private security advisory](https://github.com/spore-host/spore-host/security/advisories/new).

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -320,6 +320,32 @@ h2.section-title {
 .tool-link { font-size: 0.85rem; font-weight: 600; margin-top: 0.25rem; }
 .tool-link::after { content: " →"; }
 
+/* Tool card link row: Docs · Source · Releases (no arrow, muted separators) */
+.tool-links { font-size: 0.85rem; margin-top: 0.5rem; color: var(--text-muted); }
+.tool-links a { font-weight: 600; text-decoration: none; }
+.tool-links .tool-link::after { content: ""; }
+
+/* Hero trust strip */
+.trust-strip {
+  margin: 1rem auto 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  max-width: 46rem;
+  line-height: 1.6;
+}
+
+/* Use-case entry table */
+#use-cases { padding-top: 2rem; }
+.usecase-table { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 1rem; }
+.usecase-row {
+  display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+  padding: 0.75rem 1rem; border: 1px solid var(--border); border-radius: 8px;
+  text-decoration: none; color: var(--text); transition: border-color 0.15s, background 0.15s;
+}
+.usecase-row:hover { border-color: var(--border-strong); background: var(--surface, rgba(127,127,127,0.06)); }
+.usecase-goal { font-weight: 600; }
+.usecase-path { font-size: 0.85rem; color: var(--text-muted); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; text-align: right; }
+
 /* Tool colour theming */
 .tool-truffle .tool-tag { background: var(--truffle-bg); color: var(--truffle); }
 .tool-truffle .tool-link { color: var(--truffle); }

--- a/web/index.html
+++ b/web/index.html
@@ -59,9 +59,12 @@
           <span>macOS, Linux, Windows</span>
         </div>
         <div class="hero-actions">
-          <a href="#install" class="btn btn-primary">Get started</a>
-          <a href="https://github.com/spore-host/spore-host" target="_blank" rel="noopener" class="btn btn-outline">View on GitHub</a>
+          <a href="https://docs.spore.host/guides/first-instance" class="btn btn-primary">Launch your first protected instance</a>
+          <a href="https://docs.spore.host/how-it-works" class="btn btn-outline">See how it works</a>
+          <a href="https://github.com/spore-host/spore-host" target="_blank" rel="noopener" class="btn btn-outline">Browse source</a>
         </div>
+
+        <p class="trust-strip">Runs in your AWS account · Credentials stay with you · Hard TTL on every protected instance · Open source · No standing cluster</p>
 
         <div id="demo-wrapper">
           <p class="demo-hint">AMD EPYC Genoa search · launch with TTL + idle timeout · run a job · check cost · watch it self-terminate</p>
@@ -69,6 +72,22 @@
         </div>
       </div>
     </div>
+
+    <!-- ── Use-case entry points ── -->
+    <section id="use-cases">
+      <div class="container">
+        <p class="section-label">Start from your goal</p>
+        <h2 class="section-title">What are you trying to do?</h2>
+        <div class="usecase-table">
+          <a class="usecase-row" href="https://docs.spore.host/guides/first-instance"><span class="usecase-goal">Start a temporary research workstation</span><span class="usecase-path">spawn → connect</span></a>
+          <a class="usecase-row" href="https://docs.spore.host/guides/"><span class="usecase-goal">Run a job and terminate when it's done</span><span class="usecase-path">spawn task / job</span></a>
+          <a class="usecase-row" href="https://docs.spore.host/tools/truffle"><span class="usecase-goal">Find the right CPU or GPU (and its price)</span><span class="usecase-path">truffle</span></a>
+          <a class="usecase-row" href="https://docs.spore.host/guides/"><span class="usecase-goal">Run many independent jobs at once</span><span class="usecase-path">arrays / sweeps</span></a>
+          <a class="usecase-row" href="https://docs.spore.host/tools/lagotto"><span class="usecase-goal">Wait for scarce GPU capacity to appear</span><span class="usecase-path">lagotto</span></a>
+          <a class="usecase-row" href="https://docs.spore.host/guides/workflow-engines"><span class="usecase-goal">Use an existing workflow engine</span><span class="usecase-path">Nextflow / Snakemake / CWL / WDL / Airflow</span></a>
+        </div>
+      </div>
+    </section>
 
     <!-- ── Tools ── -->
     <section id="tools">
@@ -89,7 +108,7 @@
               <li>Quota check before you launch</li>
               <li>On-Demand Capacity Reservations</li>
             </ul>
-            <a href="https://github.com/spore-host/truffle" class="tool-link" target="_blank" rel="noopener">truffle docs</a>
+            <p class="tool-links"><a href="https://docs.spore.host/tools/truffle" class="tool-link">Docs</a> · <a href="https://github.com/spore-host/truffle" target="_blank" rel="noopener">Source</a> · <a href="https://github.com/spore-host/truffle/releases" target="_blank" rel="noopener">Releases</a></p>
           </div>
 
           <div class="tool-card tool-spawn">
@@ -102,7 +121,7 @@
               <li>Hibernation support</li>
               <li>Spot, GPU, MPI clusters, parameter sweeps</li>
             </ul>
-            <a href="https://github.com/spore-host/spawn" class="tool-link" target="_blank" rel="noopener">spawn docs</a>
+            <p class="tool-links"><a href="https://docs.spore.host/tools/spawn" class="tool-link">Docs</a> · <a href="https://github.com/spore-host/spawn" target="_blank" rel="noopener">Source</a> · <a href="https://github.com/spore-host/spawn/releases" target="_blank" rel="noopener">Releases</a></p>
           </div>
 
           <div class="tool-card tool-spored">
@@ -115,7 +134,7 @@
               <li>Fires completion, TTL-warning, and idle events</li>
               <li>Runs pre-stop hooks to save work before shutdown</li>
             </ul>
-            <a href="https://docs.spore.host/tools/spored" class="tool-link" target="_blank" rel="noopener">spored docs</a>
+            <p class="tool-links"><a href="https://docs.spore.host/tools/spored" class="tool-link">Docs</a> · <a href="https://github.com/spore-host/spawn" target="_blank" rel="noopener">Source</a> · <a href="https://github.com/spore-host/spawn/releases" target="_blank" rel="noopener">Releases</a></p>
           </div>
 
           <div class="tool-card tool-lagotto">
@@ -128,7 +147,7 @@
               <li>Serverless — runs as a Lambda function</li>
               <li>Slack notifications when capacity appears</li>
             </ul>
-            <a href="https://github.com/spore-host/lagotto" class="tool-link" target="_blank" rel="noopener">lagotto docs</a>
+            <p class="tool-links"><a href="https://docs.spore.host/tools/lagotto" class="tool-link">Docs</a> · <a href="https://github.com/spore-host/lagotto" target="_blank" rel="noopener">Source</a> · <a href="https://github.com/spore-host/lagotto/releases" target="_blank" rel="noopener">Releases</a></p>
           </div>
 
           <div class="tool-card tool-bot">
@@ -141,7 +160,7 @@
               <li>OAuth — one-click workspace connection</li>
               <li>Works from any device, anywhere</li>
             </ul>
-            <a href="https://docs.spore.host/tools/spore-bot" class="tool-link" target="_blank" rel="noopener">spore-bot docs</a>
+            <p class="tool-links"><a href="https://docs.spore.host/tools/spore-bot" class="tool-link">Docs</a> · <a href="https://github.com/spore-host/spawn" target="_blank" rel="noopener">Source</a> · <a href="https://docs.spore.host/guides/slack-setup" target="_blank" rel="noopener">Setup</a></p>
           </div>
 
           <div class="tool-card tool-mcp">
@@ -154,7 +173,7 @@
               <li>Manage running instances via spawn (status, stop, terminate, extend — no launch, by design)</li>
               <li>Install via Homebrew — one config line</li>
             </ul>
-            <a href="https://github.com/spore-host/spore-host-mcp" class="tool-link" target="_blank" rel="noopener">MCP server docs</a>
+            <p class="tool-links"><a href="https://docs.spore.host/tools/mcp-server" class="tool-link">Docs</a> · <a href="https://github.com/spore-host/spore-host-mcp" target="_blank" rel="noopener">Source</a> · <a href="https://github.com/spore-host/spore-host-mcp/releases" target="_blank" rel="noopener">Releases</a></p>
           </div>
 
         </div>


### PR DESCRIPTION
Closes #445. Addresses the review's core onboarding finding — the 5-minute promise hid the permissions cliff, and the homepage led with install rather than a guided launch.

- **Quick Start**: splits by AWS situation at the top (personal/admin → install the policy yourself; institution-managed → send your admin the deployment packet), rewords the 5-min promise to start *after* permissions are in place, and adds a **`spawn doctor` preflight** step so "if doctor passes, the Quick Start works."
- **New `reference/deployment-packet.md`**: a one-page admin/security-review packet — least-privilege policy, what spawn creates, what it audits (CloudTrail), what leaves the account (nothing by default), cost-safety posture, `spawn doctor` as the predeploy validator, and removal steps. Added to the Administration sidebar.
- **Homepage**: primary CTA → guided first-instance (was `#install`); adds a "what are you trying to do" use-case table + a trust strip; tool cards now lead to the unified docs (Docs · Source · Releases) instead of GitHub READMEs; CSS for the new components.

Docs build passes; homepage HTML validated. Depends on `spawn doctor` (spore-host/spawn#426) for the preflight step. Refs #445."