### PR TITLE
docs: scope MCP, fix SSH-key wording, add reaper-by-mode table (#451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Fixed
+- **Docs: MCP scope, SSH-key wording, and reaper guarantee-by-mode** (from a second
+  external review). Reworded the How It Works MCP section — it no longer says the
+  server "exposes all of the above"; it now states MCP does read/manage operations
+  (find, status, stop, terminate, extend) and **cannot launch** by design. Corrected
+  the SSH-key note in `how-it-works.md` and `architecture.md`: spawn imports your
+  existing default public key and only generates/manages one under `~/.spawn/keys/`
+  if you have none (never touches private keys) — matching the FAQ, aws-auth, and
+  quickstart pages. Added the **lifecycle guarantee-by-deployment-mode** table
+  (CLI-only / self-hosted backstop / hosted integrations, with the reaper's dry-run
+  default) to the Safety page, previously only in `SECURITY.md`.
 - **Docs: corrected `--cost-limit` description** (safety, glossary, spored, EC2
   tags). It's a **compute-only** ceiling (excludes EBS/storage), accumulates
   across stop/resume rather than resetting, **terminates** the instance, and fires

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,11 @@ env vars that point the tools at hosted vs. self-hosted infrastructure in
 
 ## What spore.host doesn't do
 
-- It doesn't manage your SSH keys beyond passing the one you specify at launch.
+- It doesn't take over SSH-key management. spawn imports your existing default
+  public key (`~/.ssh/id_ed25519` or `~/.ssh/id_rsa`) into EC2 and connects you as
+  a user matching your local login; only if you have no default key does it
+  generate and manage one under `~/.spawn/keys/`. It never reads, moves, or uploads
+  your private keys.
 - It doesn't modify your AWS account structure, VPCs, or security groups beyond
   what's needed to launch.
 - It doesn't store your AWS credentials — everything uses your existing chain.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -72,7 +72,7 @@ Lifecycle events from spored are routed through spore-bot to your Slack DMs:
 
 ### <span class="tool-badge mcp">MCP Server</span> — Control from AI assistants
 
-The spore.host MCP server exposes all of the above as tools for AI assistants that support the Model Context Protocol — Claude Desktop, Cursor, and others. Instead of running CLI commands, you describe what you need in plain language and the assistant handles it.
+The spore.host MCP server exposes spore.host's **read and manage** operations as tools for AI assistants that support the Model Context Protocol — Claude Desktop, Cursor, and others. It can discover instance types with truffle and inspect or manage instances you already have running (status, stop, terminate, extend) — but it deliberately **cannot launch** instances, so an assistant can never spin up billable compute on your behalf. Instead of running CLI commands, you describe what you need in plain language and the assistant handles it.
 
 > *"What instances do I have running and how long until they terminate?"*
 
@@ -106,7 +106,7 @@ This means you can set global defaults once and override per-launch without re-s
 
 ## What spore.host doesn't do
 
-- It doesn't manage your SSH keys beyond passing the one you specify at launch
+- It doesn't take over SSH-key management: spawn imports your existing default public key (`~/.ssh/id_ed25519` or `~/.ssh/id_rsa`) and only generates a managed key under `~/.spawn/keys/` if you have none — it never touches or uploads your private keys
 - It doesn't modify your AWS account structure, VPCs, or security groups (beyond what's needed to launch)
 - It doesn't store your AWS credentials — everything uses your existing credential chain
 - It doesn't require any always-on infrastructure in your account (spored runs on the instance; the Lambda functions run in the spore.host-infra account)

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -49,6 +49,27 @@ spored is healthy. This is why lifecycle enforcement doesn't depend on a single
 point of failure: the instance enforces its own deadline *and* an external sweep
 enforces it too.
 
+## What the guarantee is by deployment mode
+
+Whether you get one enforcement layer or two depends on which mode you deploy. The
+reaper is **not enabled by default** — the plain CLI gives you in-instance
+enforcement only, and the backstop is something you opt into.
+
+| Mode | spored (in-instance) | Out-of-band reaper | Workload data leaves your account | Failure guarantee |
+|------|:---:|:---:|:---:|---|
+| **CLI only** (default) | Yes | No | No | spored terminates at TTL from inside the instance. If spored is disabled or killed, only your AWS-side controls (Budgets / SCPs) remain. |
+| **Self-hosted backstop** | Yes | Yes (in your account) | No | Dual enforcement — the reaper terminates past-deadline instances even if spored fails. |
+| **Hosted integrations** | Yes | Yes / optional | Selected metadata only (never credentials or workload data) | Dual enforcement when the reaper is enabled. |
+
+The reaper (see
+[spawn/lambda/ttl-reaper](https://github.com/spore-host/spawn/tree/main/lambda/ttl-reaper))
+ships in **dry-run** — it logs "would reap" and notifies but does not terminate —
+until an operator flips it to enforce mode after verification. It assumes a narrow
+per-account [cross-account role you grant](/architecture),
+scoped to terminating past-deadline `spawn:managed` instances, and never holds your
+credentials. The full guarantee-by-mode breakdown lives in
+[SECURITY.md](https://github.com/spore-host/spore-host/blob/main/SECURITY.md#lifecycle-guarantee-by-deployment-mode).
+
 ## Verify enforcement is healthy
 
 Don't take it on faith — confirm it, especially the first few times:


### PR DESCRIPTION
Closes #451. Part of the review-response milestone (#30).

Three current-source content gaps confirmed by the second external review (verified against main by parallel Explore agents):

1. **MCP scope** — `how-it-works.md` said the MCP server "exposes all of the above as tools," implying launch. The MCP server has no launch tool by design. Reworded to describe read/manage operations (find, status, stop, terminate, extend) and call out the no-launch safety boundary explicitly, matching the already-corrected homepage card.
2. **SSH-key wording** — `how-it-works.md` and `architecture.md` said spawn does nothing "beyond passing the one you specify," contradicting the FAQ/aws-auth/quickstart pages. Corrected to the accurate story: imports your existing default public key, generates/manages one under `~/.spawn/keys/` only if you have none, never touches private keys.
3. **Reaper guarantee-by-mode** — the deployment-mode table (CLI-only / self-hosted backstop / hosted integrations, with the reaper's dry-run default) existed only in SECURITY.md. Ported into `docs/safety.md` with a pointer back to SECURITY.md.

`npm run build` passes; re-grep confirms no stale "all of the above" / "beyond passing the one you specify" strings remain.