### PR TITLE
ci(docs): make the deploy a verifiable release artifact (#455)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,9 +28,15 @@ jobs:
         working-directory: docs
         run: npm ci
 
+      # GITHUB_SHA is already in the environment; DOCS_BUILD_DATE stamps the build
+      # so the rendered footer self-identifies its commit + date (config.mts reads
+      # both). This is the source side of the release-integrity check the
+      # post-deploy smoke below asserts against the live site.
       - name: Build docs
         working-directory: docs
-        run: npm run build
+        run: |
+          export DOCS_BUILD_DATE="$(date -u +%Y-%m-%d)"
+          npm run build
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
@@ -38,14 +44,64 @@ jobs:
           role-to-assume: arn:aws:iam::966362334030:role/GitHubActionsDocsDeployRole
           aws-region: us-east-1
 
+      # Two-pass sync so caching matches asset lifetime. VitePress fingerprints
+      # JS/CSS filenames (content hash in the name), so those are safe to cache for
+      # a year — a changed asset gets a new URL. HTML filenames are stable, so a
+      # long cache there is exactly what made the site look "stale" to a returning
+      # visitor: the edge/browser served up-to-an-hour-old HTML. Sync the immutable
+      # hashed assets first with a long cache, then overlay the HTML (and other
+      # top-level files) with a short, must-revalidate cache.
       - name: Deploy to S3
         run: |
+          # Pass 1: fingerprinted assets — cache hard (immutable).
+          aws s3 sync docs/.vitepress/dist s3://spore-host-docs/ \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "*.html" \
+            --exclude "*.xml" \
+            --exclude "*.txt"
+          # Pass 2: HTML + sitemap/llms manifests — short cache, always revalidate,
+          # and --delete here so removed pages are pruned.
           aws s3 sync docs/.vitepress/dist s3://spore-host-docs/ \
             --delete \
-            --cache-control "max-age=3600"
+            --cache-control "public, max-age=60, must-revalidate" \
+            --exclude "*" \
+            --include "*.html" \
+            --include "*.xml" \
+            --include "*.txt"
 
       - name: Invalidate CloudFront
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.DOCS_CLOUDFRONT_ID }} \
             --paths "/*"
+
+      # Post-deploy smoke: prove the LIVE site serves this build, not a stale one.
+      # Poll the public URL (riding out invalidation propagation) and assert the
+      # canonical CLI strings AND this commit's short SHA appear in the footer. A
+      # stale serve — old HTML behind the CDN, a silently-failed deploy — makes the
+      # grep miss and fails the job loudly instead of looking green.
+      - name: Verify live site serves this build
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          BASE="https://docs.spore.host"
+          check() {  # $1=path  $2=needle
+            curl -fsS "$BASE/$1" | grep -qF "$2"
+          }
+          ok=0
+          for attempt in 1 2 3 4 5 6; do
+            if check "quickstart.html" "spawn doctor" \
+               && check "quickstart.html" "spawn connect" \
+               && check "safety.html" "terminate" \
+               && check "index.html" "$SHORT_SHA"; then
+              ok=1
+              echo "✅ Live site serves build $SHORT_SHA with canonical strings present."
+              break
+            fi
+            echo "Attempt $attempt: live site not yet serving build $SHORT_SHA — waiting…"
+            sleep 20
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::Live docs.spore.host did not serve build $SHORT_SHA (or a canonical string was missing) after retries. Deploy may be stale — check CloudFront invalidation and the S3 sync."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Added
+- **Docs deploy is now a verifiable release artifact.** The rendered site footer
+  carries a **build stamp** — the commit short-SHA (linked) and build date — so you
+  can tell from the live site exactly which commit is deployed. The deploy workflow
+  now runs a **post-deploy smoke** that polls the live `docs.spore.host` and fails
+  the job if the just-built commit or canonical CLI strings (`spawn doctor`,
+  `spawn connect`, `terminate`) aren't served, turning a silent stale-serve into a
+  red build. HTML is now cached short (`max-age=60, must-revalidate`) while
+  fingerprinted JS/CSS assets are cached immutably for a year — so returning
+  visitors no longer see up-to-an-hour-stale pages.
+
 ### Fixed
 - **Docs: corrected `--cost-limit` description** (safety, glossary, spored, EC2
   tags). It's a **compute-only** ceiling (excludes EBS/storage), accumulates

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,6 +4,18 @@ import path from 'node:path'
 
 const SITE_URL = 'https://docs.spore.host'
 
+// Build stamp — makes every deployed build self-identifying so you can tell from
+// the live site which commit/date it was built from (a docs-release-integrity
+// check: if the footer commit doesn't match main, the deploy is stale). In CI,
+// GITHUB_SHA and DOCS_BUILD_DATE are set by .github/workflows/docs.yaml; locally
+// they're absent, so we fall back to a "dev" marker and today's date.
+const BUILD_SHA = (process.env.GITHUB_SHA || '').slice(0, 7) || 'dev'
+const BUILD_DATE = process.env.DOCS_BUILD_DATE || new Date().toISOString().slice(0, 10)
+const BUILD_STAMP =
+  BUILD_SHA === 'dev'
+    ? `local build · ${BUILD_DATE}`
+    : `build <a href="https://github.com/spore-host/spore-host/commit/${process.env.GITHUB_SHA}"><code>${BUILD_SHA}</code></a> · ${BUILD_DATE}`
+
 // Sidebar is a top-level const so the llms.txt generator (buildEnd, below) can
 // walk the exact same structure the site renders — the manifest can't drift from
 // the nav.
@@ -243,7 +255,7 @@ export default defineConfig({
 
     footer: {
       message: 'Get help on <a href="https://discord.gg/2deGRFCW">Discord</a> · <a href="https://github.com/spore-host/spore-host/issues/new/choose">Report a problem</a> · <a href="https://github.com/spore-host/spore-host/security/advisories/new">Report a vulnerability</a> · Released under the <a href="https://github.com/spore-host/spore-host/blob/main/LICENSE">Apache 2.0 License</a>.',
-      copyright: '© 2026 Scott Friedman',
+      copyright: `© 2026 Scott Friedman · ${BUILD_STAMP}`,
     },
 
     search: {


### PR DESCRIPTION
Closes #455. Part of the review-response milestone (#30).

## Background

The second external review read the live site as stale and called it a "documentation release-integrity problem." I verified against the live system that **the pipeline is healthy** — every push to `main` under `docs/**` deploys and invalidates CloudFront (last runs all green), and `docs.spore.host` was serving current content at review time. The reviewer almost certainly hit the **1h HTML browser-cache window** (`cache-control: max-age=3600` on HTML) or reviewed before a deploy landed. There is no broken release path — but there was no way to *prove* which build the live site served, and the long HTML cache made stale-looking views easy to hit.

This PR closes that gap so the confusion can't recur.

## Changes

1. **Footer build stamp** (`docs/.vitepress/config.mts`) — renders the commit short-SHA (linked to the commit) + build date, read from `GITHUB_SHA` / `DOCS_BUILD_DATE` in CI, falling back to a `local build · <date>` marker offline so `npm run build` still works.
2. **Post-deploy smoke** (`docs.yaml`) — after the CloudFront invalidation, polls the live `docs.spore.host` (6× with backoff to ride out propagation) and **fails the job** unless it serves this commit's short-SHA *and* the canonical CLI strings (`spawn doctor`, `spawn connect`, `terminate`). A silent stale-serve becomes a red build.
3. **Cache fix** (`docs.yaml`) — two-pass `s3 sync`: fingerprinted JS/CSS assets cache immutably for a year; HTML + sitemap/llms manifests cache short (`max-age=60, must-revalidate`) so returning visitors no longer see up-to-an-hour-stale pages.

## Verification
- `npm run build` locally renders `local build · <date>` in the footer (dev fallback).
- YAML validated.
- On merge, watch the `Deploy Docs` run go green **including** the new smoke step; then load docs.spore.host and confirm the footer shows the merge commit SHA + today's date, and `curl -sI` shows short HTML caching.