### PR TITLE
fix(ci): docs post-deploy smoke false-negative under pipefail

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -85,8 +85,15 @@ jobs:
           set -euo pipefail
           SHORT_SHA="${GITHUB_SHA:0:7}"
           BASE="https://docs.spore.host"
+          # Fetch the page into a variable, THEN grep it — do NOT pipe curl into
+          # `grep -q`. Under `set -o pipefail`, `grep -q` exits on first match and
+          # closes the pipe, so curl aborts with a write error (exit 23) and
+          # pipefail reports the whole pipeline as failed even though the match
+          # succeeded. Separating the two steps avoids that false negative.
           check() {  # $1=path  $2=needle
-            curl -fsS "$BASE/$1" | grep -qF "$2"
+            local body
+            body="$(curl -fsS "$BASE/$1")" || return 1
+            printf '%s' "$body" | grep -qF "$2"
           }
           ok=0
           for attempt in 1 2 3 4 5 6; do


### PR DESCRIPTION
Follow-up to #456. The new post-deploy smoke failed its own first run even though the deploy was correct (live docs.spore.host served build `6d39db3` with all canonical strings and the new short HTML cache).

**Cause:** `check()` did `curl -fsS "$url" | grep -qF "$needle"`. Under `set -o pipefail`, `grep -q` exits on the first match and closes the pipe, so `curl` aborts with a write error (`curl: (23) Failure writing output to destination`) and pipefail marks the whole pipeline failed — a false negative on a successful match.

**Fix:** fetch the page into a variable, then grep it separately. Verified locally against the live site: all four checks now pass.

Refs #455.