### PR TITLE
ci: manual-installer platform matrix + fix broken install snippet (#454)

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -1,0 +1,80 @@
+name: Manual installer matrix
+
+# Verifies the documented manual `curl`-a-tarball install path (docs/quickstart.md
+# "Manual" tab) actually works on every platform we publish CLIs for. It resolves
+# each tool's LATEST GitHub release, downloads the OS/arch asset, extracts it onto
+# PATH, and asserts the binary runs. The install logic here mirrors the documented
+# snippet — if the docs command breaks (e.g. asset-naming drift), this job goes red.
+#
+# Runs on demand and on a weekly backstop; CLI release workflows can also fire a
+# `repository_dispatch` (type: installer-check) to re-verify install after a release.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 9 * * 1'   # Mondays, after the weekly docs sync
+  repository_dispatch:
+    types: [installer-check]
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS Intel (amd64)
+            runner: macos-13
+          - label: macOS Apple Silicon (arm64)
+            runner: macos-14
+          - label: Linux amd64
+            runner: ubuntu-latest
+          - label: Linux arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Install truffle + spawn from the latest release (manual path)
+        env:
+          # The documented snippet hits the unauthenticated GitHub API; in CI a
+          # token avoids the low anonymous rate limit. It's read-only.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Same normalization the docs snippet uses: assets are named with
+          # lowercase GOOS/GOARCH (darwin|linux, amd64|arm64).
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          case "$(uname -m)" in
+            x86_64|amd64) ARCH=amd64 ;;
+            arm64|aarch64) ARCH=arm64 ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          echo "Resolving assets for ${OS}_${ARCH}"
+          for tool in spawn truffle; do
+            url=$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              "https://api.github.com/repos/spore-host/${tool}/releases/latest" \
+              | grep -o "https://[^\"]*_${OS}_${ARCH}.tar.gz" | head -1)
+            if [ -z "$url" ]; then
+              echo "::error::No ${OS}_${ARCH} asset found for ${tool} in its latest release — the manual install would fail on this platform." >&2
+              exit 1
+            fi
+            echo "  ${tool}: ${url}"
+            curl -fsSL "$url" -o "${tool}.tar.gz"
+            tar -xzf "${tool}.tar.gz" "$tool"
+            sudo install "$tool" /usr/local/bin/
+          done
+
+      - name: Verify the installed binaries run
+        run: |
+          set -euo pipefail
+          for tool in spawn truffle; do
+            command -v "$tool" >/dev/null || { echo "::error::${tool} not on PATH after install" >&2; exit 1; }
+            # `version` must exit 0 and print something non-empty.
+            out=$("$tool" version)
+            [ -n "$out" ] || { echo "::error::${tool} version printed nothing" >&2; exit 1; }
+            echo "$tool -> $out"
+          done
+          echo "✅ Manual install path works on ${{ matrix.label }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Fixed
+- **Docs: the manual-install snippet was broken on every platform.** The Quick
+  Start "Manual" install commands matched release assets using `uname -s`/`uname -m`
+  (`Darwin`/`x86_64`), but GoReleaser names assets with lowercase GOOS/GOARCH
+  (`darwin`/`amd64`) — so the download URL resolved to nothing everywhere. The
+  snippet now lowercases the OS and maps `x86_64→amd64` / `aarch64→arm64`.
+
 ### Added
 - **Docs: new suite-wide Maturity & Support Policy page** (`/reference/maturity`).
   States in one place how mature each component is (six core tools Stable; HTTP
@@ -21,6 +28,11 @@ own changelogs for CLI releases.
   pin to a minor series), the platform support matrix (CLI OS/arch; what spawn can
   launch; GPU/EFA), and how deprecations/support work. Linked from the Reference
   index and sidebar; links to (does not duplicate) the workflow-adapter matrix.
+- **CI: manual-installer platform matrix** (`install-matrix.yml`). Runs the
+  documented manual `curl`-a-tarball install on macOS Intel/ARM and Linux
+  amd64/arm64, then asserts `spawn`/`truffle` land on PATH and run — so asset-naming
+  or install-doc drift turns into a red build instead of a broken first experience.
+  On-demand + weekly, and re-runnable via a `repository_dispatch` from CLI releases.
 - **Docs deploy is now a verifiable release artifact.** The rendered site footer
   carries a **build stamp** — the commit short-SHA (linked) and build date — so you
   can tell from the live site exactly which commit is deployed. The deploy workflow

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,7 +43,14 @@ scoop install truffle spawn
 
 ```sh [Manual]
 # Download the latest release assets for your OS/arch, then extract onto PATH.
-OS=$(uname -s); ARCH=$(uname -m)
+# Assets are named like spawn_<version>_<os>_<arch>.tar.gz with lowercase
+# GOOS/GOARCH (darwin|linux, amd64|arm64), so normalize uname's output first.
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$(uname -m)" in
+  x86_64|amd64) ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
 for tool in spawn truffle; do
   url=$(curl -fsSL "https://api.github.com/repos/spore-host/${tool}/releases/latest" \
     | grep -o "https://[^\"]*_${OS}_${ARCH}.tar.gz" | head -1)


### PR DESCRIPTION
Closes #454. Part of the review-response milestone (#30). Last of the two deferred P2 items.

Adds a **manual-installer platform CI matrix** (`.github/workflows/install-matrix.yml`) that runs the documented `curl`-a-tarball install (the Quick Start "Manual" tab) on:

- macOS Intel — `macos-13`
- macOS Apple Silicon — `macos-14`
- Linux amd64 — `ubuntu-latest`
- Linux arm64 — `ubuntu-24.04-arm`

Each leg resolves the latest release of `spawn` + `truffle`, downloads the OS/arch tarball, installs onto PATH, and asserts the binary runs (`spawn version` / `truffle version`). Triggers: `workflow_dispatch` + weekly `schedule` + `repository_dispatch(installer-check)` so a CLI release can re-verify install. Lives in the umbrella repo (where the install docs live and which already downloads other repos' release assets in `sync-cli-docs.yaml`); introduces GitHub-hosted macOS/arm64 runners here for the first time.

**Bug it caught:** writing the job surfaced that the documented manual-install snippet was **broken on every platform**. It matched assets with `uname -s`/`uname -m` (`Darwin`/`x86_64`), but GoReleaser names assets with lowercase GOOS/GOARCH (`darwin`/`amd64`) — so the download-URL grep matched nothing, everywhere. Fixed the snippet (and mirrored the fix in the CI job) to lowercase the OS and map `x86_64→amd64`/`aarch64→arm64`. Verified the corrected logic resolves real URLs against the live GitHub API (e.g. `spawn_0.91.1_darwin_arm64.tar.gz`).

Note: this is exactly the kind of drift #454 was filed to catch — the matrix would have gone red on the old snippet.