### PR TITLE
fix(ci): docs post-deploy smoke false-negative (broken pipe under pipefail), take 2

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -85,15 +85,16 @@ jobs:
           set -euo pipefail
           SHORT_SHA="${GITHUB_SHA:0:7}"
           BASE="https://docs.spore.host"
-          # Fetch the page into a variable, THEN grep it — do NOT pipe curl into
-          # `grep -q`. Under `set -o pipefail`, `grep -q` exits on first match and
-          # closes the pipe, so curl aborts with a write error (exit 23) and
-          # pipefail reports the whole pipeline as failed even though the match
-          # succeeded. Separating the two steps avoids that false negative.
+          # Fetch the page into a variable, THEN match it with a here-string — never
+          # PIPE into `grep -q`. Under `set -o pipefail`, `grep -q` exits on first
+          # match and closes the pipe, so the upstream writer (curl OR printf) aborts
+          # with a broken-pipe/write error and pipefail fails the whole pipeline even
+          # though the match succeeded. A here-string (`grep <<<"$body"`) has no pipe,
+          # so there's nothing for pipefail to trip on.
           check() {  # $1=path  $2=needle
             local body
             body="$(curl -fsS "$BASE/$1")" || return 1
-            printf '%s' "$body" | grep -qF "$2"
+            grep -qF "$2" <<<"$body"
           }
           ok=0
           for attempt in 1 2 3 4 5 6; do


### PR DESCRIPTION
The #460 docs deploy went **red** on the post-deploy smoke even though the deploy was correct (live docs.spore.host serves build `fd8bacb` with all canonical strings + the new content).

**Cause:** #457 fixed the original `curl | grep -q` by fetching into a variable first, but the implementation still **piped**: `printf '%s' "$body" | grep -qF`. Under `set -o pipefail`, `grep -q` exits on first match and closes the pipe → `printf` gets a broken-pipe/write error → pipefail fails the whole pipeline despite the match. Same failure class, different upstream writer.

**Fix:** use a here-string — `grep -qF "$needle" <<<"$body"` — which has no pipe, so there's nothing for pipefail to trip on. Verified locally under `set -euo pipefail` against the live site.

Follow-up to #457 / #456.