### PR TITLE
docs+site: restore GitHub issues as the report path (revert #460 reroute)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,11 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: 💬 Get help & report a problem (Discord)
+  - name: 💬 Community chat (Discord)
     url: https://discord.gg/2deGRFCW
-    about: >-
-      The primary place to ask questions, get help, and report bugs or problems —
-      open to everyone, no GitHub account needed. Maintainers triage from here.
+    about: Questions, help, and discussion — faster than an issue for usage questions.
   - name: 📖 Documentation
     url: https://spore.host/docs
     about: Guides and reference for the spore.host tools.
-  - name: 🔒 Report a security vulnerability (private)
+  - name: 🔒 Security issue
     url: https://github.com/spore-host/spore-host/security/advisories/new
-    about: Report a vulnerability privately via a GitHub Security Advisory — never as a public issue.
+    about: Report a vulnerability privately, not as a public issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,6 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
-### Changed
-- **Support: Discord is now the single, consistent "get help / report a problem"
-  channel** (from a third external review — the public GitHub issue path was a dead
-  end for logged-out users). The docs nav "Get help" menu, docs footer, marketing
-  site footer, the issue-template chooser (`blank_issues_enabled: false`, Discord as
-  the prominent contact link), and `CONTRIBUTING.md` all now route reporting to
-  Discord (open to everyone, no account needed); the private security-advisory path
-  is unchanged. Removed the "Report a problem" → `issues/new` links that led to a
-  restricted destination.
-
 ### Security
 - **spore-bot Lambda: bump `google.golang.org/grpc` 1.80.0 → 1.82.1** (indirect,
   via substrate) — resolves GHSA-hrxh-6v49-42gf (gRPC-Go xDS RBAC / HTTP/2, HIGH).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,16 +5,11 @@ umbrella: it holds the documentation site, the hosted API/dashboard, deployment
 automation, and this project-wide guidance. The individual tools live in their own
 repositories.
 
-## Where things live
+## Where things live (open issues in the right repo)
 
-The fastest way to report anything — a bug, a docs problem, a question — is
-[Discord](https://discord.gg/2deGRFCW); maintainers triage from there and open the
-tracking issue in the right repo. If you're a contributor sending a PR, here's
-where each tool's code and issues live:
-
-| Area | Repo |
+| You want to… | Repo |
 |--------------|------|
-| Docs, website, dashboard, or API | [spore-host](https://github.com/spore-host/spore-host) (this repo) |
+| Report a docs problem, or a website/dashboard/API issue | [spore-host](https://github.com/spore-host/spore-host) (this repo) |
 | File a bug or request a feature in **spawn** (launch/lifecycle) | [spawn](https://github.com/spore-host/spawn) |
 | …in **truffle** (discovery/pricing/quotas) | [truffle](https://github.com/spore-host/truffle) |
 | …in **lagotto** (capacity watching) | [lagotto](https://github.com/spore-host/lagotto) |
@@ -22,20 +17,14 @@ where each tool's code and issues live:
 | Add or fix an official **plugin** | [spore-plugins](https://github.com/spore-host/spore-plugins) |
 | A **workflow adapter** (Nextflow/Snakemake/CWL/WDL/Airflow) | its own `*-spawn` / `*-executor-plugin-spawn` repo |
 
-Not sure which repo, or don't have a GitHub account?
-[Discord](https://discord.gg/2deGRFCW) is the place — we'll route it from there.
+Not sure which repo? Open it here and we'll route it, or ask in
+[Discord](https://discord.gg/2deGRFCW).
 
 ## Getting help vs. reporting
 
-- **Questions, usage help, bugs, and problems:** start in
-  [Discord](https://discord.gg/2deGRFCW). It's open to everyone (no GitHub account
-  needed), it's where maintainers triage, and it's faster than an issue. This is
-  the default channel — use it whenever you're unsure.
-- **Contributing a fix:** if you're opening a PR, file or reference an issue in the
-  relevant tool repo so the change is tracked (issue templates are provided in each
-  repo for contributors with write access; otherwise raise it in Discord first and
-  we'll open the tracking issue).
-- **Security vulnerability:** do **not** report it publicly — use the private
+- **Question or usage help:** [Discord](https://discord.gg/2deGRFCW) is faster than an issue.
+- **Bug / feature:** open an issue in the relevant repo (templates provided).
+- **Security vulnerability:** do **not** open a public issue — use the private
   [security advisory form](https://github.com/spore-host/spore-host/security/advisories/new).
   See [SECURITY.md](SECURITY.md).
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -234,7 +234,8 @@ export default defineConfig({
       {
         text: 'Get help',
         items: [
-          { text: '💬 Get help & report a problem (Discord)', link: 'https://discord.gg/2deGRFCW' },
+          { text: '💬 Community chat (Discord)', link: 'https://discord.gg/2deGRFCW' },
+          { text: '🐛 Report a problem', link: 'https://github.com/spore-host/spore-host/issues/new/choose' },
           { text: '🔒 Report a vulnerability (private)', link: 'https://github.com/spore-host/spore-host/security/advisories/new' },
         ],
       },
@@ -254,7 +255,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: 'Get help or report a problem on <a href="https://discord.gg/2deGRFCW">Discord</a> · <a href="https://github.com/spore-host/spore-host/security/advisories/new">Report a vulnerability privately</a> · Released under the <a href="https://github.com/spore-host/spore-host/blob/main/LICENSE">Apache 2.0 License</a>.',
+      message: 'Get help on <a href="https://discord.gg/2deGRFCW">Discord</a> · <a href="https://github.com/spore-host/spore-host/issues/new/choose">Report a problem</a> · <a href="https://github.com/spore-host/spore-host/security/advisories/new">Report a vulnerability</a> · Released under the <a href="https://github.com/spore-host/spore-host/blob/main/LICENSE">Apache 2.0 License</a>.',
       copyright: `© 2026 Scott Friedman · ${BUILD_STAMP}`,
     },
 

--- a/docs/reference/maturity.md
+++ b/docs/reference/maturity.md
@@ -48,7 +48,7 @@ out where they appear in the docs; the list below is the canonical index.
 | **Per-event notification filtering** | <span class="doc-badge planned">Planned</span> | See [Lifecycle Notifications](/guides/notifications). |
 
 If a page and this table ever disagree, the more conservative (less mature) label
-wins — please [tell us on Discord](https://discord.gg/2deGRFCW).
+wins — please [report it](https://github.com/spore-host/spore-host/issues/new/choose).
 
 ## Versioning — what you can rely on
 
@@ -124,7 +124,7 @@ minors"). While we're pre-1.0, **the latest release of each tool is the supporte
 one**; fixes land on the latest and are shipped as a new PATCH or MINOR. If you
 need a longer support commitment for an institutional deployment, that's a good
 thing to raise in the [deployment packet](/reference/deployment-packet)
-conversation with your admin — or [ask us on Discord](https://discord.gg/2deGRFCW).
+conversation with your admin — or [ask us](https://github.com/spore-host/spore-host/issues/new/choose).
 
 ## See also
 

--- a/web/index.html
+++ b/web/index.html
@@ -292,7 +292,8 @@ done</code></pre>
         <a href="https://github.com/spore-host/spore-host" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/spore-host/spore-host/releases" target="_blank" rel="noopener">Releases</a>
         <a href="library.html">For Developers</a>
-        <a href="https://discord.gg/2deGRFCW" target="_blank" rel="noopener">Get help (Discord)</a>
+        <a href="https://github.com/spore-host/spore-host/issues" target="_blank" rel="noopener">Issues</a>
+        <a href="https://discord.gg/2deGRFCW" target="_blank" rel="noopener">Discord</a>
         <a href="/privacy.html">Privacy</a>
         <a href="/terms.html">Terms</a>
       </nav>


### PR DESCRIPTION
**Correction to PR #460.** The third review's 'issue creation is restricted' was simply the **logged-out** GitHub experience — which is standard: any logged-in user can file an issue on a public repo. **Requiring a GitHub login to file an issue is the intended, desired flow.** So #460's reroute-everything-to-Discord was an over-correction; this restores the GitHub issue path as the primary way to report a problem.

Restores the pre-#460 balance — **GitHub 'Report a problem' → issue chooser as primary reporting; Discord as the community-chat option**:
- Docs nav 'Get help' menu + footer: 'Report a problem' → `issues/new` restored; Discord back to 'Community chat'.
- `ISSUE_TEMPLATE/config.yml`: `blank_issues_enabled: true`, original contact links.
- `CONTRIBUTING.md`: restore 'open an issue in the right repo' guidance.
- `docs/reference/maturity.md`: inline links back to `issues/new`.
- `web/index.html` footer: keeps **both** 'Issues' and 'Discord' links (best of both).

**Keeps #460's unrelated good fixes** — the homepage manual-install tab fix and the grpc 1.80→1.82.1 security bump are untouched.

`npm run build` passes.