### PR TITLE
ci: automate marketing-site (spore.host) deploy

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,0 +1,92 @@
+name: Deploy Site
+
+# Deploys the marketing site (spore.host) on every push to main under web/**.
+# Before this workflow the site had NO CI deploy — it shipped only via the manual
+# web/deploy.sh, so homepage edits sat in main until someone ran the script by
+# hand and the live site drifted from source (exactly the staleness external
+# reviews kept hitting). This gives web/ the same continuous, verified deploy the
+# docs already have.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/deploy-site.yaml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+        with:
+          role-to-assume: arn:aws:iam::966362334030:role/GitHubActionsDocsDeployRole
+          aws-region: us-east-1
+
+      # Two-pass sync so caching matches asset lifetime, and so returning visitors
+      # never see a stale homepage. Fingerprinted-ish assets (css/js/assets) get a
+      # long cache; HTML gets a short, must-revalidate cache. --delete only on the
+      # HTML pass prunes removed pages. Excludes match the manual web/deploy.sh
+      # (no deploy.sh / README.md in the bucket).
+      - name: Deploy to S3
+        run: |
+          # Pass 1: static assets — long cache.
+          aws s3 sync web/ s3://spore-host-website/ \
+            --cache-control "public, max-age=86400" \
+            --exclude "*.html" \
+            --exclude "*.sh" \
+            --exclude "README.md" \
+            --exclude ".git/*" \
+            --exclude ".DS_Store"
+          # Pass 2: HTML — short cache, always revalidate; --delete prunes here.
+          aws s3 sync web/ s3://spore-host-website/ \
+            --delete \
+            --cache-control "public, max-age=60, must-revalidate" \
+            --exclude "*" \
+            --include "*.html" \
+            --exclude "*.sh" \
+            --exclude "README.md"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id EY67INS5HDFLU \
+            --paths "/*"
+
+      # Post-deploy smoke: prove the LIVE site serves this build. Asserts a few
+      # canonical strings that should always be present on the current homepage.
+      # NOTE: fetch into a variable then match with a here-string — never PIPE into
+      # `grep -q` under `set -o pipefail` (grep -q closes the pipe → the writer gets
+      # a broken-pipe error → pipefail fails the whole pipeline despite a match).
+      - name: Verify live site
+        run: |
+          set -euo pipefail
+          BASE="https://spore.host"
+          check() {  # $1=path  $2=needle
+            local body
+            body="$(curl -fsS "$BASE/$1")" || return 1
+            grep -qF "$2" <<<"$body"
+          }
+          ok=0
+          for attempt in 1 2 3 4 5 6; do
+            if check "/?cb=${GITHUB_SHA}" "Six tools" \
+               && check "/?cb=${GITHUB_SHA}" "spore.host"; then
+              ok=1
+              echo "✅ Live spore.host serves the current homepage."
+              break
+            fi
+            echo "Attempt $attempt: live site not current yet — waiting…"
+            sleep 20
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::Live spore.host did not serve the expected homepage after retries — check the CloudFront invalidation and S3 sync."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Added
+- **Marketing site (spore.host) now deploys via CI.** New `deploy-site.yaml` syncs
+  `web/` → the site bucket + invalidates CloudFront on every push to `main` under
+  `web/**` (short HTML cache, long asset cache, post-deploy smoke). Previously the
+  site shipped only via the manual `web/deploy.sh`, so homepage edits could sit in
+  `main` unpublished and the live site drifted from source — the root cause of the
+  stale-homepage findings in the external reviews. (`web/deploy.sh` stays for
+  manual/emergency deploys.)
+
 ### Security
 - **spore-bot Lambda: bump `google.golang.org/grpc` 1.80.0 → 1.82.1** (indirect,
   via substrate) — resolves GHSA-hrxh-6v49-42gf (gRPC-Go xDS RBAC / HTTP/2, HIGH).


### PR DESCRIPTION
**Fixes the recurring stale-homepage root cause.** The `web/` marketing site had **no CI deploy** — it shipped only via the manual `web/deploy.sh`, so homepage edits sat in `main` unpublished and the live site drifted from source. That's why multiple external reviews saw a stale homepage ("Five tools", old MCP wording) even though `main` was correct.

New `deploy-site.yaml` mirrors the docs pipeline:
- Triggers on push to `main` under `web/**` (+ `workflow_dispatch`).
- Assumes the OIDC role `GitHubActionsDocsDeployRole` (its `DocsS3CloudFront` policy was expanded — approved — to cover the `spore-host-website` bucket + CloudFront `EY67INS5HDFLU`; previously docs-only).
- **Two-pass `s3 sync`**: long cache for static assets, **short `max-age=60, must-revalidate` for HTML** so returning visitors don't see stale pages (the caching lesson from the docs side). `--delete` on the HTML pass prunes removed pages. Excludes `deploy.sh`/`README.md` like the manual script.
- CloudFront `/*` invalidation.
- **Post-deploy smoke** using the correct here-string pattern (no `| grep -q` under pipefail) — asserts the live homepage serves current content, fails the job otherwise.

`web/deploy.sh` stays for manual/emergency deploys. YAML validated.

After merge, any `web/` change auto-publishes and self-verifies — no more manual step to forget.