### PR TITLE
docs(mcp): add Claude Code + more client setup, document terminate confirm flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ own changelogs for CLI releases.
   `main` unpublished and the live site drifted from source — the root cause of the
   stale-homepage findings in the external reviews. (`web/deploy.sh` stays for
   manual/emergency deploys.)
+- **Docs + site: MCP client coverage and safety flow.** The MCP setup guide
+  (`/guides/mcp-setup`) and reference (`/tools/mcp-server`) now cover **Claude
+  Code** (`claude mcp add`), Windsurf, and a generic stdio-client section for
+  Kiro/Codex/Zed/etc. — previously only Claude Desktop + Cursor. All surfaces
+  (docs + `web/` homepage and library page) now document `spawn_terminate`'s
+  two-phase `confirm=true` flow and ambiguous-name refusal, the deliberate
+  no-launch boundary, and the `SPORE_PROFILE`/`~/.config/spore/config.toml`
+  config options; corrected the marketing site's "no extra auth" wording.
 
 ### Security
 - **spore-bot Lambda: bump `google.golang.org/grpc` 1.80.0 → 1.82.1** (indirect,

--- a/docs/guides/mcp-setup.md
+++ b/docs/guides/mcp-setup.md
@@ -1,10 +1,10 @@
 ---
-description: "The spore.host MCP server lets you manage compute through AI assistants that support the Model Context Protocol — including Claude Desktop and Cursor."
+description: "The spore.host MCP server lets you manage compute through AI assistants that support the Model Context Protocol — Claude Code, Claude Desktop, Cursor, Windsurf, and more."
 ---
 
 # AI Assistant Integration (MCP)
 
-The spore.host MCP server lets you manage compute through AI assistants that support the Model Context Protocol — including Claude Desktop and Cursor. Instead of running CLI commands, you describe what you need in plain language.
+The spore.host MCP server lets you manage compute through AI assistants that support the Model Context Protocol — Claude Code, Claude Desktop, Cursor, Windsurf, and any other MCP-compatible client. Instead of running CLI commands, you describe what you need in plain language.
 
 ## What you can do
 
@@ -27,7 +27,29 @@ brew install spore-host/tap/spore-host-mcp
 
 Or download from the [releases page](https://github.com/spore-host/spore-host/releases/latest).
 
-## Configure Claude Desktop
+## Configure
+
+`spore-host-mcp` is a standard stdio MCP server — it works with any
+MCP-compatible client. Point the client at the installed binary (`which
+spore-host-mcp` if you're unsure of the path; Homebrew installs to
+`/opt/homebrew/bin` on Apple Silicon, `/usr/local/bin` on Intel/Linux). Set
+`AWS_PROFILE` in the server's environment if you use a named profile.
+
+### Claude Code
+
+From your project directory:
+
+```sh
+claude mcp add spore-host -- spore-host-mcp
+# with a named AWS profile:
+claude mcp add spore-host -e AWS_PROFILE=my-profile -- spore-host-mcp
+```
+
+`claude mcp list` confirms it's connected. Use `-s user` to make it available
+across all projects, or `-s project` to share it with your team via
+`.mcp.json`. Restart Claude Code after adding so the tools load.
+
+### Claude Desktop
 
 Add spore.host to `~/.claude/claude_desktop_config.json`:
 
@@ -43,16 +65,39 @@ Add spore.host to `~/.claude/claude_desktop_config.json`:
 
 Restart Claude Desktop. You'll see a hammer icon in the input bar when the MCP server is connected.
 
-## Configure Cursor
+### Cursor
 
-Add to your Cursor MCP settings (Settings → MCP → Add Server):
+Add to your Cursor MCP settings (Settings → MCP → Add Server), or create
+`.cursor/mcp.json`:
 
 ```json
 {
-  "name": "spore-host",
-  "command": "/usr/local/bin/spore-host-mcp"
+  "mcpServers": {
+    "spore-host": {
+      "command": "/usr/local/bin/spore-host-mcp"
+    }
+  }
 }
 ```
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json` (Settings → Cascade → MCP servers →
+Add), using the same `mcpServers` block shown above.
+
+### Other clients (Kiro, Codex, Zed, Continue, …)
+
+Any client that speaks the Model Context Protocol over stdio can run it. The
+config differs per client, but the essentials are the same everywhere:
+
+- **command:** the absolute path to `spore-host-mcp`
+- **transport:** stdio (the default; no args)
+- **env (optional):** `AWS_PROFILE` / `AWS_REGION`, or `SPORE_PROFILE` /
+  `SPORE_REGION`
+
+Most clients read a JSON config with an `mcpServers` (or equivalent) map — reuse
+the block shown for Claude Desktop above, adjusting the file location to the
+client's own MCP config path.
 
 ## Available tools
 
@@ -64,16 +109,18 @@ Add to your Cursor MCP settings (Settings → MCP → Add Server):
 | `spawn_list` | List running instances (filter by state and region) |
 | `spawn_status` | Detailed status for an instance by name or ID |
 | `spawn_stop` | Stop or hibernate a running instance |
-| `spawn_terminate` | Permanently terminate an instance |
+| `spawn_terminate` | Permanently terminate an instance (two-phase — preview, then `confirm=true`) |
 | `spawn_extend` | Update an instance's TTL |
+
+There is **no launch tool, by design** — see the [MCP server reference](/tools/mcp-server) for the reasoning.
 
 ## Credentials
 
-The MCP server uses the same AWS credential chain as the CLI — `~/.aws/credentials`, environment variables, or instance metadata. No additional configuration is needed if the CLI is already working.
+The MCP server uses the same AWS credential chain as the CLI — `~/.aws/credentials`, environment variables (`AWS_PROFILE`/`AWS_REGION`), or instance metadata. It also honors the shared spore.host config base: `SPORE_PROFILE`/`SPORE_REGION` and the `[spore]` table of `~/.config/spore/config.toml`. No additional configuration is needed if the CLI is already working.
 
 ## Tips
 
-**Ask for context before acting.** The assistant won't terminate an instance without telling you what it's about to do. If you ask "clean up my running instances," it will list them and ask for confirmation.
+**Terminate is two-phase.** `spawn_terminate` never destroys an instance on the first call — it previews the exact instance that would be terminated, and only a second call with `confirm=true` actually terminates it. If the name you give matches more than one instance, it's refused (use the instance ID) so the wrong box can't be destroyed. Ask "clean up my running instances" and the assistant will list them and confirm before acting.
 
 **Natural language works for instance search.** You don't need to know exact instance type names: "a GPU with at least 40GB of VRAM for inference" will find appropriate options.
 

--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -1,12 +1,12 @@
 ---
-description: "The spore.host MCP server exposes truffle and spawn as tools for AI assistants that support the Model Context Protocol — including Claude Desktop and Cursor."
+description: "The spore.host MCP server exposes truffle and spawn as tools for AI assistants that support the Model Context Protocol — Claude Code, Claude Desktop, Cursor, Windsurf, and more."
 ---
 
 # MCP Server <span class="doc-badge automation">Automation</span> <span class="doc-badge stable">Stable</span>
 
 **What it is.** The spore.host MCP server exposes truffle and spawn as tools for AI
 assistants that support the [Model Context Protocol](https://modelcontextprotocol.io)
-— including Claude Desktop and Cursor.
+— Claude Code, Claude Desktop, Cursor, Windsurf, and any other MCP-compatible client.
 
 **When to use it.** When you'd rather describe what you need in plain language —
 *"find the cheapest A100 in us-east-1, then give me the spawn command to launch it
@@ -31,7 +31,16 @@ brew install spore-host/tap/spore-host-mcp
 
 ## Configure
 
-Add to `~/.claude/claude_desktop_config.json`:
+**Claude Code** — from your project directory:
+
+```sh
+claude mcp add spore-host -- spore-host-mcp
+# or, with a named AWS profile:
+claude mcp add spore-host -e AWS_PROFILE=my-profile -- spore-host-mcp
+```
+
+**Claude Desktop, Cursor, Windsurf, and other clients** — add to the client's
+MCP config (`~/.claude/claude_desktop_config.json` for Claude Desktop):
 
 ```json
 {
@@ -43,7 +52,8 @@ Add to `~/.claude/claude_desktop_config.json`:
 }
 ```
 
-Restart Claude Desktop. A hammer icon in the input bar confirms the server is connected.
+Restart the client. See the [setup guide](/guides/mcp-setup) for per-client
+config paths (Claude Code, Claude Desktop, Cursor, Windsurf, Kiro, Codex, Zed, …).
 
 ## Available tools
 
@@ -60,9 +70,9 @@ Restart Claude Desktop. A hammer icon in the input bar confirms the server is co
 | Tool | Description |
 |------|-------------|
 | `spawn_list` | List instances, filter by state and region |
-| `spawn_status` | Detailed status by instance name or ID |
+| `spawn_status` | Detailed status by instance name or ID, incl. absolute reap deadline |
 | `spawn_stop` | Stop or hibernate a running instance |
-| `spawn_terminate` | Permanently terminate an instance |
+| `spawn_terminate` | Permanently terminate an instance — two-phase: previews first, requires `confirm=true`; refuses an ambiguous name |
 | `spawn_extend` | Update an instance's TTL |
 
 ## Example interactions
@@ -81,7 +91,7 @@ Restart Claude Desktop. A hammer icon in the input bar confirms the server is co
 
 ## Credentials
 
-The MCP server uses whichever AWS credentials are active in your environment — the same ones the CLI uses. No additional setup is needed.
+The MCP server uses whichever AWS credentials are active in your environment — the same ones the CLI uses (`AWS_PROFILE`/`AWS_REGION`, `~/.aws/…`, or instance metadata). It also honors the shared spore.host config base: `SPORE_PROFILE`/`SPORE_REGION` and the `[spore]` table of `~/.config/spore/config.toml`. No additional setup is needed if the CLI already works.
 
 For a full setup walkthrough, see [AI Assistant (MCP)](/guides/mcp-setup).
 

--- a/web/index.html
+++ b/web/index.html
@@ -166,9 +166,9 @@
           <div class="tool-card tool-mcp">
             <span class="tool-tag">AI assistant</span>
             <h3>MCP Server</h3>
-            <p>Works with any MCP-compatible AI assistant — Claude Desktop, Cursor, Windsurf, and others. Find instances, check status, and manage compute through natural conversation.</p>
+            <p>Works with any MCP-compatible AI assistant — Claude Code, Claude Desktop, Cursor, Windsurf, and others. Find instances, check status, and manage compute through natural conversation.</p>
             <ul class="tool-features">
-              <li>Works with Claude Desktop, Cursor, and more</li>
+              <li>Works with Claude Code, Claude Desktop, Cursor, and more</li>
               <li>Natural language instance search via truffle</li>
               <li>Manage running instances via spawn (status, stop, terminate, extend — no launch, by design)</li>
               <li>Install via Homebrew — one config line</li>
@@ -243,14 +243,14 @@ done</code></pre>
       <div class="container">
         <p class="section-label">AI assistant integration</p>
         <h2 class="section-title">Ask your AI assistant to manage your compute</h2>
-        <p class="section-sub">spore-host-mcp is a standard MCP server — it works with any MCP-compatible AI tool: Claude Desktop, Cursor, Windsurf, and others. Ask it to find instances, check status, or stop a forgotten job in plain English.</p>
+        <p class="section-sub">spore-host-mcp is a standard MCP server — it works with any MCP-compatible AI tool: Claude Code, Claude Desktop, Cursor, Windsurf, and others. Ask it to find instances, check status, or stop a forgotten job in plain English.</p>
 
         <div class="terminal" role="img" aria-label="MCP server config and example conversation">
           <div class="terminal-bar" aria-hidden="true">
             <span class="terminal-dot red"></span>
             <span class="terminal-dot yellow"></span>
             <span class="terminal-dot green"></span>
-            <span class="terminal-title">mcp config (Claude Desktop · Cursor · Windsurf · …)</span>
+            <span class="terminal-title">mcp config (Claude Code · Claude Desktop · Cursor · Windsurf · …)</span>
           </div>
           <div class="terminal-body">
 <pre><span class="t-out">{

--- a/web/library.html
+++ b/web/library.html
@@ -134,16 +134,18 @@ client.UpdateInstanceTags(ctx, result.Region, result.InstanceID,
         <p class="section-label">Available now</p>
         <h2 class="section-title">MCP server</h2>
         <p class="section-sub">
-          <span class="inline-code">spore-host-mcp</span> exposes truffle and spawn as MCP tools for Claude Desktop, Cursor, and any MCP-compatible AI assistant.
-          It uses the same Go packages above — no API keys, no extra auth, just your existing AWS credentials.
+          <span class="inline-code">spore-host-mcp</span> exposes truffle and spawn as MCP tools for Claude Code, Claude Desktop, Cursor, Windsurf, and any MCP-compatible AI assistant.
+          It uses the same Go packages above and your existing AWS credential chain — no extra API keys. Read + manage-existing only: there's no launch tool, by design.
         </p>
 
         <div class="dev-grid">
           <div class="dev-block">
             <h3>Install</h3>
 <pre><code>brew install spore-host/tap/spore-host-mcp</code></pre>
-            <h3 style="margin-top:1.5rem">Configure (Claude Desktop)</h3>
-<pre><code>// ~/.claude/claude_desktop_config.json
+            <h3 style="margin-top:1.5rem">Configure (Claude Code)</h3>
+<pre><code>claude mcp add spore-host -- spore-host-mcp</code></pre>
+            <h3 style="margin-top:1.5rem">Configure (Claude Desktop, Cursor, Windsurf, …)</h3>
+<pre><code>// e.g. ~/.claude/claude_desktop_config.json
 {
   "mcpServers": {
     "spore-host": {


### PR DESCRIPTION
## Why

MCP doc audit (follow-up to the spore-host-mcp review). Three gaps found across the doc + marketing surfaces:

1. **Client coverage** — the setup guide covered only Claude Desktop + Cursor. No Claude Code, Windsurf, Kiro, Codex, Zed — even though Claude Code has first-class MCP support (`claude mcp add`) and the homepage already name-dropped Windsurf.
2. **`spawn_terminate` safety flow** — the two-phase `confirm=true` + ambiguous-name refusal (#12/#22 in spore-host-mcp), the server's core safety behavior, was documented only in the in-protocol tool description, invisible on every human-facing surface.
3. **Credentials** — pages predated the v0.37.0 shared-config-base options; `web/library.html` still claimed "no extra auth."

## Changes (docs + marketing site, no code)

- **`docs/guides/mcp-setup.md`** — new `## Configure` with per-client subsections: **Claude Code** (`claude mcp add`, `-s user/project`, restart note), Claude Desktop, Cursor (`.cursor/mcp.json`), Windsurf, and a generic **stdio-client** section for Kiro/Codex/Zed/Continue. Terminate two-phase flow in Tips + tool table; credentials refreshed with `SPORE_PROFILE`/`config.toml`; no-launch note.
- **`docs/tools/mcp-server.md`** — Claude Code config, terminate confirm flow in the tool table, credentials refresh, client list in intro/frontmatter.
- **`web/index.html` + `web/library.html`** — add Claude Code to client name-drops; library page gets a Claude Code config block; corrected "no extra auth" wording; added no-launch framing.
- CHANGELOG `Unreleased` entry.

## Verification

`npm run build` (VitePress) passes — no dead links. `web/` auto-deploys via `deploy-site.yaml` on merge (no manual deploy).