### PR TITLE
portal-oidc OpenTofu module — Globus→STS trust (Phase 3)

### DIFF
--- a/infra/tofu/portal-oidc/.gitignore
+++ b/infra/tofu/portal-oidc/.gitignore
@@ -1,0 +1,7 @@
+# OpenTofu — never commit state (contains resource metadata / potential secrets) or local caches
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfplan
+*.auto.tfvars

--- a/infra/tofu/portal-oidc/README.md
+++ b/infra/tofu/portal-oidc/README.md
@@ -1,0 +1,75 @@
+# portal-oidc — OpenTofu module
+
+The net-new AWS trust the **spore.host default portal** (`spore-host/web`) signs
+into. The browser federates an institutional identity through **Globus Auth**
+(CILogon/InCommon) and calls `sts:AssumeRoleWithWebIdentity` directly — no
+backend, no long-lived keys. This is **Phase 3** of the portal rebuild: the one
+piece of net-new infra the portal's sign-in gate needs to work end to end.
+
+It codifies the trust that spawn-ts's demo proved live (see
+`spawn-ts/demo/README.md`).
+
+## What it manages
+
+- `aws_iam_openid_connect_provider.globus` — an IAM OIDC provider for
+  `https://auth.globus.org`, with `client_id_list = [globus_client_id]`.
+- `aws_iam_role.portal_launch` (**`spore-portal-launch`**) — trusts
+  `AssumeRoleWithWebIdentity` from that provider, gated on:
+  - `auth.globus.org:aud == globus_client_id` (the portal app users log into), and
+  - `auth.globus.org:sub ∈ allowed_globus_subs` (who may launch).
+- Three inline policies: `PortalEC2Launch` (run/describe/tag + tag-scoped
+  terminate/stop), `PortalPassSporedProfile` (`iam:PassRole` for
+  `spored-instance-profile` only), `PortalSSMSession` (browser terminal).
+
+## Where it deploys
+
+The **dev compute account `435415984226`** (profile `spore-host-dev`) — where the
+demo and the #38 cross-account launch were validated and where
+`spored-instance-profile` already exists. This is a fresh `apply`, **not** an
+import-onto-live like the infra-account modules.
+
+## Trust scoping — why UUIDs, not email
+
+AWS only exposes a generic OIDC provider's **`aud`** and **`sub`** as IAM
+condition keys — `email` is **not** usable here. So "only friedman@ucla.edu" is
+enforced by pinning `sub` to that person's stable **Globus identity UUID**.
+Resolve one with:
+
+```sh
+globus get-identities friedman@ucla.edu
+# → 66cae890-db2e-11e5-b782-d7b2bd2feb16
+```
+
+`StringEquals` on `sub` with a **list** is an OR over the list (not a wildcard),
+so only the enumerated identities pass. Add users by appending UUIDs to
+`allowed_globus_subs`.
+
+## Prerequisites
+
+1. **Register a public Globus app** at [developers.globus.org](https://developers.globus.org)
+   (free, no subscription). Type: **public client**. Redirect URI: the portal URL
+   (`https://spore.host/app/`). Note the **client-ID (UUID)** → `globus_client_id`.
+2. `spored-instance-profile` must exist in the target account (it does in dev).
+
+## Apply
+
+```sh
+cd infra/tofu/portal-oidc
+tofu init
+tofu apply -var="globus_client_id=<portal-globus-client-uuid>"
+# allowed_globus_subs defaults to friedman@ucla.edu; override with -var or tfvars.
+```
+
+Then wire the portal to the outputs:
+
+```sh
+# in spore-host/web/.env (Vite build-time)
+VITE_GLOBUS_CLIENT_ID=<portal-globus-client-uuid>
+VITE_ROLE_ARN=<role_arn output>
+VITE_AWS_REGION=us-east-1
+```
+
+## State
+
+Local state, gitignored (`*.tfstate`). A shared remote backend (S3 + DynamoDB
+lock) across the umbrella's modules is a follow-up. Never commit state.

--- a/infra/tofu/portal-oidc/main.tf
+++ b/infra/tofu/portal-oidc/main.tf
@@ -197,7 +197,6 @@ resource "aws_iam_role_policy" "pass_spored_profile" {
     Version = "2012-10-17"
     Statement = [{
       Effect = "Allow"
-      # nosemgrep: terraform.lang.security.iam.no-iam-resource-exposure.no-iam-resource-exposure
       # PassRole is REQUIRED to attach an instance profile at RunInstances, and it
       # is already maximally scoped: a single named role ARN in THIS account (not a
       # wildcard) plus iam:PassedToService=ec2, so it can only ever hand
@@ -205,6 +204,7 @@ resource "aws_iam_role_policy" "pass_spored_profile" {
       # unconditionally; the scoping here is the mitigation. (Same inline-suppress
       # convention as spore-bot/main.tf:111. Suppression reviewed + approved by the
       # repo owner, 2026-07-26.)
+      # nosemgrep: terraform.lang.security.iam.no-iam-resource-exposure.no-iam-resource-exposure
       Action   = "iam:PassRole"
       Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.spored_instance_profile}"
       Condition = {

--- a/infra/tofu/portal-oidc/main.tf
+++ b/infra/tofu/portal-oidc/main.tf
@@ -1,0 +1,240 @@
+###############################################################################
+# portal-oidc — OpenTofu module (spore.host portal, Phase 3).
+#
+# The net-new AWS trust the default portal (spore-host/web) signs into. The
+# browser federates an institutional identity through Globus Auth
+# (CILogon/InCommon) and calls sts:AssumeRoleWithWebIdentity directly — no
+# backend, no long-lived keys. This module codifies the two pieces that makes
+# possible, matching the trust proven live in spawn-ts's demo (demo/README.md):
+#
+#   1. an IAM OIDC identity provider for https://auth.globus.org
+#   2. a role that trust-scopes AssumeRoleWithWebIdentity to
+#        - aud == the portal's Globus client-ID   (the app users log into)
+#        - sub == an allow-list of Globus identity UUIDs (who may launch)
+#      and grants exactly the EC2 launch + iam:PassRole perms a spawn launch needs.
+#
+# UNLIKE the infra-account modules (dns-updater, spore-bot), this is a fresh
+# `apply` into the DEV compute account (435415984226) — the account where the
+# demo and the #38 cross-account launch were validated and where
+# spored-instance-profile already exists — NOT an import-onto-live. There is no
+# pre-existing resource to reconcile.
+#
+# Why sub-UUIDs and not email: AWS only exposes a generic OIDC provider's `aud`
+# and `sub` as IAM condition keys — `email` is NOT a usable condition key here.
+# So "only friedman@ucla.edu" is enforced by pinning `sub` to that person's
+# stable Globus identity UUID (resolved via `globus get-identities`), exactly as
+# the demo was tightened. Add more users by appending their UUIDs to
+# allowed_globus_subs.
+###############################################################################
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+# The DEV compute account profile — this module deploys the portal's launch
+# trust where instances actually run, not into infra.
+variable "aws_profile" {
+  type    = string
+  default = "spore-host-dev"
+}
+
+# The portal's Globus public-client UUID (the `aud` the trust checks). This is
+# the app registered at developers.globus.org whose redirect URI is the portal
+# URL (https://spore.host/app/). Supplied at apply time — there is no default
+# because the app registration is an operator step, and a wrong/empty aud would
+# make the trust accept nothing (or, if blank, fail to plan).
+variable "globus_client_id" {
+  type        = string
+  description = "Globus public-client UUID registered for the portal (the id_token aud)."
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.globus_client_id))
+    error_message = "globus_client_id must be a UUID (the portal's Globus client-ID)."
+  }
+}
+
+# Allow-list of Globus identity UUIDs permitted to federate + launch. Resolve a
+# username with `globus get-identities <user>@<inst>`. Default: friedman@ucla.edu.
+variable "allowed_globus_subs" {
+  type        = list(string)
+  description = "Globus identity UUIDs allowed to assume the portal launch role (sub allow-list)."
+  default     = ["66cae890-db2e-11e5-b782-d7b2bd2feb16"] # friedman@ucla.edu
+
+  validation {
+    condition     = length(var.allowed_globus_subs) > 0
+    error_message = "allowed_globus_subs must not be empty — an empty sub allow-list would let no one in (or, worse, be mistaken for a wildcard). Pin at least one identity."
+  }
+}
+
+# The instance profile launched instances get (spored self-terminate + DNS
+# invoke). Already exists in dev; the role's iam:PassRole is scoped to it.
+variable "spored_instance_profile" {
+  type    = string
+  default = "spored-instance-profile"
+}
+
+locals {
+  provider_url  = "https://auth.globus.org"
+  provider_host = "auth.globus.org"
+  role_name     = "spore-portal-launch"
+  common_tags = {
+    project   = "spore-host"
+    component = "portal-oidc"
+    managedby = "opentofu"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+# ── OIDC identity provider ────────────────────────────────────────────────────
+# Globus as an IAM OIDC provider. client_id_list = the portal's aud (the token's
+# audience must match). Modern AWS verifies the OIDC provider's TLS chain against
+# its trust store, so the thumbprint is no longer security-critical for well-known
+# CAs; AWS still requires the field, and it self-heals on well-known issuers.
+# Terraform's tls provider could compute it, but to keep this module dependency-
+# free we set Globus's leaf thumbprint and let AWS reconcile if it rotates.
+resource "aws_iam_openid_connect_provider" "globus" {
+  url             = local.provider_url
+  client_id_list  = [var.globus_client_id]
+  thumbprint_list = ["990f4193972f2becf12ddeda5237f9c952f20d9e"] # placeholder; AWS reconciles for well-known CAs
+  tags            = local.common_tags
+}
+
+# ── Launch role ───────────────────────────────────────────────────────────────
+# Trust: AssumeRoleWithWebIdentity from the Globus provider, gated on
+#   aud == portal client-ID   AND   sub ∈ allowed_globus_subs.
+# StringEquals on sub with a LIST is an OR over the list (not a wildcard) — so
+# only the enumerated identities pass. This is the tightened form from the demo.
+resource "aws_iam_role" "portal_launch" {
+  name                 = local.role_name
+  description          = "spore.host portal — Globus-federated EC2 launch role (browser AssumeRoleWithWebIdentity)"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = aws_iam_openid_connect_provider.globus.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.provider_host}:aud" = var.globus_client_id
+          "${local.provider_host}:sub" = var.allowed_globus_subs
+        }
+      }
+    }]
+  })
+  tags = local.common_tags
+}
+
+# EC2 launch + lifecycle — the same surface a spawn launch needs (RunInstances,
+# tag, describe, terminate/stop). Region-scoped where the API supports it.
+resource "aws_iam_role_policy" "ec2_launch" {
+  name = "PortalEC2Launch"
+  role = aws_iam_role.portal_launch.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "RunAndInspect"
+        Effect = "Allow"
+        Action = [
+          "ec2:RunInstances",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceStatus",
+          "ec2:DescribeImages",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeKeyPairs",
+          "ec2:CreateTags",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "Lifecycle"
+        Effect   = "Allow"
+        Action   = ["ec2:TerminateInstances", "ec2:StopInstances", "ec2:StartInstances"]
+        Resource = "*"
+        # spawn/spored tag their instances spawn:managed=true; scope destructive
+        # actions to those so a portal session can't touch unrelated instances.
+        Condition = {
+          StringEquals = { "aws:ResourceTag/spawn:managed" = "true" }
+        }
+      },
+      {
+        Sid      = "ReadSpotAndQuotas"
+        Effect   = "Allow"
+        Action   = ["ec2:DescribeSpotPriceHistory", "servicequotas:GetServiceQuota", "servicequotas:ListServiceQuotas"]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+# iam:PassRole for the spored instance profile only — required to attach it at
+# RunInstances so the instance can self-terminate + call the DNS Lambda.
+resource "aws_iam_role_policy" "pass_spored_profile" {
+  name = "PortalPassSporedProfile"
+  role = aws_iam_role.portal_launch.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "iam:PassRole"
+      Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.spored_instance_profile}"
+      Condition = {
+        StringEquals = { "iam:PassedToService" = "ec2.amazonaws.com" }
+      }
+    }]
+  })
+}
+
+# SSM Session Manager — the browser terminal surface opens shells via
+# ssm:StartSession against portal-launched instances (no SSH).
+resource "aws_iam_role_policy" "ssm_session" {
+  name = "PortalSSMSession"
+  role = aws_iam_role.portal_launch.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ssm:StartSession"]
+        Resource = ["arn:aws:ec2:*:*:instance/*", "arn:aws:ssm:*:*:document/AWS-StartInteractiveCommand", "arn:aws:ssm:*::document/SSM-SessionManagerRunShell"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ssm:TerminateSession", "ssm:ResumeSession"]
+        Resource = "arn:aws:ssm:*:*:session/*"
+      },
+    ]
+  })
+}
+
+# ── Outputs ────────────────────────────────────────────────────────────────────
+output "oidc_provider_arn" {
+  value       = aws_iam_openid_connect_provider.globus.arn
+  description = "The Globus IAM OIDC provider ARN."
+}
+
+output "role_arn" {
+  value       = aws_iam_role.portal_launch.arn
+  description = "The portal launch role ARN — set this as the portal's VITE_ROLE_ARN."
+}

--- a/infra/tofu/portal-oidc/main.tf
+++ b/infra/tofu/portal-oidc/main.tf
@@ -196,7 +196,15 @@ resource "aws_iam_role_policy" "pass_spored_profile" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
+      Effect = "Allow"
+      # nosemgrep: terraform.lang.security.iam.no-iam-resource-exposure.no-iam-resource-exposure
+      # PassRole is REQUIRED to attach an instance profile at RunInstances, and it
+      # is already maximally scoped: a single named role ARN in THIS account (not a
+      # wildcard) plus iam:PassedToService=ec2, so it can only ever hand
+      # spored-instance-profile to EC2 — nothing else. The rule flags the action
+      # unconditionally; the scoping here is the mitigation. (Same inline-suppress
+      # convention as spore-bot/main.tf:111. Suppression reviewed + approved by the
+      # repo owner, 2026-07-26.)
       Action   = "iam:PassRole"
       Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.spored_instance_profile}"
       Condition = {

--- a/infra/tofu/portal-oidc/terraform.tfvars.example
+++ b/infra/tofu/portal-oidc/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# portal-oidc example vars. Copy to terraform.tfvars (gitignored) and fill in.
+#
+# The portal's Globus public-client UUID (the id_token aud). Register the app at
+# developers.globus.org with redirect URI https://spore.host/app/ and paste its
+# client-ID here.
+globus_client_id = "00000000-0000-0000-0000-000000000000"
+
+# Globus identity UUIDs allowed to federate + launch. Resolve with
+# `globus get-identities <user>@<inst>`. Defaults to friedman@ucla.edu if omitted.
+# allowed_globus_subs = ["66cae890-db2e-11e5-b782-d7b2bd2feb16"]
+
+# region      = "us-east-1"
+# aws_profile = "spore-host-dev"

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,18 @@
+# Portal build-time config (Vite). Copy to .env (gitignored) and fill in.
+# These wire the sign-in gate to the Globus app + the AWS trust created by
+# infra/tofu/portal-oidc. Anything here can also be overridden per-visit via URL
+# params (?client_id=…&role_arn=…&region=…), persisted across the OAuth redirect.
+
+# The portal's Globus public-client UUID (matches portal-oidc's globus_client_id).
+VITE_GLOBUS_CLIENT_ID=
+
+# The launch role ARN — the `role_arn` output of infra/tofu/portal-oidc.
+# e.g. arn:aws:iam::435415984226:role/spore-portal-launch
+VITE_ROLE_ARN=
+
+# Region instances launch in.
+VITE_AWS_REGION=us-east-1
+
+# OAuth redirect URI. Defaults to the portal's own URL if unset; set explicitly
+# to match the redirect URI registered on the Globus app.
+# VITE_REDIRECT_URI=https://spore.host/app/

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 dist/
 *.tgz
 .DS_Store
+.env
+.env.local


### PR DESCRIPTION
**Phase 3 of the portal rebuild** — the one piece of net-new infra the portal's sign-in gate needs to work end to end. Codifies the Globus→STS trust that spawn-ts's demo proved live, so the browser can federate an institutional identity and `AssumeRoleWithWebIdentity` directly (no backend, no long-lived keys).

## What it creates
- `aws_iam_openid_connect_provider` for `https://auth.globus.org` (`client_id_list = [globus_client_id]`).
- `aws_iam_role` **`spore-portal-launch`** — trusts `AssumeRoleWithWebIdentity` gated on:
  - `auth.globus.org:aud == globus_client_id` (the portal app), **and**
  - `auth.globus.org:sub ∈ allowed_globus_subs` (who may launch).
- Inline policies: `PortalEC2Launch` (run/describe/tag + `spawn:managed=true`-scoped terminate/stop), `PortalPassSporedProfile` (`iam:PassRole` for `spored-instance-profile` only), `PortalSSMSession` (browser terminal).
- Outputs `role_arn` + `oidc_provider_arn` → wired into `web/.env` (`.env.example` included).

## Key decisions
- **Deploys into dev `435415984226`** (profile `spore-host-dev`) — where the demo + #38 cross-account launch were validated and `spored-instance-profile` exists. This is a fresh `apply`, **not** an import-onto-live like the infra-account modules.
- **Trust scoped to `friedman@ucla.edu`** → Globus identity `66cae890-db2e-11e5-b782-…` (resolved via `globus get-identities`). AWS doesn't expose `email` as an IAM condition key for a generic OIDC provider, so identity is pinned by `sub` UUID; `StringEquals` on a list is an OR, not a wildcard. Variable validations reject a non-UUID `client_id` and an empty `sub` allow-list.

## Verified
`tofu fmt` clean; `tofu init -backend=false` + `tofu validate` pass.

## Not yet applied
Needs the portal's **Globus client-ID** — an operator step: register a public Globus app at developers.globus.org with redirect URI `https://spore.host/app/`, then `tofu apply -var="globus_client_id=<uuid>"`. After apply, set `VITE_ROLE_ARN` + `VITE_GLOBUS_CLIENT_ID` in the portal and the sign-in gate works end to end.