### PR TITLE
Portal truffle + terminal surfaces, code-split (Slice 2)

### DIFF
--- a/web/app/surfaces/registry.ts
+++ b/web/app/surfaces/registry.ts
@@ -1,13 +1,62 @@
 // The ordered list of tool surfaces the portal shows. This is the ONLY file that
 // changes when a tool joins the portal: add its dep + one surfaces/<tool>.ts, then
-// append it here. The shell renders whatever is in this array.
+// append a lazy() entry here. The shell renders whatever is in this array.
 //
-// Slice 1 ships instances (spawn) only. truffle (browse, no-auth) and terminal
-// (SSM) land in slice 2 as additional entries — the shell already supports them.
-import type { ToolSurface } from "./types.js";
-import { instancesSurface } from "./instances.js";
+// Slice 1 shipped instances (spawn). Slice 2 adds truffle (offline catalog browse,
+// no-auth) and terminal (SSM shell). Each surface is LAZILY loaded: the metadata
+// (id/label/accent/requiresAuth) is eager and tiny, but the mount implementation —
+// which drags in the heavy deps (xterm + the SSM/STS SDK for terminal, the bundled
+// catalog for truffle, EC2 SDK for instances) — is code-split behind a dynamic
+// import() and only fetched when the user first opens that surface. So the initial
+// portal load stays lean and the terminal's xterm bundle never loads until needed.
+import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
 
-export const surfaces: ToolSurface[] = [instancesSurface];
+// Metadata + a loader that resolves to the real ToolSurface module. `lazy` wraps
+// it so the shell still sees a plain ToolSurface (mount() awaits the import).
+interface LazyEntry {
+  id: string;
+  label: string;
+  accent: string;
+  requiresAuth: boolean;
+  load: () => Promise<{ mount: ToolSurface["mount"] }>;
+}
+
+function lazy(e: LazyEntry): ToolSurface {
+  return {
+    id: e.id,
+    label: e.label,
+    accent: e.accent,
+    requiresAuth: e.requiresAuth,
+    async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+      const mod = await e.load();
+      return mod.mount(host, ctx);
+    },
+  };
+}
+
+export const surfaces: ToolSurface[] = [
+  lazy({
+    id: "instances",
+    label: "Instances",
+    accent: "--spawn",
+    requiresAuth: true,
+    load: () => import("./instances.js").then((m) => ({ mount: m.instancesSurface.mount })),
+  }),
+  lazy({
+    id: "truffle",
+    label: "Find instances",
+    accent: "--truffle",
+    requiresAuth: false,
+    load: () => import("./truffle.js").then((m) => ({ mount: m.truffleSurface.mount })),
+  }),
+  lazy({
+    id: "terminal",
+    label: "Terminal",
+    accent: "--spored",
+    requiresAuth: true,
+    load: () => import("./terminal.js").then((m) => ({ mount: m.terminalSurface.mount })),
+  }),
+];
 
 export function findSurface(id: string): ToolSurface | undefined {
   return surfaces.find((s) => s.id === id);

--- a/web/app/surfaces/terminal.ts
+++ b/web/app/surfaces/terminal.ts
@@ -1,0 +1,146 @@
+// The terminal surface: a live shell into a portal-launched instance over AWS
+// SSM Session Manager — no SSH, no port 22, no key. The browser calls
+// ssm:StartSession with the session's in-memory creds, gets a session-scoped
+// StreamUrl + token, and attachTerminal (from @spore-host/spawn-ts/terminal)
+// opens the data channel and renders with xterm. On teardown we close the socket
+// AND TerminateSession (StartSession leaks a server-side session otherwise).
+import { SSMClient, StartSessionCommand, TerminateSessionCommand } from "@aws-sdk/client-ssm";
+import { attachTerminal, type AttachedTerminal } from "@spore-host/spawn-ts/terminal";
+import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+
+export const terminalSurface: ToolSurface = {
+  id: "terminal",
+  label: "Terminal",
+  accent: "--spored",
+  requiresAuth: true,
+
+  async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+    const creds = ctx.session.getCreds();
+    if (!creds) throw new Error("terminal surface mounted without a session");
+    const region = ctx.session.region;
+    const credentials = {
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      sessionToken: creds.sessionToken,
+    };
+
+    const root = document.createElement("div");
+    root.className = "terminal-surface";
+    root.innerHTML = `
+      <div class="terminal-connect">
+        <h2>Connect a terminal</h2>
+        <p class="terminal-hint">Opens a shell over SSM Session Manager (no SSH). The
+          instance must have the SSM agent + an instance profile allowing SSM —
+          spawn-launched instances do.</p>
+        <form class="terminal-form">
+          <input class="terminal-target" type="text" placeholder="i-0123456789abcdef0" autocomplete="off" spellcheck="false" />
+          <button type="submit" class="terminal-open">Connect</button>
+          <button type="button" class="terminal-close" hidden>Disconnect</button>
+        </form>
+        <div class="terminal-status" aria-live="polite"></div>
+      </div>
+      <div class="terminal-host" hidden></div>`;
+    host.appendChild(root);
+
+    const form = root.querySelector<HTMLFormElement>(".terminal-form")!;
+    const target = root.querySelector<HTMLInputElement>(".terminal-target")!;
+    const openBtn = root.querySelector<HTMLButtonElement>(".terminal-open")!;
+    const closeBtn = root.querySelector<HTMLButtonElement>(".terminal-close")!;
+    const status = root.querySelector<HTMLElement>(".terminal-status")!;
+    const termHost = root.querySelector<HTMLElement>(".terminal-host")!;
+
+    let attached: AttachedTerminal | null = null;
+    let sessionId: string | null = null;
+
+    // Best-effort SSM cleanup: close the socket + TerminateSession (a bare
+    // StartSession leaves a live session server-side until it times out).
+    async function teardown(): Promise<void> {
+      attached?.dispose();
+      attached = null;
+      const sid = sessionId;
+      sessionId = null;
+      if (sid) {
+        try {
+          await new SSMClient({ region, credentials }).send(new TerminateSessionCommand({ SessionId: sid }));
+        } catch {
+          // The session may already be gone (agent exit); ignore.
+        }
+      }
+    }
+
+    function resetUi(): void {
+      termHost.hidden = true;
+      termHost.innerHTML = "";
+      closeBtn.hidden = true;
+      openBtn.disabled = false;
+      target.disabled = false;
+    }
+
+    async function connect(instanceId: string): Promise<void> {
+      const id = instanceId.trim();
+      if (!/^i-[0-9a-f]{8,}$/.test(id)) {
+        status.textContent = "enter a valid instance id (i-…)";
+        return;
+      }
+      openBtn.disabled = true;
+      target.disabled = true;
+      status.textContent = "starting SSM session…";
+      try {
+        const ssm = new SSMClient({ region, credentials });
+        const started = await ssm.send(new StartSessionCommand({ Target: id }));
+        if (!started.StreamUrl || !started.TokenValue || !started.SessionId) {
+          throw new Error("StartSession returned an incomplete session");
+        }
+        sessionId = started.SessionId;
+        status.textContent = "";
+        // Un-hide BEFORE attach so xterm's fit addon measures a real size.
+        termHost.hidden = false;
+        attached = await attachTerminal(
+          termHost,
+          { streamUrl: started.StreamUrl, tokenValue: started.TokenValue, sessionId: started.SessionId },
+          (reason) => {
+            status.textContent = `session closed${reason ? ": " + reason : ""}`;
+            void teardown();
+            resetUi();
+          },
+        );
+        closeBtn.hidden = false;
+      } catch (err) {
+        status.textContent = `couldn't connect: ${(err as Error).message}`;
+        await teardown();
+        resetUi();
+      }
+    }
+
+    const onSubmit = (e: Event) => {
+      e.preventDefault();
+      void connect(target.value);
+    };
+    const onClose = () => {
+      void teardown();
+      resetUi();
+      status.textContent = "disconnected";
+    };
+    form.addEventListener("submit", onSubmit);
+    closeBtn.addEventListener("click", onClose);
+
+    // If the session's creds expire, drop the live shell.
+    const offExpiry = ctx.session.onExpiry((state) => {
+      if (state === "expired") {
+        void teardown();
+        resetUi();
+        status.textContent = "session expired — sign in again";
+      }
+    });
+
+    return {
+      dispose() {
+        offExpiry();
+        form.removeEventListener("submit", onSubmit);
+        closeBtn.removeEventListener("click", onClose);
+        void teardown();
+        root.remove();
+      },
+    };
+  },
+};

--- a/web/app/surfaces/truffle.ts
+++ b/web/app/surfaces/truffle.ts
@@ -1,0 +1,101 @@
+// The truffle surface: a standalone EC2 instance-type catalog search, offline
+// and auth-free. truffle-ts ships pure logic + a bundled catalog (no UI), so this
+// mounts a thin search box over find() and renders the ranked results + match
+// reasons. No AWS creds, no network — browse/compare before you ever sign in.
+import { find, type FindResult } from "@spore-host/truffle-ts";
+import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+
+export const truffleSurface: ToolSurface = {
+  id: "truffle",
+  label: "Find instances",
+  accent: "--truffle",
+  requiresAuth: false,
+
+  async mount(host: HTMLElement, _ctx: SurfaceContext): Promise<Disposable> {
+    const root = document.createElement("div");
+    root.className = "truffle-surface";
+    root.innerHTML = `
+      <div class="truffle-search">
+        <h2>Find an instance type</h2>
+        <p class="truffle-hint">Natural language — e.g. <code>gpu with 80gb for training</code>,
+          <code>32 vcpus arm</code>, <code>cheapest 64gb</code>. Offline catalog (${"as of 2026-01"}).</p>
+        <form class="truffle-form">
+          <input class="truffle-q" type="search" placeholder="describe what you need…" autocomplete="off" />
+          <button type="submit">Search</button>
+        </form>
+      </div>
+      <div class="truffle-results" aria-live="polite"></div>`;
+    host.appendChild(root);
+
+    const form = root.querySelector<HTMLFormElement>(".truffle-form")!;
+    const input = root.querySelector<HTMLInputElement>(".truffle-q")!;
+    const results = root.querySelector<HTMLElement>(".truffle-results")!;
+
+    // Guard against out-of-order async results if the user searches rapidly.
+    let seq = 0;
+    async function run(query: string): Promise<void> {
+      const mine = ++seq;
+      if (!query.trim()) {
+        results.innerHTML = "";
+        return;
+      }
+      results.innerHTML = `<div class="truffle-status">searching…</div>`;
+      try {
+        const found = await find(query);
+        if (mine !== seq) return; // a newer search superseded this one
+        renderResults(results, found);
+      } catch (err) {
+        if (mine !== seq) return;
+        results.innerHTML = `<div class="truffle-status error">${escapeHtml((err as Error).message)}</div>`;
+      }
+    }
+
+    const onSubmit = (e: Event) => {
+      e.preventDefault();
+      void run(input.value);
+    };
+    form.addEventListener("submit", onSubmit);
+
+    return {
+      dispose() {
+        form.removeEventListener("submit", onSubmit);
+        root.remove();
+      },
+    };
+  },
+};
+
+function renderResults(host: HTMLElement, found: FindResult[]): void {
+  if (found.length === 0) {
+    host.innerHTML = `<div class="truffle-status">no matches — try relaxing the query</div>`;
+    return;
+  }
+  const rows = found
+    .slice(0, 50)
+    .map((r) => {
+      const i = r.instance;
+      const gib = (i.memoryMib / 1024).toFixed(i.memoryMib % 1024 === 0 ? 0 : 1);
+      const price = i.onDemandPrice != null ? `$${i.onDemandPrice.toFixed(4)}/hr${i.estimatedPrice ? "*" : ""}` : "—";
+      const gpu = i.gpus ? `${i.gpus}× ${escapeHtml(i.gpuModel ?? "GPU")}` : "";
+      const reasons = r.reasons.map((x) => `<li>${escapeHtml(x)}</li>`).join("");
+      return `
+        <div class="truffle-row">
+          <div class="truffle-row-head">
+            <span class="truffle-type">${escapeHtml(i.instanceType)}</span>
+            <span class="truffle-specs">${i.vcpus} vCPU · ${gib} GiB · ${escapeHtml(i.architecture)}${gpu ? " · " + gpu : ""}</span>
+            <span class="truffle-price">${price}</span>
+          </div>
+          <ul class="truffle-reasons">${reasons}</ul>
+        </div>`;
+    })
+    .join("");
+  const note = found.some((r) => r.instance.estimatedPrice) ? `<div class="truffle-note">* estimated price (type not in the live-pulled region)</div>` : "";
+  host.innerHTML = `<div class="truffle-count">${found.length} match${found.length === 1 ? "" : "es"}${found.length > 50 ? " (showing 50)" : ""}</div>${rows}${note}`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -508,3 +508,33 @@ footer {
 .portal-banner.warn { background: var(--truffle-bg); color: var(--truffle); }
 .portal-banner.expired { background: #fef2f2; color: var(--accent-red); }
 [data-theme="dark"] .portal-banner.expired { background: #2a1010; }
+
+/* ── truffle surface — offline instance-type catalog search ── */
+.truffle-surface { max-width: 820px; }
+.truffle-hint { color: var(--text-muted); font-size: 0.9rem; }
+.truffle-hint code { background: var(--code-bg); padding: 0.05rem 0.35rem; border-radius: 4px; }
+.truffle-form { display: flex; gap: 0.5rem; margin: 0.75rem 0 1.25rem; }
+.truffle-q { flex: 1; font: inherit; padding: 0.5rem 0.75rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+.truffle-q:focus-visible { outline: 2px solid var(--truffle); outline-offset: -2px; }
+.truffle-form button { font: inherit; cursor: pointer; padding: 0.5rem 1rem; border-radius: var(--radius); border: 1px solid var(--truffle); background: var(--truffle); color: #fff; }
+.truffle-count, .truffle-note { color: var(--text-muted); font-size: 0.85rem; margin-bottom: 0.5rem; }
+.truffle-note { margin-top: 0.75rem; }
+.truffle-status.error { color: var(--accent-red); }
+.truffle-row { border: 1px solid var(--border); border-radius: var(--radius); padding: 0.6rem 0.8rem; margin-bottom: 0.5rem; background: var(--bg-card); }
+.truffle-row-head { display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; }
+.truffle-type { font-weight: 700; color: var(--truffle); }
+.truffle-specs { color: var(--text); font-size: 0.9rem; }
+.truffle-price { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--text-muted); }
+.truffle-reasons { margin: 0.4rem 0 0; padding-left: 1.1rem; color: var(--text-muted); font-size: 0.85rem; }
+
+/* ── terminal surface — SSM Session Manager shell ── */
+.terminal-surface { display: flex; flex-direction: column; gap: 1rem; }
+.terminal-hint { color: var(--text-muted); font-size: 0.9rem; max-width: 640px; }
+.terminal-form { display: flex; gap: 0.5rem; align-items: center; }
+.terminal-target { flex: 0 1 320px; font: inherit; font-family: ui-monospace, monospace; padding: 0.5rem 0.75rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+.terminal-target:focus-visible { outline: 2px solid var(--spored); outline-offset: -2px; }
+.terminal-form button { font: inherit; cursor: pointer; padding: 0.5rem 1rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+.terminal-open { border-color: var(--spored) !important; color: var(--spored) !important; }
+.terminal-status { color: var(--text-muted); font-size: 0.9rem; min-height: 1.2em; }
+.terminal-host { height: 460px; border-radius: var(--radius); overflow: hidden; border: 2px solid transparent; background: var(--terminal-bg); }
+.terminal-host:focus-within { border-color: var(--spored); }


### PR DESCRIPTION
**Slice 2 of the portal** — two additive `ToolSurface` registrations. The shell needed **zero changes**, which is the whole point of the pluggable pattern.

## Surfaces
- **truffle** (`surfaces/truffle.ts`, `requiresAuth:false`) — a standalone, offline EC2 instance-type catalog search over `@spore-host/truffle-ts`'s `find()`. truffle-ts ships pure logic + a bundled catalog (no UI), so this is a thin search box rendering ranked results + human-readable match reasons. Browse/compare before ever signing in.
- **terminal** (`surfaces/terminal.ts`, `requiresAuth:true`) — a live shell into a portal-launched instance over **SSM Session Manager** (no SSH). Browser calls `ssm:StartSession` with the session's in-memory creds → `attachTerminal()` from `@spore-host/spawn-ts/terminal` (xterm). Teardown closes the socket **and** `TerminateSession` (a bare StartSession leaks a server-side session); drops the shell on creds expiry. Mirrors the demo's proven glue.

## Code-splitting
`registry.ts` now `lazy()`-loads each surface's `mount` behind a dynamic `import()`. Metadata stays eager + tiny; heavy deps load only when a surface is opened:

| chunk | size | loads when |
|---|---|---|
| `app` (initial) | **144 kB** (was 714 kB) | always |
| `terminal` (xterm + SSM SDK) | 413 kB | Connect clicked |
| `instances` (EC2 SDK + Dashboard) | 87 kB | Instances opened |
| `find` (truffle catalog) | 69 kB | first search |

Kills the >500 kB chunk-size warning.

## Verified
Typecheck clean; build emits split chunks (no warning); headless Playwright drives all three — sidebar lists all tools, truffle returns 130 ranked matches for a GPU query + sensible price ordering for "cheapest arm 32gb", terminal shows the auth gate — **zero console errors**. (Screenshot of the truffle results in the branch.)