### PR TITLE
Style the Dashboard — consume spawn-ts 0.6.1 + import its CSS

### DIFF
--- a/web/app/surfaces/instances.ts
+++ b/web/app/surfaces/instances.ts
@@ -5,6 +5,9 @@
 import { SpawnClient } from "@spore-host/spawn-ts";
 import { EC2Provider } from "@spore-host/spawn-ts";
 import { Dashboard, confirmDialog } from "@spore-host/spawn-ts/ui";
+// The Dashboard's own component styles (tokens scoped to .dashboard/.modal-backdrop,
+// so they don't fight the portal's brand theme). Loaded with the instances chunk.
+import "@spore-host/spawn-ts/ui/style.css";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
 
 export const instancesSurface: ToolSurface = {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "spore-host-web",
       "version": "0.1.0",
       "dependencies": {
-        "@spore-host/spawn-ts": "^0.6.0",
+        "@spore-host/spawn-ts": "^0.6.1",
         "@spore-host/truffle-ts": "^0.4.2"
       },
       "devDependencies": {
@@ -1298,9 +1298,9 @@
       }
     },
     "node_modules/@spore-host/spawn-ts": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@spore-host/spawn-ts/-/spawn-ts-0.6.0.tgz",
-      "integrity": "sha512-Hlp/R/yXQnOfbQr3EPQnN0iPqDwKZTLPVxqbf7nRSbGUUkFrgS5W+YCwt24RV3ySyTefp0WQySMJ1dBvlMWWKg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@spore-host/spawn-ts/-/spawn-ts-0.6.1.tgz",
+      "integrity": "sha512-fpokao5csK7ZjEK8k7Ru0OpsjCz8181b66GWLqLwr0AKpSJJ7BedGIyhO0BHQar0y2OuHbDbu68OePuOlPewFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.700.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "deploy": "npm run build && ./deploy.sh"
   },
   "dependencies": {
-    "@spore-host/spawn-ts": "^0.6.0",
+    "@spore-host/spawn-ts": "^0.6.1",
     "@spore-host/truffle-ts": "^0.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The live portal rendered an **unstyled Dashboard** because `@spore-host/spawn-ts@0.6.0` shipped the Dashboard JS but not its CSS. **0.6.1** fixes that (ships + exports `./ui/style.css`, published via Trusted Publishing).

- Bump dep to `^0.6.1`, `import "@spore-host/spawn-ts/ui/style.css"` in the instances surface — bundles into the code-split `instances` chunk (loads only when signed in).
- Verified: typecheck clean; build emits `instances-*.css` (7.4 kB); **deployed to spore.host** — CSS served live with the `.dashboard`/`.dash-section` rules. Tokens are scoped to `.dashboard`/`.modal-backdrop` so they don't fight the portal's brand theme.