### PR TITLE
Connect account onboarding surface — web CloudFormation quick-create (Slice 4)

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -16,3 +16,8 @@ VITE_AWS_REGION=us-east-1
 # OAuth redirect URI. Defaults to the portal's own URL if unset; set explicitly
 # to match the redirect URI registered on the Globus app.
 # VITE_REDIRECT_URI=https://spore.host/app/
+
+# BYOA onboarding (Connect account surface) — from infra/tofu/portal-phone-home outputs.
+# VITE_PHONE_HOME_ROLE_ARN=arn:aws:iam::<infra>:role/PortalPhoneHomeLambdaRole
+# VITE_PHONE_HOME_URL=https://<id>.lambda-url.<region>.on.aws/
+# VITE_ONBOARD_TEMPLATE_URL defaults to <origin>/cloudformation/portal-onboarding-role.yaml

--- a/web/app/config.ts
+++ b/web/app/config.ts
@@ -12,6 +12,15 @@ const DEFAULTS: PortalConfig = {
   globusClientId: import.meta.env.VITE_GLOBUS_CLIENT_ID ?? "",
   roleArn: import.meta.env.VITE_ROLE_ARN ?? "",
   redirectUri: import.meta.env.VITE_REDIRECT_URI ?? defaultRedirectUri(),
+  onboarding: {
+    // The onboarding template deploys alongside the portal (copy-static →
+    // dist/cloudformation/); default to its served URL on this origin.
+    templateUrl:
+      import.meta.env.VITE_ONBOARD_TEMPLATE_URL ??
+      `${window.location.origin}/cloudformation/portal-onboarding-role.yaml`,
+    phoneHomeRoleArn: import.meta.env.VITE_PHONE_HOME_ROLE_ARN ?? "",
+    phoneHomeUrl: import.meta.env.VITE_PHONE_HOME_URL ?? "",
+  },
 };
 
 function defaultRedirectUri(): string {
@@ -34,6 +43,8 @@ export function resolveConfig(search = window.location.search): PortalConfig {
     roleArn: params.get("role_arn") ?? stored?.roleArn ?? DEFAULTS.roleArn,
     // redirectUri is always this page — never take it from the URL.
     redirectUri: DEFAULTS.redirectUri,
+    // Onboarding config isn't overridable per-visit (build-time only).
+    onboarding: DEFAULTS.onboarding,
   };
   sessionStorage.setItem(SS_CONFIG, JSON.stringify(merged));
   return merged;

--- a/web/app/surfaces/onboarding.ts
+++ b/web/app/surfaces/onboarding.ts
@@ -1,0 +1,131 @@
+// The onboarding surface: "Connect your AWS account" (BYOA). The no-auth-required
+// path for a user to grant the portal access to their own account, modeled on
+// Coiled's flow: generate a per-account ExternalId, then hand off to the AWS
+// CloudFormation console via a prefilled quick-create URL for
+// deployment/cloudformation/portal-onboarding-role.yaml. The template's
+// phone-home custom resource auto-registers the new role with the portal on stack
+// create, so there's nothing to copy-paste back.
+import type { Disposable, PortalConfig, SurfaceContext, ToolSurface } from "./types.js";
+
+export const onboardingSurface: ToolSurface = {
+  id: "connect",
+  label: "Connect account",
+  accent: "--bot",
+  requiresAuth: false,
+
+  async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+    const root = document.createElement("div");
+    root.className = "onboard-surface";
+    const cfg = ctx.config.onboarding;
+
+    // Missing config → show what an operator must set, don't render a broken CTA.
+    const missing: string[] = [];
+    if (!cfg.templateUrl) missing.push("template URL");
+    if (!cfg.phoneHomeRoleArn) missing.push("phone-home role ARN");
+    if (missing.length) {
+      root.innerHTML = `
+        <div class="onboard-panel">
+          <h2>Connect your AWS account</h2>
+          <p class="onboard-unconfigured">Onboarding isn't configured for this
+            deployment yet (missing: ${escapeHtml(missing.join(", "))}). Set the
+            <code>VITE_ONBOARD_TEMPLATE_URL</code> / <code>VITE_PHONE_HOME_ROLE_ARN</code>
+            build vars from <code>infra/tofu/portal-phone-home</code>'s outputs.</p>
+        </div>`;
+      host.appendChild(root);
+      return { dispose: () => root.remove() };
+    }
+
+    const externalId = generateExternalId();
+
+    root.innerHTML = `
+      <div class="onboard-panel">
+        <h2>Connect your AWS account</h2>
+        <p>Grant spore.host permission to launch and manage EC2 in <b>your own</b>
+          AWS account. This opens the AWS console with a CloudFormation stack
+          pre-filled — review it, then <b>Create stack</b>. Nothing to copy back:
+          the stack registers itself with the portal automatically.</p>
+
+        <ol class="onboard-steps">
+          <li>Sign in to the AWS account you want to use (in another tab).</li>
+          <li>Click <b>Launch the CloudFormation stack</b> below.</li>
+          <li>Leave the pre-filled parameters as-is and create the stack.</li>
+          <li>When it completes (~1 min), your account appears in the portal.</li>
+        </ol>
+
+        <div class="onboard-region">
+          <label>Region
+            <select class="onboard-region-select">
+              ${REGIONS.map((r) => `<option value="${r}"${r === ctx.config.region ? " selected" : ""}>${r}</option>`).join("")}
+            </select>
+          </label>
+        </div>
+
+        <a class="onboard-launch" target="_blank" rel="noopener">Launch the CloudFormation stack ↗</a>
+
+        <details class="onboard-details">
+          <summary>What this creates / prefer the CLI?</summary>
+          <p>The stack creates an IAM role (<code>spore-portal-onboard</code>) that
+            trusts the portal under a one-time ExternalId, scoped to EC2 launch +
+            SSM + passing the spored instance profile. Destructive actions are
+            limited to <code>spawn:managed</code> instances.</p>
+          <p>Prefer the terminal? Run <code>spawn onboard</code> with credentials
+            for the account — it does the same thing without the console.</p>
+          <p class="onboard-extid">This session's ExternalId:
+            <code>${escapeHtml(externalId)}</code></p>
+        </details>
+      </div>`;
+    host.appendChild(root);
+
+    const launch = root.querySelector<HTMLAnchorElement>(".onboard-launch")!;
+    const regionSelect = root.querySelector<HTMLSelectElement>(".onboard-region-select")!;
+
+    const updateUrl = () => {
+      launch.href = quickCreateUrl(cfg, regionSelect.value, externalId);
+    };
+    updateUrl();
+    regionSelect.addEventListener("change", updateUrl);
+
+    return {
+      dispose() {
+        regionSelect.removeEventListener("change", updateUrl);
+        root.remove();
+      },
+    };
+  },
+};
+
+// The regions a stack can be created in (the role is global, but the console
+// quick-create is region-scoped and the phone-home records the launch region).
+const REGIONS = ["us-east-1", "us-west-2", "us-east-2", "eu-west-1", "eu-central-1", "ap-southeast-2"];
+
+/**
+ * Build a CloudFormation console quick-create URL that pre-fills the onboarding
+ * stack. The console reads templateURL + stackName + param_<Name> from the query
+ * string of the #/stacks/quickcreate hash route.
+ */
+function quickCreateUrl(cfg: PortalConfig["onboarding"], region: string, externalId: string): string {
+  const params = new URLSearchParams({
+    templateURL: cfg.templateUrl,
+    stackName: "spore-portal-onboard",
+    param_PhoneHomeLambdaRoleArn: cfg.phoneHomeRoleArn,
+    param_ExternalId: externalId,
+  });
+  if (cfg.phoneHomeUrl) params.set("param_PhoneHomeUrl", cfg.phoneHomeUrl);
+  return `https://${region}.console.aws.amazon.com/cloudformation/home?region=${encodeURIComponent(
+    region,
+  )}#/stacks/quickcreate?${params.toString()}`;
+}
+
+/** A high-entropy hex ExternalId (WebCrypto), matching `spawn onboard`'s format. */
+function generateExternalId(): string {
+  const b = new Uint8Array(16);
+  crypto.getRandomValues(b);
+  return Array.from(b, (x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}

--- a/web/app/surfaces/registry.ts
+++ b/web/app/surfaces/registry.ts
@@ -56,6 +56,13 @@ export const surfaces: ToolSurface[] = [
     requiresAuth: true,
     load: () => import("./terminal.js").then((m) => ({ mount: m.terminalSurface.mount })),
   }),
+  lazy({
+    id: "connect",
+    label: "Connect account",
+    accent: "--bot",
+    requiresAuth: false,
+    load: () => import("./onboarding.js").then((m) => ({ mount: m.onboardingSurface.mount })),
+  }),
 ];
 
 export function findSurface(id: string): ToolSurface | undefined {

--- a/web/app/surfaces/types.ts
+++ b/web/app/surfaces/types.ts
@@ -39,4 +39,16 @@ export interface PortalConfig {
   roleArn: string;
   /** OAuth redirect URI (this portal's app/ URL). */
   redirectUri: string;
+  /**
+   * BYOA onboarding (the "connect your AWS account" quick-create). Optional —
+   * the onboarding surface degrades to instructions if any are unset.
+   */
+  onboarding: {
+    /** Public HTTPS URL of the CloudFormation onboarding template. */
+    templateUrl: string;
+    /** Phone-home Lambda execution role ARN the onboarding role trusts. */
+    phoneHomeRoleArn: string;
+    /** Phone-home Function URL (baked into the template default too). */
+    phoneHomeUrl: string;
+  };
 }

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -538,3 +538,23 @@ footer {
 .terminal-status { color: var(--text-muted); font-size: 0.9rem; min-height: 1.2em; }
 .terminal-host { height: 460px; border-radius: var(--radius); overflow: hidden; border: 2px solid transparent; background: var(--terminal-bg); }
 .terminal-host:focus-within { border-color: var(--spored); }
+
+/* ── onboarding surface — "Connect your AWS account" (BYOA quick-create) ── */
+.onboard-surface { max-width: 720px; }
+.onboard-panel p { color: var(--text); line-height: 1.5; }
+.onboard-steps { color: var(--text); line-height: 1.7; padding-left: 1.2rem; }
+.onboard-steps b { color: var(--text); }
+.onboard-region { margin: 1rem 0; }
+.onboard-region label { font-size: 0.9rem; color: var(--text-muted); display: inline-flex; align-items: center; gap: 0.5rem; }
+.onboard-region select { font: inherit; padding: 0.35rem 0.5rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+.onboard-launch {
+  display: inline-block; margin: 0.5rem 0 1rem; padding: 0.6rem 1.2rem;
+  border-radius: var(--radius); background: var(--bot); color: #fff; font-weight: 700;
+  text-decoration: none;
+}
+.onboard-launch:hover { filter: brightness(1.08); }
+.onboard-details { margin-top: 1rem; color: var(--text-muted); font-size: 0.9rem; }
+.onboard-details summary { cursor: pointer; color: var(--bot); }
+.onboard-details code, .onboard-panel code { background: var(--code-bg); padding: 0.05rem 0.35rem; border-radius: 4px; font-size: 0.85em; }
+.onboard-extid code { word-break: break-all; }
+.onboard-unconfigured { color: var(--text-muted); }

--- a/web/scripts/copy-static.mjs
+++ b/web/scripts/copy-static.mjs
@@ -19,4 +19,13 @@ for (const p of pages) {
 for (const d of dirs) {
   await cp(resolve(web, d), resolve(dist, d), { recursive: true });
 }
-console.log(`copied ${pages.length} pages + ${dirs.join(", ")} → dist/`);
+
+// The BYOA onboarding CloudFormation template — served publicly so the portal's
+// "Connect account" quick-create URL can point CloudFormation at it. Lives in the
+// repo's deployment/ dir (one level above web/), copied to dist/cloudformation/.
+const cfnSrc = resolve(web, "..", "deployment", "cloudformation", "portal-onboarding-role.yaml");
+const cfnDest = resolve(dist, "cloudformation", "portal-onboarding-role.yaml");
+await mkdir(dirname(cfnDest), { recursive: true });
+await cp(cfnSrc, cfnDest);
+
+console.log(`copied ${pages.length} pages + ${dirs.join(", ")} + onboarding template → dist/`);


### PR DESCRIPTION
**Slice 4 of the portal — the no-auth BYOA onboarding path.** A "Connect account" surface that lets a user grant spore.host access to their **own** AWS account in a few clicks (the Coiled pattern), pairing with the phone-home Lambda + CFN template already deployed in Slice 3.

## Flow
1. Generates a per-account **ExternalId** (WebCrypto).
2. Builds a CloudFormation console **quick-create URL** that pre-fills the deployed `portal-onboarding-role.yaml` (`templateURL` + `stackName` + `param_PhoneHomeLambdaRoleArn`/`ExternalId`/`PhoneHomeUrl`).
3. User reviews + creates the stack → its **phone-home custom resource auto-registers** the new role with the portal. Nothing to copy back.

## Changes
- `app/surfaces/onboarding.ts` — the surface (`requiresAuth:false`, `--bot` accent): region selector, launch CTA, expandable "what this creates / prefer the CLI (`spawn onboard`)" details. Degrades to an operator-config message if unconfigured.
- `registry.ts` — 4th tool, lazy-loaded.
- `types.ts` + `config.ts` — `PortalConfig.onboarding {templateUrl, phoneHomeRoleArn, phoneHomeUrl}`; `templateUrl` defaults to `<origin>/cloudformation/…`.
- `copy-static.mjs` — copies `deployment/cloudformation/portal-onboarding-role.yaml` → `dist/cloudformation/` so it's served publicly for the quick-create.

## Verified
Typecheck clean; build emits the `onboarding-*.js` chunk + copies the template; headless drive renders the surface (4th sidebar tool), generates a 32-char ExternalId, and produces a **correct quickcreate URL with all params** — zero console errors.