### PR TITLE
feat(portal): Software catalog surface — first Slice 5 dashboard-api feature

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -13,6 +13,11 @@ VITE_ROLE_ARN=
 # Region instances launch in.
 VITE_AWS_REGION=us-east-1
 
+# Shared dashboard-api base (teams, strata catalog, cost-history, Slack).
+# Authenticated via the session's federated creds in an X-AWS-Credentials header.
+# Defaults to https://api.spore.host if unset.
+# VITE_API_BASE=https://api.spore.host
+
 # OAuth redirect URI. Defaults to the portal's own URL if unset; set explicitly
 # to match the redirect URI registered on the Globus app.
 # VITE_REDIRECT_URI=https://spore.host/app/

--- a/web/app/config.ts
+++ b/web/app/config.ts
@@ -9,6 +9,7 @@ const SS_CONFIG = "portal.config";
 // the fallbacks keep dev working before infra is wired.
 const DEFAULTS: PortalConfig = {
   region: import.meta.env.VITE_AWS_REGION ?? "us-east-1",
+  apiBase: import.meta.env.VITE_API_BASE ?? "https://api.spore.host",
   globusClientId: import.meta.env.VITE_GLOBUS_CLIENT_ID ?? "",
   roleArn: import.meta.env.VITE_ROLE_ARN ?? "",
   redirectUri: import.meta.env.VITE_REDIRECT_URI ?? defaultRedirectUri(),
@@ -38,6 +39,8 @@ export function resolveConfig(search = window.location.search): PortalConfig {
   const params = new URLSearchParams(search);
   const merged: PortalConfig = {
     region: params.get("region") ?? stored?.region ?? DEFAULTS.region,
+    // apiBase is build-time only (not overridable per-visit).
+    apiBase: stored?.apiBase ?? DEFAULTS.apiBase,
     globusClientId:
       params.get("client_id") ?? stored?.globusClientId ?? DEFAULTS.globusClientId,
     roleArn: params.get("role_arn") ?? stored?.roleArn ?? DEFAULTS.roleArn,

--- a/web/app/surfaces/catalog.ts
+++ b/web/app/surfaces/catalog.ts
@@ -1,0 +1,133 @@
+// The strata catalog surface: browse the software "formations" (curated
+// environment stacks — R, Python ML, HPC/MPI, genomics, CUDA) the shared
+// dashboard-api publishes. This is the first Slice 5 surface: it consumes the
+// multi-tenant API (api.spore.host) authenticated by the signed-in user's
+// federated AWS creds in an X-AWS-Credentials header — the same path teams,
+// cost-history, and Slack will use next.
+//
+// The catalog itself is static/shared (not per-account), so this is the
+// lowest-risk exercise of the X-AWS-Credentials plumbing end to end.
+import type { AwsCreds } from "@spore-host/spawn-ts/auth";
+import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+
+interface Formation {
+  name: string;
+  display_name: string;
+  description: string;
+}
+
+interface CatalogResponse {
+  success: boolean;
+  formations?: Formation[];
+  error?: string;
+}
+
+/**
+ * Base64-encode the session's federated creds for the X-AWS-Credentials header
+ * the dashboard-api validates via STS GetCallerIdentity. Creds stay in memory
+ * (from the SessionController) — never persisted.
+ */
+function credentialsHeader(creds: AwsCreds): string {
+  const json = JSON.stringify({
+    accessKeyId: creds.accessKeyId,
+    secretAccessKey: creds.secretAccessKey,
+    sessionToken: creds.sessionToken,
+  });
+  // btoa is fine here: the JSON is ASCII (base64/hex AWS cred fields).
+  return btoa(json);
+}
+
+export const catalogSurface: ToolSurface = {
+  id: "catalog",
+  label: "Software catalog",
+  accent: "--strata",
+  requiresAuth: true,
+
+  async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+    const creds = ctx.session.getCreds();
+    if (!creds) throw new Error("catalog surface mounted without a session");
+
+    const root = document.createElement("div");
+    root.className = "catalog-surface";
+    root.innerHTML = `
+      <div class="catalog-head">
+        <h2>Software catalog</h2>
+        <p class="catalog-hint">Curated environment formations you can launch onto an
+          instance. Served by the shared dashboard-api over your federated session.</p>
+      </div>
+      <div class="catalog-results" aria-live="polite"><div class="catalog-status">loading…</div></div>`;
+    host.appendChild(root);
+
+    const results = root.querySelector<HTMLElement>(".catalog-results")!;
+    const controller = new AbortController();
+
+    async function load(): Promise<void> {
+      results.innerHTML = `<div class="catalog-status">loading…</div>`;
+      try {
+        const resp = await fetch(`${ctx.config.apiBase}/api/strata/catalog`, {
+          method: "GET",
+          headers: { "X-AWS-Credentials": credentialsHeader(creds!) },
+          signal: controller.signal,
+        });
+        if (!resp.ok) {
+          const detail = resp.status === 401 ? "authentication failed" : `HTTP ${resp.status}`;
+          results.innerHTML = `<div class="catalog-status error">Couldn't load the catalog (${escapeHtml(detail)}).</div>`;
+          return;
+        }
+        const body = (await resp.json()) as CatalogResponse;
+        if (!body.success || !body.formations) {
+          results.innerHTML = `<div class="catalog-status error">${escapeHtml(body.error ?? "no catalog returned")}</div>`;
+          return;
+        }
+        renderCatalog(results, body.formations);
+      } catch (err) {
+        if (controller.signal.aborted) return; // surface torn down mid-flight
+        results.innerHTML = `<div class="catalog-status error">${escapeHtml((err as Error).message)}</div>`;
+      }
+    }
+
+    // Reload if creds expire+refresh isn't wired yet — for now just surface it.
+    const offExpiry = ctx.session.onExpiry((state) => {
+      if (state === "expired") {
+        results.innerHTML = `<div class="catalog-status error">Session expired — sign in again to reload the catalog.</div>`;
+      }
+    });
+
+    void load();
+
+    return {
+      dispose() {
+        offExpiry();
+        controller.abort();
+        root.remove();
+      },
+    };
+  },
+};
+
+function renderCatalog(host: HTMLElement, formations: Formation[]): void {
+  if (formations.length === 0) {
+    host.innerHTML = `<div class="catalog-status">the catalog is empty</div>`;
+    return;
+  }
+  const cards = formations
+    .map(
+      (f) => `
+      <div class="catalog-card">
+        <div class="catalog-card-head">
+          <span class="catalog-name">${escapeHtml(f.display_name)}</span>
+          <code class="catalog-slug">${escapeHtml(f.name)}</code>
+        </div>
+        <p class="catalog-desc">${escapeHtml(f.description)}</p>
+      </div>`,
+    )
+    .join("");
+  host.innerHTML = `<div class="catalog-count">${formations.length} formation${formations.length === 1 ? "" : "s"}</div>${cards}`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}

--- a/web/app/surfaces/registry.ts
+++ b/web/app/surfaces/registry.ts
@@ -57,6 +57,13 @@ export const surfaces: ToolSurface[] = [
     load: () => import("./terminal.js").then((m) => ({ mount: m.terminalSurface.mount })),
   }),
   lazy({
+    id: "catalog",
+    label: "Software catalog",
+    accent: "--strata",
+    requiresAuth: true,
+    load: () => import("./catalog.js").then((m) => ({ mount: m.catalogSurface.mount })),
+  }),
+  lazy({
     id: "connect",
     label: "Connect account",
     accent: "--bot",

--- a/web/app/surfaces/types.ts
+++ b/web/app/surfaces/types.ts
@@ -33,6 +33,12 @@ export interface ToolSurface {
 /** Portal configuration, resolved from Vite build-time defaults + URL overrides. */
 export interface PortalConfig {
   region: string;
+  /**
+   * Base URL of the shared dashboard-api (teams, strata catalog, cost-history,
+   * Slack). Authenticated via the session's federated creds in an
+   * X-AWS-Credentials header. Defaults to https://api.spore.host.
+   */
+  apiBase: string;
   /** Globus OIDC application (public client) id. */
   globusClientId: string;
   /** The AssumeRoleWithWebIdentity role the browser federates into. */

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -32,6 +32,8 @@
   --mcp-bg:       #eef0ff;
   --spored:       #059669;   /* emerald — lifecycle / self-healing */
   --spored-bg:    #ecfdf5;
+  --strata:       #db2777;   /* pink/magenta — software formations */
+  --strata-bg:    #fdf2f8;
 
   --code-bg:      #f3f4f6;
   --terminal-bg:  #f3f4f6;
@@ -68,6 +70,7 @@
   --bot-bg:       #1a0d30;
   --mcp-bg:       #12103a;
   --spored-bg:    #052e22;
+  --strata-bg:    #2d0a1f;
 
   --code-bg:      #1a0e28;
   --terminal-bg:  #1a0e28;
@@ -558,3 +561,15 @@ footer {
 .onboard-details code, .onboard-panel code { background: var(--code-bg); padding: 0.05rem 0.35rem; border-radius: 4px; font-size: 0.85em; }
 .onboard-extid code { word-break: break-all; }
 .onboard-unconfigured { color: var(--text-muted); }
+
+/* ── catalog surface — strata software formations (shared dashboard-api) ── */
+.catalog-surface { max-width: 820px; }
+.catalog-hint { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 1.25rem; }
+.catalog-count { color: var(--text-muted); font-size: 0.85rem; margin-bottom: 0.5rem; }
+.catalog-status { color: var(--text-muted); }
+.catalog-status.error { color: var(--accent-red); }
+.catalog-card { border: 1px solid var(--border); border-radius: var(--radius); padding: 0.7rem 0.9rem; margin-bottom: 0.6rem; background: var(--bg-card); }
+.catalog-card-head { display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; }
+.catalog-name { font-weight: 700; color: var(--strata); }
+.catalog-slug { margin-left: auto; background: var(--code-bg); padding: 0.05rem 0.4rem; border-radius: 4px; font-size: 0.8rem; color: var(--text-muted); }
+.catalog-desc { margin: 0.4rem 0 0; color: var(--text); font-size: 0.9rem; }


### PR DESCRIPTION
## What

Adds a **Software catalog** ToolSurface (accent `--strata`) that browses the strata software formations published by the shared **dashboard-api** (`api.spore.host`). This is the **first portal feature to consume the multi-tenant API** over the signed-in user's federated AWS creds in an `X-AWS-Credentials` header — the same path teams, cost-history, and Slack will use next (Slice 5).

The catalog is **static/shared** (not per-account), so it's the lowest-risk exercise of the `X-AWS-Credentials` plumbing end to end.

## Depends on

`spawn#445` (merged + deployed): the dashboard-api federated-identity auth fix. A `spore-portal-launch` caller (Globus→STS assumed-role) is now scoped by its **verified AWS account** instead of 401'ing on the Cognito/email/CLI-link path.

## Changes

- **`surfaces/catalog.ts`** — `GET {apiBase}/api/strata/catalog` with the base64 `X-AWS-Credentials` header built from the in-memory session creds; renders formation cards; `AbortController` teardown; expiry-aware.
- **`registry.ts`** — `lazy()` entry, code-split into its own ~2.4 kB chunk (loads only when the surface opens).
- **`PortalConfig.apiBase`** — default `https://api.spore.host`, overridable via `VITE_API_BASE` (build-time). Wired in `config.ts` + `types.ts` + `.env.example`.
- **css** — `--strata` accent token (light + dark) + `.catalog-*` styles, mirroring the truffle/onboarding conventions.

## Verification

- `npm run typecheck` + `npm run build` clean; catalog is its own code-split chunk.
- Headless render (Playwright): the tool appears in the sidebar (5 tools), the `#/catalog` route shows the **sign-in gate** (`requiresAuth: true`) rather than crashing, **zero console errors**.
- The authenticated **200** over the `X-AWS-Credentials` path is proven against the deployed API + `spawn#445` unit tests. The full in-browser positive path (rendered catalog for a real `spore-portal-launch` sign-in) needs the interactive Globus login — a natural click once deployed.