### PR TITLE
feat(portal): Cost history surface — per-account spend chart (Slice 5)

### DIFF
--- a/web/app/surfaces/costs.ts
+++ b/web/app/surfaces/costs.ts
@@ -1,0 +1,416 @@
+// The cost-history surface: your account's spend over time, from the shared
+// dashboard-api (GET /api/cost-history?days=N) over the session's federated
+// creds. Per-account scoped (the auth fix keys cost rows by the verified
+// account). Second Slice 5 feature after the catalog — first one with per-user
+// data + a chart.
+//
+// Dataviz: single series, "trend over time" → area+line, sequential blue
+// (#2a78d6 light / #3987e5 dark, both validated ≥3:1 on the portal card
+// surfaces). No legend (one series; the title names it). Crosshair + one
+// tooltip snapping to the nearest day. KPI row of stat tiles for the current
+// values. Days-range presets in one row above. Table view for a11y. Text wears
+// ink tokens, never the series hue.
+import type { AwsCreds } from "@spore-host/spawn-ts/auth";
+import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+
+interface CostComponents {
+  compute: number;
+  storage: number;
+  network: number;
+}
+
+interface CostPoint {
+  timestamp: string;
+  hourly_cost: number;
+  monthly_estimate: number;
+  instance_count: number;
+  breakdown: CostComponents;
+}
+
+interface CostHistoryResponse {
+  success: boolean;
+  days?: number;
+  history?: CostPoint[];
+  error?: string;
+}
+
+const DAY_PRESETS = [7, 30, 90] as const;
+
+function credentialsHeader(creds: AwsCreds): string {
+  return btoa(
+    JSON.stringify({
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      sessionToken: creds.sessionToken,
+    }),
+  );
+}
+
+export const costsSurface: ToolSurface = {
+  id: "costs",
+  label: "Cost history",
+  accent: "--spawn",
+  requiresAuth: true,
+
+  async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+    const creds = ctx.session.getCreds();
+    if (!creds) throw new Error("costs surface mounted without a session");
+
+    const root = document.createElement("div");
+    root.className = "costs-surface";
+    root.innerHTML = `
+      <div class="costs-head">
+        <h2>Cost history</h2>
+        <p class="costs-hint">Estimated hourly spend across your account, from the
+          shared dashboard-api over your federated session.</p>
+      </div>
+      <div class="costs-controls" role="group" aria-label="Time range">
+        ${DAY_PRESETS.map(
+          (d) =>
+            `<button type="button" class="costs-range" data-days="${d}" aria-pressed="${d === 30}">${d}d</button>`,
+        ).join("")}
+        <button type="button" class="costs-tabletoggle" aria-pressed="false">Table</button>
+      </div>
+      <div class="costs-kpis" aria-live="polite"></div>
+      <div class="costs-body" aria-live="polite"><div class="costs-status">loading…</div></div>`;
+    host.appendChild(root);
+
+    const controls = root.querySelector<HTMLElement>(".costs-controls")!;
+    const kpis = root.querySelector<HTMLElement>(".costs-kpis")!;
+    const body = root.querySelector<HTMLElement>(".costs-body")!;
+
+    let days = 30;
+    let showTable = false;
+    let last: CostPoint[] = [];
+    let controller: AbortController | null = null;
+    let seq = 0;
+
+    async function load(): Promise<void> {
+      const mine = ++seq;
+      controller?.abort();
+      controller = new AbortController();
+      // Refetch keeps the frame: dim the prior render rather than clearing.
+      body.style.opacity = last.length ? "0.5" : "1";
+      if (!last.length) body.innerHTML = `<div class="costs-status">loading…</div>`;
+      try {
+        const resp = await fetch(`${ctx.config.apiBase}/api/cost-history?days=${days}`, {
+          method: "GET",
+          headers: { "X-AWS-Credentials": credentialsHeader(creds!) },
+          signal: controller.signal,
+        });
+        if (mine !== seq) return;
+        if (!resp.ok) {
+          const detail = resp.status === 401 ? "authentication failed" : `HTTP ${resp.status}`;
+          body.style.opacity = "1";
+          body.innerHTML = `<div class="costs-status error">Couldn't load cost history (${escapeHtml(detail)}).</div>`;
+          kpis.innerHTML = "";
+          return;
+        }
+        const data = (await resp.json()) as CostHistoryResponse;
+        if (mine !== seq) return;
+        body.style.opacity = "1";
+        if (!data.success || !data.history) {
+          body.innerHTML = `<div class="costs-status error">${escapeHtml(data.error ?? "no data returned")}</div>`;
+          kpis.innerHTML = "";
+          return;
+        }
+        last = data.history;
+        render();
+      } catch (err) {
+        if (controller?.signal.aborted || mine !== seq) return;
+        body.style.opacity = "1";
+        body.innerHTML = `<div class="costs-status error">${escapeHtml((err as Error).message)}</div>`;
+      }
+    }
+
+    function render(): void {
+      renderKpis(kpis, last);
+      if (!last.length) {
+        body.innerHTML = `<div class="costs-status">No cost history yet for this account.</div>`;
+        return;
+      }
+      body.innerHTML = "";
+      body.appendChild(showTable ? buildTable(last) : buildChart(last));
+    }
+
+    const onControlsClick = (e: Event) => {
+      const btn = (e.target as HTMLElement).closest("button");
+      if (!btn) return;
+      if (btn.classList.contains("costs-range")) {
+        const d = Number(btn.dataset.days);
+        if (d && d !== days) {
+          days = d;
+          for (const b of controls.querySelectorAll<HTMLButtonElement>(".costs-range")) {
+            b.setAttribute("aria-pressed", String(Number(b.dataset.days) === days));
+          }
+          void load();
+        }
+      } else if (btn.classList.contains("costs-tabletoggle")) {
+        showTable = !showTable;
+        btn.setAttribute("aria-pressed", String(showTable));
+        render();
+      }
+    };
+    controls.addEventListener("click", onControlsClick);
+
+    const offExpiry = ctx.session.onExpiry((state) => {
+      if (state === "expired") {
+        body.innerHTML = `<div class="costs-status error">Session expired — sign in again to reload.</div>`;
+      }
+    });
+
+    void load();
+
+    return {
+      dispose() {
+        offExpiry();
+        controls.removeEventListener("click", onControlsClick);
+        controller?.abort();
+        root.remove();
+      },
+    };
+  },
+};
+
+// ── KPI row ──────────────────────────────────────────────────────────────────
+function renderKpis(host: HTMLElement, history: CostPoint[]): void {
+  if (!history.length) {
+    host.innerHTML = "";
+    return;
+  }
+  const latest = history[history.length - 1]!;
+  const tiles = [
+    { label: "Current hourly cost", value: fmtUsd(latest.hourly_cost) },
+    { label: "Monthly estimate", value: fmtUsd(latest.monthly_estimate) },
+    { label: "Instances", value: String(latest.instance_count) },
+  ];
+  host.innerHTML = tiles
+    .map(
+      (t) => `
+      <div class="costs-tile">
+        <div class="costs-tile-label">${escapeHtml(t.label)}</div>
+        <div class="costs-tile-value">${escapeHtml(t.value)}</div>
+      </div>`,
+    )
+    .join("");
+}
+
+// ── Area + line chart (SVG) ────────────────────────────────────────────────────
+function buildChart(history: CostPoint[]): SVGSVGElement {
+  const W = 720;
+  const H = 300;
+  const M = { top: 16, right: 20, bottom: 28, left: 56 };
+  const iw = W - M.left - M.right;
+  const ih = H - M.top - M.bottom;
+
+  const xs = history.map((_, i) => i);
+  const ys = history.map((p) => p.hourly_cost);
+  const maxY = Math.max(...ys, 0.0001);
+  const niceMax = niceCeil(maxY);
+  const n = history.length;
+
+  const x = (i: number) => M.left + (n <= 1 ? iw / 2 : (i / (n - 1)) * iw);
+  const y = (v: number) => M.top + ih - (v / niceMax) * ih;
+
+  const svgNS = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(svgNS, "svg");
+  svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+  svg.setAttribute("class", "costs-chart");
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label", `Hourly cost over ${n} points`);
+  svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+
+  // Gridlines + y ticks (hairline, muted ink).
+  const ticks = 4;
+  for (let t = 0; t <= ticks; t++) {
+    const val = (niceMax / ticks) * t;
+    const gy = y(val);
+    const line = document.createElementNS(svgNS, "line");
+    line.setAttribute("x1", String(M.left));
+    line.setAttribute("x2", String(M.left + iw));
+    line.setAttribute("y1", String(gy));
+    line.setAttribute("y2", String(gy));
+    line.setAttribute("class", "costs-grid");
+    svg.appendChild(line);
+    const lbl = document.createElementNS(svgNS, "text");
+    lbl.setAttribute("x", String(M.left - 8));
+    lbl.setAttribute("y", String(gy + 4));
+    lbl.setAttribute("text-anchor", "end");
+    lbl.setAttribute("class", "costs-axis");
+    lbl.textContent = fmtAxis(val, niceMax);
+    svg.appendChild(lbl);
+  }
+
+  // Area fill (~10% opacity wash) + 2px line.
+  const linePath = xs.map((i) => `${i === 0 ? "M" : "L"}${x(i)},${y(ys[i]!)}`).join(" ");
+  const areaPath = `${linePath} L${x(n - 1)},${y(0)} L${x(0)},${y(0)} Z`;
+  const area = document.createElementNS(svgNS, "path");
+  area.setAttribute("d", areaPath);
+  area.setAttribute("class", "costs-area");
+  svg.appendChild(area);
+  const line = document.createElementNS(svgNS, "path");
+  line.setAttribute("d", linePath);
+  line.setAttribute("class", "costs-line");
+  line.setAttribute("fill", "none");
+  svg.appendChild(line);
+
+  // End marker (≥8px) with a 2px surface ring.
+  const end = document.createElementNS(svgNS, "circle");
+  end.setAttribute("cx", String(x(n - 1)));
+  end.setAttribute("cy", String(y(ys[n - 1]!)));
+  end.setAttribute("r", "4.5");
+  end.setAttribute("class", "costs-endmarker");
+  svg.appendChild(end);
+
+  // X axis labels: first + last date only (selective).
+  const firstLbl = document.createElementNS(svgNS, "text");
+  firstLbl.setAttribute("x", String(x(0)));
+  firstLbl.setAttribute("y", String(H - 8));
+  firstLbl.setAttribute("text-anchor", "start");
+  firstLbl.setAttribute("class", "costs-axis");
+  firstLbl.textContent = fmtDate(history[0]!.timestamp);
+  svg.appendChild(firstLbl);
+  if (n > 1) {
+    const lastLbl = document.createElementNS(svgNS, "text");
+    lastLbl.setAttribute("x", String(x(n - 1)));
+    lastLbl.setAttribute("y", String(H - 8));
+    lastLbl.setAttribute("text-anchor", "end");
+    lastLbl.setAttribute("class", "costs-axis");
+    lastLbl.textContent = fmtDate(history[n - 1]!.timestamp);
+    svg.appendChild(lastLbl);
+  }
+
+  // Crosshair + tooltip layer.
+  const crosshair = document.createElementNS(svgNS, "line");
+  crosshair.setAttribute("class", "costs-crosshair");
+  crosshair.setAttribute("y1", String(M.top));
+  crosshair.setAttribute("y2", String(M.top + ih));
+  crosshair.style.display = "none";
+  svg.appendChild(crosshair);
+
+  const focusDot = document.createElementNS(svgNS, "circle");
+  focusDot.setAttribute("r", "4.5");
+  focusDot.setAttribute("class", "costs-focusdot");
+  focusDot.style.display = "none";
+  svg.appendChild(focusDot);
+
+  const tip = document.createElement("div");
+  tip.className = "costs-tip";
+  tip.style.display = "none";
+
+  const wrap = document.createElement("div");
+  wrap.className = "costs-chartwrap";
+  wrap.appendChild(svg);
+  wrap.appendChild(tip);
+
+  const nearestIndex = (clientX: number): number => {
+    const rect = svg.getBoundingClientRect();
+    const px = ((clientX - rect.left) / rect.width) * W; // back to viewBox space
+    let best = 0;
+    let bestD = Infinity;
+    for (let i = 0; i < n; i++) {
+      const d = Math.abs(x(i) - px);
+      if (d < bestD) {
+        bestD = d;
+        best = i;
+      }
+    }
+    return best;
+  };
+
+  const showAt = (i: number) => {
+    const p = history[i]!;
+    const cx = x(i);
+    const cy = y(p.hourly_cost);
+    crosshair.setAttribute("x1", String(cx));
+    crosshair.setAttribute("x2", String(cx));
+    crosshair.style.display = "";
+    focusDot.setAttribute("cx", String(cx));
+    focusDot.setAttribute("cy", String(cy));
+    focusDot.style.display = "";
+    tip.replaceChildren();
+    const val = document.createElement("div");
+    val.className = "costs-tip-val";
+    val.textContent = `${fmtUsd(p.hourly_cost)}/hr`;
+    const meta = document.createElement("div");
+    meta.className = "costs-tip-meta";
+    meta.textContent = `${fmtDate(p.timestamp)} · ${p.instance_count} instance${p.instance_count === 1 ? "" : "s"}`;
+    tip.appendChild(val);
+    tip.appendChild(meta);
+    // Position in wrap pixel space (viewBox → wrap ratio).
+    const ratio = wrap.clientWidth / W || 1;
+    tip.style.display = "";
+    const tipX = cx * ratio + 12;
+    const tipY = cy * (wrap.clientHeight / H || 1) - 8;
+    tip.style.left = `${Math.min(tipX, wrap.clientWidth - tip.offsetWidth - 8)}px`;
+    tip.style.top = `${Math.max(0, tipY)}px`;
+  };
+  const hide = () => {
+    crosshair.style.display = "none";
+    focusDot.style.display = "none";
+    tip.style.display = "none";
+  };
+
+  svg.addEventListener("pointermove", (e) => showAt(nearestIndex(e.clientX)));
+  svg.addEventListener("pointerleave", hide);
+
+  // Return the wrap as if it were the SVG (caller appends it).
+  return wrap as unknown as SVGSVGElement;
+}
+
+// ── Table view (a11y / non-visual) ─────────────────────────────────────────────
+function buildTable(history: CostPoint[]): HTMLElement {
+  const table = document.createElement("table");
+  table.className = "costs-table";
+  const thead = document.createElement("thead");
+  thead.innerHTML = `<tr><th>Date</th><th>Hourly</th><th>Monthly est.</th><th>Instances</th></tr>`;
+  table.appendChild(thead);
+  const tbody = document.createElement("tbody");
+  for (const p of history) {
+    const tr = document.createElement("tr");
+    const cells = [fmtDate(p.timestamp), fmtUsd(p.hourly_cost), fmtUsd(p.monthly_estimate), String(p.instance_count)];
+    for (const c of cells) {
+      const td = document.createElement("td");
+      td.textContent = c; // untrusted data → textContent
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  return table;
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+function niceCeil(v: number): number {
+  if (v <= 0) return 1;
+  const mag = Math.pow(10, Math.floor(Math.log10(v)));
+  const norm = v / mag;
+  const step = norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 5 ? 5 : 10;
+  return step * mag;
+}
+
+function fmtUsd(v: number): string {
+  if (v >= 100) return `$${v.toFixed(0)}`;
+  if (v >= 1) return `$${v.toFixed(2)}`;
+  return `$${v.toFixed(4)}`;
+}
+
+// Axis ticks use ONE consistent precision across the whole scale (driven by the
+// axis max), so ticks don't mix $0.5000 with $1.00. Clean, comma'd, tabular.
+function fmtAxis(v: number, axisMax: number): string {
+  const decimals = axisMax >= 100 ? 0 : axisMax >= 1 ? 2 : 4;
+  return `$${v.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}`;
+}
+
+function fmtDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}

--- a/web/app/surfaces/registry.ts
+++ b/web/app/surfaces/registry.ts
@@ -57,6 +57,13 @@ export const surfaces: ToolSurface[] = [
     load: () => import("./terminal.js").then((m) => ({ mount: m.terminalSurface.mount })),
   }),
   lazy({
+    id: "costs",
+    label: "Cost history",
+    accent: "--spawn",
+    requiresAuth: true,
+    load: () => import("./costs.js").then((m) => ({ mount: m.costsSurface.mount })),
+  }),
+  lazy({
     id: "catalog",
     label: "Software catalog",
     accent: "--strata",

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -573,3 +573,49 @@ footer {
 .catalog-name { font-weight: 700; color: var(--strata); }
 .catalog-slug { margin-left: auto; background: var(--code-bg); padding: 0.05rem 0.4rem; border-radius: 4px; font-size: 0.8rem; color: var(--text-muted); }
 .catalog-desc { margin: 0.4rem 0 0; color: var(--text); font-size: 0.9rem; }
+
+/* ── cost-history surface — dataviz single-series area+line (sequential blue) ── */
+/* Series hue validated ≥3:1 on the portal card surfaces (light #fff / dark #2a1839). */
+.costs-surface {
+  max-width: 820px;
+  --cost-series: #2a78d6;    /* sequential blue, light */
+  --cost-grid:   var(--border);
+  --cost-axis:   var(--text-muted);
+}
+[data-theme="dark"] .costs-surface { --cost-series: #3987e5; }  /* dark-surface step */
+.costs-hint { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 1rem; }
+.costs-controls { display: flex; gap: 0.4rem; margin-bottom: 1rem; align-items: center; }
+.costs-range, .costs-tabletoggle {
+  font: inherit; cursor: pointer; padding: 0.3rem 0.7rem; border-radius: var(--radius);
+  border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); font-size: 0.85rem;
+}
+.costs-tabletoggle { margin-left: auto; }
+.costs-range[aria-pressed="true"], .costs-tabletoggle[aria-pressed="true"] {
+  border-color: var(--cost-series); color: var(--cost-series); font-weight: 600;
+}
+.costs-kpis { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1.25rem; }
+.costs-tile { flex: 1 1 140px; border: 1px solid var(--border); border-radius: var(--radius); padding: 0.7rem 0.9rem; background: var(--bg-card); }
+.costs-tile-label { color: var(--text-muted); font-size: 0.8rem; }
+.costs-tile-value { color: var(--text); font-size: 1.5rem; font-weight: 600; margin-top: 0.2rem; }
+.costs-status { color: var(--text-muted); }
+.costs-status.error { color: var(--accent-red); }
+.costs-body { transition: opacity 0.15s ease; }
+.costs-chartwrap { position: relative; }
+.costs-chart { width: 100%; height: auto; display: block; overflow: visible; }
+.costs-grid { stroke: var(--cost-grid); stroke-width: 1; }
+.costs-axis { fill: var(--cost-axis); font-size: 11px; font-variant-numeric: tabular-nums; }
+.costs-area { fill: var(--cost-series); fill-opacity: 0.1; stroke: none; }
+.costs-line { stroke: var(--cost-series); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+.costs-endmarker { fill: var(--cost-series); stroke: var(--bg-card); stroke-width: 2; }
+.costs-crosshair { stroke: var(--cost-axis); stroke-width: 1; stroke-dasharray: 3 3; pointer-events: none; }
+.costs-focusdot { fill: var(--cost-series); stroke: var(--bg-card); stroke-width: 2; pointer-events: none; }
+.costs-tip {
+  position: absolute; pointer-events: none; background: var(--bg-card); border: 1px solid var(--border-strong);
+  border-radius: 6px; padding: 0.35rem 0.55rem; font-size: 0.8rem; box-shadow: 0 2px 8px rgba(0,0,0,0.12); white-space: nowrap;
+}
+.costs-tip-val { color: var(--text); font-weight: 600; font-variant-numeric: tabular-nums; }
+.costs-tip-meta { color: var(--text-muted); font-size: 0.75rem; margin-top: 0.1rem; }
+.costs-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.costs-table th, .costs-table td { text-align: left; padding: 0.35rem 0.6rem; border-bottom: 1px solid var(--border); }
+.costs-table th { color: var(--text-muted); font-weight: 600; }
+.costs-table td { color: var(--text); font-variant-numeric: tabular-nums; }


### PR DESCRIPTION
## What

A **Cost history** ToolSurface — the third Slice 5 feature and the first with **per-user data + a chart**. It consumes `GET /api/cost-history?days=N` from the shared dashboard-api over the session's federated creds (`X-AWS-Credentials`); the auth fix (`spawn#445`) scopes cost rows by the verified account.

## Dataviz (skill-guided)

Followed the `dataviz` skill procedure end to end:

- **Form:** single-series *trend over time* → **area + line** (not a bar chart).
- **Color:** sequential **blue** (`#2a78d6` light / `#3987e5` dark), each run through the palette validator against the portal's *actual* card surfaces (`#fff` / `#2a1839`) — both PASS ≥3:1 contrast, in-band, chroma floor. Single series ⇒ **no legend** (the title names it).
- **Marks:** 2px line, ~10% area wash, ≥8px end-marker with a 2px surface ring, hairline solid gridlines, muted **tabular** axis ticks with one consistent precision across the scale. Text wears ink tokens, never the series hue.
- **Interaction:** crosshair + one tooltip snapping to the nearest day; day-range presets (7/30/90) in one row above; refetch keeps the frame (dim, no layout jump).
- **A11y:** table-view toggle (every value reachable without hover); **real dark mode** stepped for the dark surface (not an auto-flip); untrusted API strings inserted via `textContent`.
- **KPI row:** current hourly cost, monthly estimate, instance count.

SVG built by hand — no chart lib, matching the portal's vanilla-TS ethos. Code-split into its own ~8 kB chunk.

## Verification

- `npm run typecheck` + `npm run build` clean.
- Headless render with mock data: chart, KPI tiles, working tooltip (value + date + instances), table toggle (30 rows), range switch, in **both light and dark**, **zero console errors**. Screenshots eyeballed for geometry/overflow (skill step 7).
- The live authenticated path reuses the `X-AWS-Credentials` plumbing already proven by the catalog surface + `spawn#445`.