### PR TITLE
feat(portal): Slack surface + fix hash-router query handling (Slice 5)

### DIFF
--- a/web/app/shell.ts
+++ b/web/app/shell.ts
@@ -78,7 +78,10 @@ export class Shell {
   }
 
   private currentId(): string {
-    const id = location.hash.replace(/^#\/?/, "").split("/")[0];
+    // Strip a trailing ?query before splitting the path — a surface can be
+    // returned to with params (e.g. the Slack OAuth callback lands on
+    // #/slack?bot=connected), and the route id must still resolve.
+    const id = location.hash.replace(/^#\/?/, "").split("?")[0]!.split("/")[0];
     return id || surfaces[0]?.id || "";
   }
 

--- a/web/app/surfaces/registry.ts
+++ b/web/app/surfaces/registry.ts
@@ -78,6 +78,13 @@ export const surfaces: ToolSurface[] = [
     load: () => import("./teams.js").then((m) => ({ mount: m.teamsSurface.mount })),
   }),
   lazy({
+    id: "slack",
+    label: "Slack",
+    accent: "--bot",
+    requiresAuth: false,
+    load: () => import("./slack.js").then((m) => ({ mount: m.slackSurface.mount })),
+  }),
+  lazy({
     id: "connect",
     label: "Connect account",
     accent: "--bot",

--- a/web/app/surfaces/slack.ts
+++ b/web/app/surfaces/slack.ts
@@ -1,0 +1,109 @@
+// The Slack surface: connect a Slack workspace to spore.host so the bot can post
+// notifications (spawn events, budgets…). The OAuth flow is server-driven by the
+// shared dashboard-api: GET /api/slack/oauth issues a PKCE + signed-state redirect
+// to Slack, and Slack calls back to /api/slack/oauth/callback which stores the
+// workspace and redirects back with ?bot=connected. This surface launches that
+// flow and reflects the return status.
+//
+// Unlike the other Slice 5 surfaces this one needs no X-AWS-Credentials: the
+// OAuth endpoints are intentionally unauthenticated (they're hit by Slack's
+// redirect, not an authenticated fetch), and the secrets live server-side
+// (Secrets Manager — see spawn#446). So this is a thin launcher + status view.
+import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+
+export const slackSurface: ToolSurface = {
+  id: "slack",
+  label: "Slack",
+  accent: "--bot",
+  requiresAuth: false,
+
+  async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+    const root = document.createElement("div");
+    root.className = "slack-surface";
+
+    // The OAuth start endpoint on the shared API. A full-page navigation (not a
+    // fetch) — Slack's consent screen + callback need a top-level browsing
+    // context, and the flow ends by redirecting back to the dashboard.
+    const startUrl = `${ctx.config.apiBase}/api/slack/oauth`;
+
+    // Reflect a return from the OAuth round-trip. The callback redirects to
+    // DASHBOARD_URL with bot=connected / workspace_name=… or error=…; if that's
+    // pointed at the portal, surface it. Read from both query + hash (the portal
+    // is a hash-router, so params may ride either).
+    const status = readReturnStatus();
+
+    const banner = status
+      ? status.ok
+        ? `<div class="slack-banner ok">✓ Connected${status.workspace ? ` <b>${escapeHtml(status.workspace)}</b>` : ""} to Slack.</div>`
+        : `<div class="slack-banner error">Slack connection failed: ${escapeHtml(status.error ?? "unknown error")}.</div>`
+      : "";
+
+    root.innerHTML = `
+      <div class="slack-head">
+        <h2>Slack</h2>
+        <p class="slack-hint">Connect a Slack workspace so spore.host can post
+          notifications — launch/termination events, budget alerts, and bot
+          commands — into your channels.</p>
+      </div>
+      ${banner}
+      <div class="slack-panel">
+        <a class="slack-connect" href="${escapeAttr(startUrl)}">Add to Slack</a>
+        <p class="slack-note">You'll pick a workspace and channel on Slack's own
+          consent screen, then land back here. spore.host never sees your Slack
+          password — only a scoped bot token, held server-side.</p>
+      </div>
+      <details class="slack-details">
+        <summary>What gets requested</summary>
+        <ul class="slack-scopes">
+          <li><code>commands</code> — slash commands (e.g. <code>/spawn</code>)</li>
+          <li><code>chat:write</code> — post messages as the bot</li>
+          <li><code>incoming-webhook</code> — post to the channel you choose</li>
+          <li><code>users:read</code>, <code>users:read.email</code> — map Slack users to accounts</li>
+        </ul>
+      </details>`;
+    host.appendChild(root);
+
+    return {
+      dispose() {
+        root.remove();
+      },
+    };
+  },
+};
+
+interface ReturnStatus {
+  ok: boolean;
+  workspace?: string;
+  error?: string;
+}
+
+// Parse OAuth return params from the URL (query string and/or hash query).
+function readReturnStatus(): ReturnStatus | null {
+  const params = new URLSearchParams(window.location.search);
+  // Hash may be "#/slack?bot=connected" — pull any query part after the route.
+  const hash = window.location.hash;
+  const qIdx = hash.indexOf("?");
+  if (qIdx >= 0) {
+    const hashParams = new URLSearchParams(hash.slice(qIdx + 1));
+    for (const [k, v] of hashParams) if (!params.has(k)) params.set(k, v);
+  }
+  if (params.get("bot") === "connected") {
+    return { ok: true, workspace: params.get("workspace_name") ?? undefined };
+  }
+  if (params.has("error")) {
+    return { ok: false, error: params.get("error") ?? undefined };
+  }
+  return null;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}
+
+// Attribute-context escape for the href (defends against a crafted apiBase).
+function escapeAttr(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!);
+}

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -655,3 +655,21 @@ footer {
 .teams-formmsg.error { color: var(--accent-red); }
 .teams-danger { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
 .teams-delete { font: inherit; cursor: pointer; padding: 0.45rem 1rem; border-radius: var(--radius); border: 1px solid var(--accent-red); background: var(--bg); color: var(--accent-red); }
+
+/* ── slack surface — connect-a-workspace OAuth launcher (accent --bot) ── */
+.slack-surface { max-width: 720px; }
+.slack-hint { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 1rem; }
+.slack-banner { border-radius: var(--radius); padding: 0.6rem 0.9rem; margin-bottom: 1rem; font-size: 0.9rem; }
+.slack-banner.ok { background: var(--spored-bg); color: var(--spored); border: 1px solid var(--spored); }
+.slack-banner.error { background: var(--bg-subtle); color: var(--accent-red); border: 1px solid var(--accent-red); }
+.slack-panel { border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.1rem; background: var(--bg-card); }
+.slack-connect {
+  display: inline-block; padding: 0.6rem 1.2rem; border-radius: var(--radius);
+  background: var(--bot); color: #fff; font-weight: 700; text-decoration: none;
+}
+.slack-connect:hover { filter: brightness(1.08); }
+.slack-note { color: var(--text-muted); font-size: 0.85rem; margin: 0.75rem 0 0; line-height: 1.5; }
+.slack-details { margin-top: 1rem; color: var(--text-muted); font-size: 0.9rem; }
+.slack-details summary { cursor: pointer; color: var(--bot); }
+.slack-scopes { margin: 0.5rem 0 0; padding-left: 1.2rem; line-height: 1.7; }
+.slack-scopes code, .slack-panel code { background: var(--code-bg); padding: 0.05rem 0.35rem; border-radius: 4px; font-size: 0.85em; }


### PR DESCRIPTION
## What

The **final Slice 5 increment**: a **Slack** ToolSurface (accent `--bot`) to connect a Slack workspace for bot notifications (launch/termination events, budget alerts, slash commands).

The OAuth flow is **server-driven** by dashboard-api: `GET /api/slack/oauth` issues a PKCE + signed-state redirect to Slack → Slack calls `/api/slack/oauth/callback` which stores the workspace and redirects back with `?bot=connected`. So this surface is a thin **launcher + return-status view**:

- **"Add to Slack"** — full-page navigation to `{apiBase}/api/slack/oauth` (Slack's consent screen needs a top-level browsing context; deliberately not a `fetch`).
- Reads OAuth return params (`bot=connected` / `workspace_name` / `error`) from the hash query and shows a success/error banner.
- Scope disclosure + "spore.host never sees your Slack password, only a scoped bot token held server-side" (the secrets now live in **Secrets Manager** — `spawn#446`).
- **No `X-AWS-Credentials`**: the OAuth endpoints are intentionally unauthenticated (hit by Slack's redirect, not an authenticated fetch), so `requiresAuth: false`.

## Shell bug fixed (surfaced by this surface)

`currentId()` split the hash on `/` only, so a route reached **with a query** — `#/slack?bot=connected`, exactly the OAuth callback landing — resolved to the bogus id `slack?bot=connected` and rendered "Unknown tool". Now it strips a trailing `?query` before the path split. General fix; any surface returned-to with params benefits.

## Verification

- `npm run typecheck` + `npm run build` clean (slack code-split ~2.2 kB).
- Headless render on **fresh page loads** (matching real OAuth-return behavior): launcher renders, correct OAuth href, success banner for `?bot=connected&workspace_name=…`, error banner for `?error=…`; 8 tools in the sidebar; **zero console errors**. Screenshot eyeballed.
- The secret-hardening backend (`spawn#446`) is deployed + verified live: `GET /api/slack/oauth` 302s to Slack with an HMAC-signed state (secret read from Secrets Manager at runtime).