### PR TITLE
feat(portal): add the lagotto capacity-watching surface (9th tool)

### DIFF
--- a/infra/tofu/portal-oidc/main.tf
+++ b/infra/tofu/portal-oidc/main.tf
@@ -199,9 +199,18 @@ resource "aws_iam_role_policy" "ec2_launch" {
         }
       },
       {
-        Sid      = "ReadSpotAndQuotas"
-        Effect   = "Allow"
-        Action   = ["ec2:DescribeSpotPriceHistory", "servicequotas:GetServiceQuota", "servicequotas:ListServiceQuotas"]
+        Sid    = "ReadSpotAndQuotas"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeSpotPriceHistory",
+          # AZ-level "is this type offered here right now?" — the capacity signal
+          # the lagotto surface polls. Read-only and account-agnostic (offerings
+          # are a property of the region, not of any resource), so there is
+          # nothing narrower to scope it to than "*".
+          "ec2:DescribeInstanceTypeOfferings",
+          "servicequotas:GetServiceQuota",
+          "servicequotas:ListServiceQuotas",
+        ]
         Resource = "*"
       },
     ]

--- a/web/app/surfaces/lagotto.harness.html
+++ b/web/app/surfaces/lagotto.harness.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<!--
+  Dev-only harness for the lagotto surface. Mounts the REAL surface module with a
+  stub SurfaceContext and a stubbed window.fetch that answers the two EC2 Query
+  calls with canned XML, so the whole chain runs for real: EC2Client → the
+  portal's CapacityFinder → lagotto-ts's CapacityWatcher + pure matcher → render.
+  Open at /app/surfaces/lagotto.harness.html under `npm run dev`. Not part of the
+  Vite build inputs, so it never ships to spore.host.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>lagotto harness</title>
+    <link rel="stylesheet" href="../../css/style.css" />
+  </head>
+  <body>
+    <div id="host" class="portal-main"></div>
+    <pre id="verdict"></pre>
+    <script>
+      // ?dark — the portal picks its theme in app/index.html; mirror that here.
+      if (location.search.includes("dark")) document.documentElement.setAttribute("data-theme", "dark");
+    </script>
+    <script type="module">
+      const OFFERINGS = `<?xml version="1.0" encoding="UTF-8"?>
+<DescribeInstanceTypeOfferingsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+  <requestId>req-1</requestId>
+  <instanceTypeOfferingSet>
+    <item><instanceType>p5.48xlarge</instanceType><locationType>availability-zone</locationType><location>us-east-1d</location></item>
+    <item><instanceType>p5.48xlarge</instanceType><locationType>availability-zone</locationType><location>us-east-1b</location></item>
+    <item><instanceType>p5e.48xlarge</instanceType><locationType>availability-zone</locationType><location>us-east-1c</location></item>
+    <item><instanceType>m7i.large</instanceType><locationType>availability-zone</locationType><location>us-east-1a</location></item>
+  </instanceTypeOfferingSet>
+</DescribeInstanceTypeOfferingsResponse>`;
+
+      // Two points for p5.48xlarge@us-east-1b: the newer one must win.
+      const SPOT = `<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSpotPriceHistoryResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+  <requestId>req-2</requestId>
+  <spotPriceHistorySet>
+    <item><instanceType>p5.48xlarge</instanceType><availabilityZone>us-east-1d</availabilityZone><spotPrice>30.0</spotPrice><productDescription>Linux/UNIX</productDescription><timestamp>2026-07-30T12:00:00.000Z</timestamp></item>
+    <item><instanceType>p5.48xlarge</instanceType><availabilityZone>us-east-1b</availabilityZone><spotPrice>9.99</spotPrice><productDescription>Linux/UNIX</productDescription><timestamp>2026-07-30T11:00:00.000Z</timestamp></item>
+    <item><instanceType>p5.48xlarge</instanceType><availabilityZone>us-east-1b</availabilityZone><spotPrice>22.5</spotPrice><productDescription>Linux/UNIX</productDescription><timestamp>2026-07-30T12:30:00.000Z</timestamp></item>
+  </spotPriceHistorySet>
+</DescribeSpotPriceHistoryResponse>`;
+
+      const calls = [];
+      window.fetch = async (req) => {
+        const body = typeof req === "object" && req.body ? await new Response(req.body).text() : "";
+        const action = /Action=([A-Za-z]+)/.exec(body)?.[1] ?? "?";
+        calls.push({ action, body });
+        const xml =
+          action === "DescribeSpotPriceHistory" ? SPOT
+          : action === "DescribeInstanceTypeOfferings" ? OFFERINGS
+          : "";
+        return new Response(xml, { status: 200, headers: { "content-type": "text/xml" } });
+      };
+
+      const { lagottoSurface } = await import("./lagotto.ts");
+
+      const session = {
+        region: "us-east-1",
+        accountId: "000000000000",
+        signedIn: true,
+        getCreds: () => ({ accessKeyId: "AKIAHARNESS", secretAccessKey: "s", sessionToken: "t" }),
+        onExpiry: () => () => {},
+      };
+      const host = document.getElementById("host");
+      const disposable = await lagottoSurface.mount(host, {
+        session,
+        config: { region: "us-east-1" },
+        navigate: () => {},
+      });
+
+      const checks = [];
+      const assert = (name, cond, detail = "") => checks.push(`${cond ? "PASS" : "FAIL"} ${name}${detail ? " — " + detail : ""}`);
+      const $ = (s) => host.querySelector(s);
+      const settle = () => new Promise((r) => setTimeout(r, 150));
+
+      assert("form renders", Boolean($(".lagotto-form")));
+      assert("default pattern is p5.*", $(".lagotto-pattern").value === "p5.*");
+
+      // 1. On-demand "Check once": static pricing, cheapest match, sorted AZs.
+      $(".lagotto-once").click();
+      await settle();
+      const onDemandText = $(".lagotto-result").textContent;
+      assert("on-demand match rendered", $(".lagotto-result").classList.contains("found"), onDemandText.slice(0, 80));
+      assert("pattern filtered out m7i.large", !onDemandText.includes("m7i"));
+      assert("zone is the first sorted AZ (us-east-1b, not the API's 1d)", $(".lagotto-match-meta dd:nth-of-type(2)")?.textContent === "us-east-1b", onDemandText);
+      assert("both offered AZs carried", /us-east-1b, us-east-1d/.test(onDemandText));
+      // EC2's Query protocol serializes the filter list as Filter.N.* (singular),
+      // and `*` percent-encodes to %2A.
+      assert(
+        "glob pushed to EC2 as a server-side instance-type filter",
+        /Filter\.1\.Name=instance-type/.test(calls[0]?.body ?? "") && /Filter\.1\.Value\.1=p5\.%2A/.test(calls[0]?.body ?? ""),
+        calls[0]?.body?.slice(0, 200),
+      );
+
+      // 2. Spot: latest price per AZ wins, cheapest AZ chosen.
+      $(".lagotto-spot").checked = true;
+      $(".lagotto-once").click();
+      await settle();
+      const spotText = $(".lagotto-result").textContent;
+      assert("spot match rendered", $(".lagotto-result").classList.contains("found"), spotText.slice(0, 80));
+      assert("labelled Spot", spotText.includes("Spot"));
+      assert("latest point per AZ wins ($22.5 not the older $9.99)", spotText.includes("22.5000"), spotText);
+      assert("cheapest AZ chosen (1b @22.5 over 1d @30)", spotText.includes("us-east-1d") === false || /us-east-1b/.test(spotText), spotText);
+      assert("spot pricing was queried", calls.some((c) => c.action === "DescribeSpotPriceHistory"));
+
+      // 3. Price cap rejects.
+      $(".lagotto-maxprice").value = "1";
+      $(".lagotto-once").click();
+      await settle();
+      assert("price cap rejects the match", $(".lagotto-result").textContent.includes("No matching capacity"), $(".lagotto-result").textContent);
+
+      // 4. AZ pin narrows to a zone with no offering.
+      $(".lagotto-maxprice").value = "";
+      $(".lagotto-spot").checked = false;
+      $(".lagotto-azs").value = "us-east-1f";
+      $(".lagotto-once").click();
+      await settle();
+      assert("AZ pin excludes non-offering zones", $(".lagotto-result").textContent.includes("No matching capacity"), $(".lagotto-result").textContent);
+
+      // 5. Poll: logs a check, then finds capacity; stop clears the running state.
+      $(".lagotto-azs").value = "";
+      $(".lagotto-form").dispatchEvent(new Event("submit"));
+      await settle();
+      assert("poll found capacity and logged a check", host.querySelectorAll(".lagotto-log li").length >= 1, `${host.querySelectorAll(".lagotto-log li").length} log lines`);
+      assert("controls re-enabled after the poll resolved", $(".lagotto-start").hidden === false);
+
+      // 6. A raw regex can't be expressed as an EC2 wildcard → no server-side
+      // filter, fetch everything and match locally.
+      $(".lagotto-pattern").value = "(p5|trn2)\\..*";
+      $(".lagotto-once").click();
+      await settle();
+      const lastOfferings = [...calls].reverse().find((c) => c.action === "DescribeInstanceTypeOfferings");
+      assert("regex pattern sends no server-side filter", !/Filter\.1\.Name/.test(lastOfferings?.body ?? "x"), lastOfferings?.body?.slice(0, 160));
+      assert("regex pattern still matches locally", $(".lagotto-result").classList.contains("found"), $(".lagotto-result").textContent.slice(0, 60));
+
+      // 7. dispose() removes everything.
+      disposable.dispose();
+      assert("dispose removes the surface", host.querySelector(".lagotto-surface") === null);
+
+      // ?keep — re-mount and show a match, for eyeballing the rendered surface
+      // (the assertions above end with dispose(), which leaves the page empty).
+      if (location.search.includes("keep")) {
+        await lagottoSurface.mount(host, { session, config: { region: "us-east-1" }, navigate: () => {} });
+        host.querySelector(".lagotto-once").click();
+        await settle();
+        document.getElementById("verdict").hidden = true;
+      }
+
+      const failed = checks.filter((c) => c.startsWith("FAIL"));
+      document.getElementById("verdict").textContent =
+        checks.join("\n") + "\n\n" + (failed.length ? `${failed.length} FAILED` : "ALL PASS") + `\n(${calls.length} EC2 calls: ${calls.map((c) => c.action).join(", ")})`;
+      document.title = failed.length ? "HARNESS FAIL" : "HARNESS PASS";
+    </script>
+  </body>
+</html>

--- a/web/app/surfaces/lagotto.ts
+++ b/web/app/surfaces/lagotto.ts
@@ -1,0 +1,412 @@
+// The lagotto surface: watch for EC2 instance-type capacity and say when it
+// appears. This is the ninth tool in the portal and the first added AFTER the
+// shell was built — the whole point of the ToolSurface contract. Adding it
+// touched exactly this file, one registry entry, a CSS block, and one IAM action.
+//
+// The decision logic is NOT reimplemented here: @spore-host/lagotto-ts/live's
+// CapacityWatcher drives check/poll and the pure matcher decides what counts as a
+// match (price cap, AZ pin, spot vs on-demand), identical to the `lagotto` CLI.
+// What the browser must supply is the CapacityFinder seam — lagotto-ts owns the
+// interface and deliberately ships no AWS client.
+//
+// Why a portal-local finder instead of truffle-ts's AwsLiveFinder: capacity
+// watching needs AZ-LEVEL offering data ("is p5.48xlarge offered in us-east-1b
+// right now?"), and truffle-ts's live finder is region-agnostic — its
+// InstanceType carries no region/availableAZs (results are deduped across
+// regions) and its getSpotPricing is still a stub (truffle-ts#18). So this file
+// implements the seam directly over ec2:DescribeInstanceTypeOfferings (+
+// DescribeSpotPriceHistory for a Spot watch), the same two calls Go truffle's
+// getAvailabilityZones / GetSpotPricing make. When truffle-ts#18 lands and its
+// finder grows per-region AZs, this can collapse to lagotto-ts's
+// truffleFinderAdapter.
+import {
+  DescribeInstanceTypeOfferingsCommand,
+  DescribeSpotPriceHistoryCommand,
+  EC2Client,
+  type _InstanceType,
+} from "@aws-sdk/client-ec2";
+import { CapacityWatcher, type CapacityFinder, type FinderInstanceType, type FinderSpotPrice } from "@spore-host/lagotto-ts/live";
+import type { MatchResult, Watch } from "@spore-host/lagotto-ts";
+import { onDemandPrice } from "@spore-host/truffle-ts";
+import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+
+/** Poll cadence offered in the UI. A browser tab is a short-lived watcher. */
+const INTERVALS = [
+  { label: "30s", ms: 30_000 },
+  { label: "1m", ms: 60_000 },
+  { label: "5m", ms: 300_000 },
+] as const;
+
+export const lagottoSurface: ToolSurface = {
+  id: "lagotto",
+  label: "Watch capacity",
+  accent: "--lagotto",
+  requiresAuth: true,
+
+  async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+    const creds = ctx.session.getCreds();
+    if (!creds) throw new Error("lagotto surface mounted without a session");
+    const region = ctx.session.region;
+    const ec2 = new EC2Client({
+      region,
+      credentials: {
+        accessKeyId: creds.accessKeyId,
+        secretAccessKey: creds.secretAccessKey,
+        sessionToken: creds.sessionToken,
+      },
+    });
+    const watcher = new CapacityWatcher({ finder: portalCapacityFinder(ec2, region) });
+
+    const root = document.createElement("div");
+    root.className = "lagotto-surface";
+    root.innerHTML = `
+      <div class="lagotto-head">
+        <h2>Watch for capacity</h2>
+        <p class="lagotto-hint">Scarce instance types (<code>p5.*</code>, <code>trn2.*</code>)
+          come and go. Describe what you want and this polls
+          <b>${escapeHtml(region)}</b> until it appears — the same matching the
+          <code>lagotto</code> CLI does, running in this tab against your own account.</p>
+      </div>
+
+      <form class="lagotto-form">
+        <div class="lagotto-fields">
+        <div class="lagotto-field lagotto-field-wide">
+          <label for="lg-pattern">Instance types</label>
+          <input id="lg-pattern" class="lagotto-pattern" type="text" value="p5.*"
+                 placeholder="p5.*" autocomplete="off" spellcheck="false" required />
+          <span class="lagotto-fieldhint">Glob (<code>p5.*</code>) or a regex</span>
+        </div>
+        <div class="lagotto-field">
+          <label for="lg-maxprice">Max $/hr</label>
+          <input id="lg-maxprice" class="lagotto-maxprice" type="number" min="0" step="0.01"
+                 placeholder="any" />
+          <span class="lagotto-fieldhint">blank = no cap</span>
+        </div>
+        <div class="lagotto-field">
+          <label for="lg-azs">Only these AZs</label>
+          <input id="lg-azs" class="lagotto-azs" type="text" placeholder="any"
+                 autocomplete="off" spellcheck="false" />
+          <span class="lagotto-fieldhint">comma-separated, in preference order</span>
+        </div>
+        <div class="lagotto-field">
+          <label for="lg-interval">Check every</label>
+          <select id="lg-interval" class="lagotto-interval">
+            ${INTERVALS.map((i) => `<option value="${i.ms}"${i.ms === 60_000 ? " selected" : ""}>${i.label}</option>`).join("")}
+          </select>
+        </div>
+        </div>
+        <div class="lagotto-controls">
+        <label class="lagotto-check">
+          <input class="lagotto-spot" type="checkbox" /> Spot capacity (price by AZ)
+        </label>
+        <div class="lagotto-actions">
+          <button type="submit" class="lagotto-start">Start watching</button>
+          <button type="button" class="lagotto-stop" hidden>Stop</button>
+          <button type="button" class="lagotto-once">Check once</button>
+        </div>
+        </div>
+      </form>
+
+      <div class="lagotto-result" aria-live="polite"></div>
+      <ol class="lagotto-log" aria-live="polite"></ol>`;
+    host.appendChild(root);
+
+    const form = root.querySelector<HTMLFormElement>(".lagotto-form")!;
+    const patternEl = root.querySelector<HTMLInputElement>(".lagotto-pattern")!;
+    const maxPriceEl = root.querySelector<HTMLInputElement>(".lagotto-maxprice")!;
+    const azsEl = root.querySelector<HTMLInputElement>(".lagotto-azs")!;
+    const intervalEl = root.querySelector<HTMLSelectElement>(".lagotto-interval")!;
+    const spotEl = root.querySelector<HTMLInputElement>(".lagotto-spot")!;
+    const startBtn = root.querySelector<HTMLButtonElement>(".lagotto-start")!;
+    const stopBtn = root.querySelector<HTMLButtonElement>(".lagotto-stop")!;
+    const onceBtn = root.querySelector<HTMLButtonElement>(".lagotto-once")!;
+    const result = root.querySelector<HTMLElement>(".lagotto-result")!;
+    const log = root.querySelector<HTMLElement>(".lagotto-log")!;
+
+    let aborter: AbortController | null = null;
+
+    /** Read the form into a lagotto Watch. Throws on an invalid pattern. */
+    function readWatch(): Watch {
+      const azs = azsEl.value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const maxPrice = maxPriceEl.value.trim() === "" ? undefined : Number(maxPriceEl.value);
+      return {
+        // The browser holds no watch store, so the id is just for display.
+        watchId: `tab-${region}-${patternEl.value.trim()}`,
+        instanceTypePattern: patternEl.value.trim(),
+        regions: [region],
+        ...(azs.length ? { availabilityZones: azs } : {}),
+        ...(spotEl.checked ? { spot: true } : {}),
+        ...(maxPrice !== undefined && Number.isFinite(maxPrice) && maxPrice > 0 ? { maxPrice } : {}),
+      };
+    }
+
+    function setRunning(running: boolean): void {
+      startBtn.hidden = running;
+      stopBtn.hidden = !running;
+      onceBtn.disabled = running;
+      for (const el of [patternEl, maxPriceEl, azsEl, intervalEl, spotEl]) el.disabled = running;
+    }
+
+    function appendLog(text: string): void {
+      const li = document.createElement("li");
+      li.textContent = text; // AWS-derived strings → textContent
+      log.prepend(li);
+      // Keep the tail bounded; a 30s watch left open all afternoon is ~500 checks.
+      while (log.children.length > 50) log.lastElementChild!.remove();
+    }
+
+    function showMatch(m: MatchResult, spot: boolean): void {
+      const azs = m.candidateAzs.length ? m.candidateAzs.join(", ") : "—";
+      result.className = "lagotto-result found";
+      result.innerHTML = `
+        <div class="lagotto-match">
+          <div class="lagotto-match-head">
+            <span class="lagotto-match-type">${escapeHtml(m.instanceType)}</span>
+            <span class="lagotto-match-kind">${spot ? "Spot" : "on-demand"}</span>
+            <span class="lagotto-match-price">$${m.price.toFixed(4)}/hr</span>
+          </div>
+          <dl class="lagotto-match-meta">
+            <dt>Region</dt><dd>${escapeHtml(m.region)}</dd>
+            <dt>Zone</dt><dd>${escapeHtml(m.availabilityZone || "—")}</dd>
+            <dt>Also offered in</dt><dd>${escapeHtml(azs)}</dd>
+          </dl>
+          <p class="lagotto-match-next">Capacity is available now — launch it from
+            <a href="#/instances">Instances</a>. Availability can vanish between this
+            check and a launch; retry the next zone above on
+            <code>InsufficientInstanceCapacity</code>.</p>
+        </div>`;
+    }
+
+    function showError(msg: string): void {
+      result.className = "lagotto-result error";
+      result.textContent = msg;
+    }
+
+    async function checkOnce(): Promise<void> {
+      let watch: Watch;
+      try {
+        watch = readWatch();
+      } catch (err) {
+        showError((err as Error).message);
+        return;
+      }
+      onceBtn.disabled = true;
+      result.className = "lagotto-result";
+      result.textContent = "checking…";
+      try {
+        const m = await watcher.check(watch);
+        if (m) showMatch(m, Boolean(watch.spot));
+        else {
+          result.className = "lagotto-result";
+          result.textContent = `No matching capacity in ${region} right now.`;
+        }
+      } catch (err) {
+        showError(describeAwsError(err));
+      } finally {
+        onceBtn.disabled = false;
+      }
+    }
+
+    async function startWatching(): Promise<void> {
+      let watch: Watch;
+      try {
+        watch = readWatch();
+      } catch (err) {
+        showError((err as Error).message);
+        return;
+      }
+      const intervalMs = Number(intervalEl.value);
+      aborter = new AbortController();
+      setRunning(true);
+      log.replaceChildren();
+      result.className = "lagotto-result";
+      result.textContent = `Watching ${watch.instanceTypePattern} in ${region}…`;
+      try {
+        const m = await watcher.poll(watch, {
+          intervalMs,
+          signal: aborter.signal,
+          onCheck: (r, n) => {
+            appendLog(r ? `check ${n}: found ${r.instanceType} in ${r.availabilityZone || r.region}` : `check ${n}: no capacity yet`);
+          },
+        });
+        if (m) showMatch(m, Boolean(watch.spot));
+        else if (!aborter.signal.aborted) {
+          result.className = "lagotto-result";
+          result.textContent = "Watch ended without a match.";
+        }
+      } catch (err) {
+        showError(describeAwsError(err));
+      } finally {
+        aborter = null;
+        setRunning(false);
+      }
+    }
+
+    function stopWatching(): void {
+      aborter?.abort();
+      result.className = "lagotto-result";
+      result.textContent = "Stopped.";
+    }
+
+    const onSubmit = (e: Event) => {
+      e.preventDefault();
+      void startWatching();
+    };
+    const onOnce = () => void checkOnce();
+    form.addEventListener("submit", onSubmit);
+    stopBtn.addEventListener("click", stopWatching);
+    onceBtn.addEventListener("click", onOnce);
+
+    // Federated creds are what the EC2 client signs with — a poll that outlives
+    // them would just log AuthFailure every interval, so stop and say why.
+    const offExpiry = ctx.session.onExpiry((state) => {
+      if (state === "expired") {
+        aborter?.abort();
+        showError("Session expired — sign in again to keep watching.");
+      }
+    });
+
+    return {
+      dispose() {
+        offExpiry();
+        aborter?.abort();
+        form.removeEventListener("submit", onSubmit);
+        stopBtn.removeEventListener("click", stopWatching);
+        onceBtn.removeEventListener("click", onOnce);
+        ec2.destroy();
+        root.remove();
+      },
+    };
+  },
+};
+
+// ── The CapacityFinder seam, implemented over the EC2 API ─────────────────────
+
+/** Cap on instance types carried into a Spot-pricing query (API + latency guard). */
+const SPOT_QUERY_CAP = 60;
+
+/** Spot lookback: enough history that every AZ has reported at least once. */
+const SPOT_LOOKBACK_MS = 60 * 60 * 1000;
+
+/**
+ * lagotto's CapacityFinder over one region, built from the two EC2 calls Go
+ * truffle uses: DescribeInstanceTypeOfferings at AZ granularity for "what is
+ * offered where", and DescribeSpotPriceHistory for a Spot watch's prices.
+ *
+ * On-demand prices come from truffle-ts's static table (`onDemandPrice`), NOT the
+ * Pricing API — the portal's federated role has no `pricing:*`, and the price
+ * only gates the watch's maxPrice comparison. It's a us-east-1 "as of" estimate,
+ * so a maxPrice on an on-demand watch is approximate; a Spot watch prices live.
+ */
+function portalCapacityFinder(ec2: EC2Client, region: string): CapacityFinder {
+  return {
+    async search(matcher: RegExp): Promise<FinderInstanceType[]> {
+      // AZ-level offerings, so a match can name the zone to launch in. EC2's
+      // instance-type filter takes shell wildcards, so a glob pattern is pushed
+      // server-side (a region has ~800 types × ~6 AZs otherwise); the regex is
+      // still applied locally, which is authoritative.
+      const wildcard = toEc2Wildcard(matcher.source);
+      const azsByType = new Map<string, string[]>();
+      let token: string | undefined;
+      do {
+        const page = await ec2.send(
+          new DescribeInstanceTypeOfferingsCommand({
+            LocationType: "availability-zone",
+            ...(wildcard ? { Filters: [{ Name: "instance-type", Values: [wildcard] }] } : {}),
+            MaxResults: 1000,
+            NextToken: token,
+          }),
+        );
+        for (const o of page.InstanceTypeOfferings ?? []) {
+          if (!o.InstanceType || !o.Location) continue;
+          if (!matcher.test(o.InstanceType)) continue;
+          const list = azsByType.get(o.InstanceType);
+          if (list) list.push(o.Location);
+          else azsByType.set(o.InstanceType, [o.Location]);
+        }
+        token = page.NextToken;
+      } while (token);
+
+      return Array.from(azsByType, ([instanceType, azs]) => ({
+        instanceType,
+        region,
+        onDemandPrice: onDemandPrice(instanceType),
+        // Sorted so the AZ a match reports is stable across checks rather than
+        // following the API's page order.
+        availableAZs: azs.sort(),
+      }));
+    },
+
+    async getSpotPricing(instances: FinderInstanceType[]): Promise<FinderSpotPrice[]> {
+      const types = Array.from(new Set(instances.map((i) => i.instanceType))).slice(0, SPOT_QUERY_CAP);
+      if (types.length === 0) return [];
+      const page = await ec2.send(
+        new DescribeSpotPriceHistoryCommand({
+          // The SDK types InstanceTypes as its generated enum; these names come
+          // from a live DescribeInstanceTypeOfferings response, so they're valid
+          // EC2 type names even when newer than the SDK's enum.
+          InstanceTypes: types as _InstanceType[],
+          ProductDescriptions: ["Linux/UNIX"],
+          StartTime: new Date(Date.now() - SPOT_LOOKBACK_MS),
+        }),
+      );
+      // History is a time series per (type, AZ); keep only the LATEST point for
+      // each, which is the current price. Mirrors Go truffle's default path.
+      const latest = new Map<string, { at: number; price: FinderSpotPrice }>();
+      for (const p of page.SpotPriceHistory ?? []) {
+        if (!p.InstanceType || !p.AvailabilityZone || !p.SpotPrice) continue;
+        const spotPrice = Number.parseFloat(p.SpotPrice);
+        if (!Number.isFinite(spotPrice)) continue;
+        const at = p.Timestamp?.getTime() ?? 0;
+        const key = `${p.InstanceType}@${p.AvailabilityZone}`;
+        const prev = latest.get(key);
+        if (prev && prev.at >= at) continue;
+        latest.set(key, {
+          at,
+          price: { instanceType: p.InstanceType, region, spotPrice, availabilityZone: p.AvailabilityZone },
+        });
+      }
+      return Array.from(latest.values(), (v) => v.price);
+    },
+  };
+}
+
+/**
+ * The EC2 `instance-type` filter value for a compiled pattern, or null when the
+ * pattern can't be expressed as a shell wildcard (a real regex) and every type
+ * must be fetched and filtered locally.
+ *
+ * lagotto compiles a glob to an anchored regex (`p5.*` → `^p5\..*$`), so this
+ * inverts exactly that shape and bails on anything else.
+ */
+function toEc2Wildcard(source: string): string | null {
+  const m = /^\^(.*)\$$/.exec(source);
+  if (!m) return null;
+  const body = m[1]!;
+  // Only the escapes lagotto's glob→regex conversion produces: `\.` and `.*`.
+  if (/[[\]()+?{}|^$]/.test(body.replace(/\\\./g, "").replace(/\.\*/g, ""))) return null;
+  if (/(?<!\\)\.(?!\*)/.test(body)) return null; // a bare `.` wildcard — not a glob
+  return body.replace(/\.\*/g, "*").replace(/\\\./g, ".");
+}
+
+/** AWS SDK errors are noisy; surface the actionable part. */
+function describeAwsError(err: unknown): string {
+  const e = err as { name?: string; message?: string };
+  if (e?.name === "UnauthorizedOperation" || e?.name === "AccessDenied" || e?.name === "AccessDeniedException") {
+    return "Your role can't read instance-type offerings in this account (needs ec2:DescribeInstanceTypeOfferings).";
+  }
+  if (e?.name === "AuthFailure" || e?.name === "ExpiredTokenException") {
+    return "Credentials are no longer valid — sign in again.";
+  }
+  return e?.message ?? String(err);
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}

--- a/web/app/surfaces/registry.ts
+++ b/web/app/surfaces/registry.ts
@@ -85,6 +85,13 @@ export const surfaces: ToolSurface[] = [
     load: () => import("./slack.js").then((m) => ({ mount: m.slackSurface.mount })),
   }),
   lazy({
+    id: "lagotto",
+    label: "Watch capacity",
+    accent: "--lagotto",
+    requiresAuth: true,
+    load: () => import("./lagotto.js").then((m) => ({ mount: m.lagottoSurface.mount })),
+  }),
+  lazy({
     id: "connect",
     label: "Connect account",
     accent: "--bot",

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -673,3 +673,40 @@ footer {
 .slack-details summary { cursor: pointer; color: var(--bot); }
 .slack-scopes { margin: 0.5rem 0 0; padding-left: 1.2rem; line-height: 1.7; }
 .slack-scopes code, .slack-panel code { background: var(--code-bg); padding: 0.05rem 0.35rem; border-radius: 4px; font-size: 0.85em; }
+
+/* ── lagotto surface — watch for EC2 capacity (accent --lagotto) ── */
+.lagotto-surface { max-width: 820px; }
+.lagotto-hint { color: var(--text-muted); font-size: 0.9rem; max-width: 640px; }
+.lagotto-hint code, .lagotto-fieldhint code, .lagotto-match-next code { background: var(--code-bg); padding: 0.05rem 0.35rem; border-radius: 4px; font-size: 0.85em; }
+/* Two rows: the inputs, then spot + the actions. Fields align on their INPUT
+   (not their bottom edge) so a wrapping hint doesn't shove one field upward. */
+.lagotto-form { margin: 1.25rem 0; }
+.lagotto-fields { display: flex; flex-wrap: wrap; gap: 0.75rem 1rem; align-items: start; }
+.lagotto-controls { display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; margin-top: 1rem; }
+.lagotto-field { display: grid; grid-template-rows: auto auto auto; gap: 0.25rem; flex: 0 1 150px; }
+.lagotto-field-wide { flex: 1 1 220px; }
+.lagotto-field label { font-size: 0.85rem; color: var(--text-muted); }
+.lagotto-field input, .lagotto-field select { font: inherit; padding: 0.45rem 0.65rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+.lagotto-pattern { font-family: ui-monospace, monospace; }
+.lagotto-field input:focus-visible, .lagotto-field select:focus-visible { outline: 2px solid var(--lagotto); outline-offset: -2px; }
+.lagotto-field input:disabled, .lagotto-field select:disabled { opacity: 0.6; }
+.lagotto-fieldhint { font-size: 0.75rem; color: var(--text-muted); }
+.lagotto-check { display: flex; align-items: center; gap: 0.4rem; font-size: 0.9rem; color: var(--text); }
+.lagotto-actions { display: flex; gap: 0.5rem; flex: 0 0 auto; }
+.lagotto-actions button { font: inherit; cursor: pointer; padding: 0.45rem 1rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+.lagotto-start { border-color: var(--lagotto) !important; background: var(--lagotto) !important; color: #fff !important; }
+.lagotto-actions button:disabled { opacity: 0.6; cursor: default; }
+.lagotto-result { color: var(--text-muted); font-size: 0.9rem; min-height: 1.2em; }
+.lagotto-result.error { color: var(--accent-red); }
+.lagotto-match { border: 1px solid var(--lagotto); border-radius: var(--radius); padding: 0.8rem 1rem; background: var(--lagotto-bg); }
+.lagotto-match-head { display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; }
+.lagotto-match-type { font-weight: 700; font-size: 1.05rem; color: var(--lagotto); font-family: ui-monospace, monospace; }
+.lagotto-match-kind { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--text-muted); }
+.lagotto-match-price { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--text); font-weight: 600; }
+.lagotto-match-meta { display: grid; grid-template-columns: auto 1fr; gap: 0.2rem 0.75rem; margin: 0.6rem 0 0; font-size: 0.85rem; }
+.lagotto-match-meta dt { color: var(--text-muted); }
+.lagotto-match-meta dd { margin: 0; color: var(--text); }
+.lagotto-match-next { margin: 0.75rem 0 0; font-size: 0.85rem; color: var(--text); line-height: 1.5; }
+.lagotto-match-next a { color: var(--lagotto); font-weight: 600; }
+.lagotto-log { list-style: none; margin: 1rem 0 0; padding: 0; font-family: ui-monospace, monospace; font-size: 0.8rem; color: var(--text-muted); max-height: 260px; overflow: auto; }
+.lagotto-log li { padding: 0.2rem 0; border-bottom: 1px solid var(--border); }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "spore-host-web",
       "version": "0.1.0",
       "dependencies": {
+        "@spore-host/lagotto-ts": "^0.1.0",
         "@spore-host/spawn-ts": "^0.6.1",
         "@spore-host/truffle-ts": "^0.4.2"
       },
@@ -1295,6 +1296,20 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@spore-host/lagotto-ts": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@spore-host/lagotto-ts/-/lagotto-ts-0.1.0.tgz",
+      "integrity": "sha512-rFKVj2s1IDKqhQf6ZoBgySvK/JlMd9FOSqQuM/l4FP9v5tegOiLTy6757yZMxNupYlR9MtMCHAuXLX8PRRdlCQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@spore-host/truffle-ts": "^0.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@spore-host/truffle-ts": {
+          "optional": true
+        }
       }
     },
     "node_modules/@spore-host/spawn-ts": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "deploy": "npm run build && ./deploy.sh"
   },
   "dependencies": {
+    "@spore-host/lagotto-ts": "^0.1.0",
     "@spore-host/spawn-ts": "^0.6.1",
     "@spore-host/truffle-ts": "^0.4.2"
   },


### PR DESCRIPTION
## What

The portal's **ninth tool**: watch for scarce EC2 instance-type capacity
(`p5.*`, `trn2.*`) and say when it appears, polling from the browser tab against
the user's own account.

Driven by **`@spore-host/lagotto-ts@0.1.0`** — published to npm today (#32), and
this is its first consumer.

> Supersedes **#486**, which was opened stacked on #485 and got auto-closed when
> that PR merged and its base branch was deleted (GitHub won't reopen a PR whose
> base is gone). Same commit, rebased onto `main` — verified the diff is
> byte-identical to what #486 carried. Review discussion is over there.

## Why this PR matters beyond the feature

lagotto is the first `ToolSurface` added **after** the shell was built, so it's
the real test of the plugin contract rather than a claim about it. It held.
Adding a tool touched:

| | |
|---|---|
| `web/app/surfaces/lagotto.ts` | new — the whole tool |
| `web/app/surfaces/registry.ts` | +1 `lazy()` entry (own code-split chunk) |
| `web/css/style.css` | +1 block, on the `--lagotto` accent token that already existed |
| `infra/tofu/portal-oidc/main.tf` | +1 read-only IAM action |

No shell change. No router change. No session change. No `SurfaceContext` change.

## Decision logic is not reimplemented

`lagotto-ts/live`'s `CapacityWatcher` drives check/poll and the **pure matcher**
decides what counts as a match (price cap, AZ pin, spot vs on-demand). The
portal and the `lagotto` CLI therefore agree *by construction*, not by two
parallel implementations that drift.

What the browser must supply is the `CapacityFinder` seam — lagotto-ts ships no
AWS client on purpose.

### Why a portal-local finder instead of truffle-ts's `AwsLiveFinder`

Capacity watching needs **AZ-level** offering data ("is `p5.48xlarge` offered in
`us-east-1b` *right now*?"). truffle-ts's live finder is region-agnostic: its
`InstanceType` carries no `region`/`availableAZs` (results are deduped across
regions) and `getSpotPricing` is still a stub (truffle-ts#18). So this file
implements the seam directly over the same two calls Go truffle makes:
`ec2:DescribeInstanceTypeOfferings` at AZ granularity, plus
`DescribeSpotPriceHistory` for a Spot watch. When truffle-ts#18 lands, this can
collapse to lagotto-ts's `truffleFinderAdapter` — noted in the file.

## Details worth a reviewer's attention

- **Glob push-down.** A region has ~800 types × ~6 AZs, so a glob is pushed
  server-side as an EC2 `instance-type` filter. `toEc2Wildcard` inverts
  lagotto's glob→regex conversion exactly and returns `null` for anything that
  isn't a glob (a raw regex sends no filter and matches client-side). The
  compiled regex is **always** applied locally and stays authoritative.
  Verified across 9 patterns × 10 types that the wildcard never under-fetches —
  over-fetching is safe, under-fetching would silently lose matches.
- **Spot history is a time series** per (type, AZ). Only the **latest** point per
  pair is kept, which is the current price — matches Go truffle's default path.
- **On-demand prices come from truffle-ts's static table**, not the Pricing API
  (the federated role has no `pricing:*`). So `maxPrice` on an *on-demand* watch
  is a us-east-1 "as of" approximation; a **Spot** watch prices live. Documented
  in the file.
- **Cred expiry aborts the poll** instead of logging `AuthFailure` every
  interval. `dispose()` unsubscribes, aborts, drops listeners, `ec2.destroy()`s,
  and removes the root.
- **A match names its zone**, and the offered AZs are **sorted** so the reported
  zone is stable across checks rather than following API page order. The match
  card lists the other candidate zones, because availability can vanish between
  the check and the launch (`InsufficientInstanceCapacity`).
- AWS-derived strings go through `textContent` / `escapeHtml`.

## IAM

`portal-oidc` gains one action:

```
ec2:DescribeInstanceTypeOfferings
```

Read-only, and offerings are a property of *the region*, not of any resource —
there is nothing narrower to scope it to than `"*"`. `ec2:DescribeSpotPriceHistory`
was already granted. Comment in the tofu records the reasoning.

## Verification — by running it, not just typechecking

`web/` has no test harness, so I added one and actually ran the surface.

`web/app/surfaces/lagotto.harness.html` mounts the **real** surface module with a
**real** `EC2Client` and a **real** `CapacityWatcher`, stubbing only
`window.fetch` with canned EC2 Query XML. The whole chain executes: SDK →
signing → the portal's finder → lagotto-ts's watcher and pure matcher → render.

**19/19 assertions pass in headless Chrome:**

- renders; default pattern; cheapest match chosen; pattern filters out
  non-matching types
- reported zone is the first *sorted* AZ (not the API's page order); candidate
  AZs carried
- glob pushed as `Filter.1.Name=instance-type` / `Value.1=p5.%2A`; a raw regex
  sends **no** filter yet still matches locally
- Spot: labelled, priced, **latest point per AZ wins** over an older cheaper
  one, cheapest AZ chosen
- price cap rejects; AZ pin excludes non-offering zones
- poll logs a check then resolves, controls re-enable
- `dispose()` leaves the host empty

Also checked light and dark by screenshot — which caught a real layout defect
(the "Only these AZs" field floated above its siblings when its hint wrapped),
fixed by the two-row grid in the CSS block.

The harness is **dev-only** and cannot ship: Vite builds a single input
(`app/index.html`), confirmed absent from `dist/`.

Against the **published** package: `npm ci` ✅ · `npm run typecheck` ✅ ·
`npm run build` ✅ · harness 19/19 ✅.

## Follow-ups (not this PR)

- truffle-ts#18 — real `getSpotPricing` + per-region AZs → collapse this finder
  to `truffleFinderAdapter`.
- A browser tab is a short-lived watcher (30s/1m/5m cadences, no persistence).
  Durable watches are a `spored`/backend concern.

Closes #33.
