### PR TITLE
feat(portal-phone-home): account lifecycle state machine (spawn#457)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
             min_coverage: '10'   # target 60% (CLAUDE.md); current ~10.8%
           - module: lambda/spore-bot
             min_coverage: '12'   # current ~13.8%
+          - module: lambda/portal-phone-home
+            min_coverage: '70'   # current ~76.8% — the SigV4 invariant and the
+                                 # account lifecycle machine (spawn#457) are both
+                                 # pure and fully covered, so this floor is real.
+                                 # Was absent from this matrix entirely, so its
+                                 # tests had never run in CI.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **Account lifecycle state machine for BYOA deprovisioning** (`lambda/portal-phone-home/lifecycle.go`,
+  spawn#457 checkbox 2). Onboarding was one-way — the registry exposed only
+  `PutAccount`/`GetAccount`, so nothing could ever conclude "this account is gone"
+  and every artifact left behind was permanent. One of those artifacts is a real
+  hazard: a Route53 A-record whose public IP has returned to the EC2 pool
+  eventually resolves to an unrelated instance.
+  - New `Account` lifecycle fields, all `omitempty`: `status`, `lastSeenAt`,
+    `lastErrorAt`, `consecutiveFailures`, `lastInstanceAt`, `statusReason`,
+    `statusChangedAt`. A row written before this change unmarshals to the zero
+    value and reads as `active` via `AccountStatus()` — **no backfill needed**.
+  - Four states — `active`, `unreachable`, `dormant`, `offboarded` — each existing
+    to answer one question: is it safe to delete this account's DNS records?
+    `DNSExpiryEligible` says yes for only `dormant` (emptiness *proven* through a
+    working `DescribeInstances`) and `offboarded` (a human stated intent).
+  - `ApplyProbes` is the pure state machine (no AWS, no clock — `now` is a
+    parameter), driven by the liveness signal the reaper already pays for: it
+    assumes every account's role every 10 minutes. Policy is K/N configurable,
+    defaulting to K=6 consecutive failed runs (one hour) and N=30 days.
+  - **Refuses to act on correlated failure**: if *every* probe fails, nothing
+    changes. The reaper's role ARN embeds a CloudFormation-generated physical ID,
+    so recreating that stack breaks every customer's trust policy at once — a
+    machine acting on assume-role failure alone would forget the entire customer
+    base because we redeployed. Same instinct as the DNS sweep's refusal to delete
+    against a partial live set.
+  - **`unreachable` deletes nothing**, deliberately. It is the state we would most
+    like to clean up and the one where verification has become impossible, because
+    the deleted role is what we would have verified through.
+  - `ListAccounts` (paginated Scan) and `UpdateLifecycle` (UpdateItem, not Put — a
+    Put would clobber a concurrent re-onboard's fresh ExternalId with the stale copy
+    a reaper run happened to read) plus `Offboard` for the explicit human path. No
+    `DeleteItem`: the registry is the audit trail.
+  - 45 tests, mutation-verified — every guard above fails a test when reverted.
+    Not yet wired to the reaper (cross-repo; the IAM grants for `Scan`/`UpdateItem`
+    land with that wiring, so no perms exist without a caller). See spawn#457.
 - **Docs: "Verify a download" section** in the installation guide — how to check a
   manually-downloaded release with keyless cosign (`cosign verify-blob --bundle`
   against the release workflow's OIDC identity) plus the checksum, for the CLIs now

--- a/lambda/portal-phone-home/README.md
+++ b/lambda/portal-phone-home/README.md
@@ -1,0 +1,170 @@
+# portal-phone-home
+
+The spore.host portal's BYOA onboarding registrar, and the home of the
+**account lifecycle state machine**.
+
+Runs in the infra account (966362334030) — the control plane. One DynamoDB table,
+`spore-portal-accounts`, keyed on `accountId`.
+
+## Registration
+
+When a user onboards their AWS account (via the `spawn onboard` CLI wizard or the
+web CloudFormation quick-create), the newly created cross-account role phones home
+here to register `{roleArn, externalId, region}`.
+
+**Security — the SigV4-verified-principal model** (mirrors `dns-updater`,
+spawn#173): the Function URL runs under `AuthType: AWS_IAM`, so every request that
+reaches the handler has already passed SigV4 verification and carries the *verified*
+caller account in `requestContext.authorizer.iam`. We trust that account, never
+anything in the body. The body's `roleArn` must belong to the verified account or
+we reject — so a caller can only ever register a role in its own account. No shared
+secret, no allow-list, no spoofable claims. `validate()` is pure and holds this
+invariant; `TestValidate_SecurityInvariant` covers it with no AWS.
+
+## Account lifecycle (spawn#457)
+
+### The problem
+
+Onboarding was one-way. The registry exposed `PutAccount` and `GetAccount` and
+nothing else, so there was no state in which spore.host could conclude "this
+account is gone" — and everything left behind was therefore permanent.
+
+Most of that residue is harmless. One piece is not: a Route53 A-record under
+`{base36}.spore.host` outlives the instance it named, and the public IP it points
+at returns to the general EC2 pool. Once AWS reassigns that address, the record
+resolves to a stranger's instance. That inverts the usual instinct — the security
+consequence argues for expiring DNS records **sooner**, not keeping them around
+just in case.
+
+Note what we *cannot* expire: `spawn-ttl-reaper-ec2` is created in the
+**customer's** account. We hold only the trust relationship. Only they can delete
+it, and an IAM role with no caller is inert and free, so no cost pressure ever
+forces the issue.
+
+### The signal is already paid for
+
+The reaper assumes every account's role every 10 minutes. That probe already
+distinguishes exactly the states that matter:
+
+- assume **succeeds**, zero managed instances for N days → *dormant but reachable*
+- assume **fails** while other accounts succeed → *the customer uninstalled*
+
+Role deletion is the natural uninstall gesture. No new API, and no customer action
+beyond what they would already do.
+
+### The four states
+
+Each state exists to answer one question: **is it safe to delete this account's
+DNS records?**
+
+| Status | Meaning | DNS expiry eligible |
+|---|---|---|
+| `active` | assume-role works (also: any legacy row with no `status`) | no — in use |
+| `unreachable` | assume-role failed K consecutive runs *while others succeeded* | **no** — see below |
+| `dormant` | assume-role **works**, zero managed instances for N | yes — emptiness proven |
+| `offboarded` | a human said so | yes — intent stated |
+
+`DNSExpiryEligible()` is the single gate. Unknown/future status values return
+false, so a typo can never authorize a deletion.
+
+### Two traps this design refuses to fall into
+
+**1. Correlated failure is indistinguishable from mass uninstall.** The reaper's
+role ARN embeds a CloudFormation-generated physical ID
+(`…TTLReaperFunctionRole-ZJ84YZ2dCPei`). Recreating that stack changes the suffix
+and breaks **every** customer's trust policy simultaneously. So `ApplyProbes`
+**changes nothing when every probe fails** — an observation explainable by our own
+breakage is not evidence about the customer. This is the same instinct as the DNS
+sweep's existing refusal to delete against a partial live set.
+
+The sharp edge is the single-account deployment, where "all probes failed" and
+"this one account failed" are the same observation. The guard resolves it as
+uninformative, by design (`TestApplyProbes_SingleAccountFailureIsUninformative`).
+
+**2. We lose the ability to verify at the exact moment we would act.** "Only the
+role is left, nothing else" needs a *working* assume-role to confirm —
+`DescribeInstances` is how emptiness is established. Once the role is gone that
+check is impossible. Hence `unreachable` deletes nothing: it is simultaneously the
+state we would most like to clean up and the state where we can no longer prove
+anything. Those records surface instead through the reaper's report-only
+[unmanaged-subdomain signal](https://github.com/spore-host/spawn/blob/main/lambda/ttl-reaper/README.md)
+for a human to resolve.
+
+### Policy
+
+`DefaultLifecyclePolicy()` is **K=6** consecutive failed runs (one hour at the
+reaper's `rate(10 minutes)`, long enough to ride out a transient STS blip) and
+**N=30 days** reachable-and-empty (long enough that a researcher between jobs is
+not deprovisioned mid-project). Both are fields on `LifecyclePolicy`.
+
+Other properties worth knowing:
+
+- **`unreachable` stops counting into the reaper's `Errors`.** That field means
+  "investigate this" and is worthless once it holds a permanent expected failure —
+  a forever-failing assume-role trains the operator to ignore the count.
+- **A never-used account is not instantly dormant.** Absent evidence is not
+  evidence of absence, so the N-day clock is seeded from first observation.
+- **Recovery is automatic, revival is not.** A `dormant` or `unreachable` account
+  that runs a spore again returns to `active`. An `offboarded` one never does —
+  that status was a human decision and only a human (a re-onboard) undoes it.
+- **An unparseable timestamp never triggers a transition.** Acting on a value we
+  cannot read is how a healthy account gets deprovisioned by a formatting bug.
+
+### Schema compatibility
+
+Every lifecycle field is `omitempty`, so rows written before this change unmarshal
+to the zero value. `AccountStatus()` maps `""` → `active`. **No backfill migration.**
+Read the status through that method, never off `.Status` directly, or legacy rows
+look like an unknown state.
+
+### Persistence
+
+- `ListAccounts` — paginated Scan. One row per onboarded account (tens, not
+  millions). Paginated anyway because a truncated Scan would look exactly like
+  "these accounts no longer exist", the precise false conclusion this work exists
+  to prevent.
+- `UpdateLifecycle` — `UpdateItem`, writing **only** the lifecycle attributes.
+  Not a Put, in two directions: a Put would clobber a concurrent re-onboard's fresh
+  ExternalId/roleArn with the stale copy a reaper run happened to read, and because
+  UpdateItem upserts, it would also resurrect a row deliberately deleted between
+  the Scan and the write. Empty timestamps are omitted rather than written as `""`,
+  since the dormancy math reads them back.
+- `Offboard` — the explicit human transition.
+- **No `DeleteItem`.** The registry row costs nothing and is the audit trail;
+  offboarding is a status transition, not a deletion.
+
+### Not yet wired
+
+`ApplyProbes` has no caller in production yet — the reaper lives in the `spawn`
+repo and would need to collect `ProbeResult`s per run, plus `dynamodb:Scan` and
+`dynamodb:UpdateItem` on this table in **its** execution role. Those IAM grants
+land with that wiring rather than here, so the policy never carries permissions
+with no caller. Tracked in spawn#457.
+
+## Tests
+
+```bash
+go test ./...
+```
+
+Pure logic (`validate`, `ApplyProbes`, `DNSExpiryEligible`) needs no AWS. The
+persistence tests run against substrate's in-memory DynamoDB
+(`substrate.StartTestServer`), not a real table.
+
+The state machine's guards are mutation-verified: neutering the correlated-failure
+guard, the K threshold, the N threshold, or either `offboarded` exclusion each
+fails a test. One redundancy is documented in place — the never-used-account clock
+seed reaches the same result as the unparseable-timestamp branch, and is kept
+because "never observed" and "observed but unreadable" are different facts that
+happen to share a remedy.
+
+## Build & deploy
+
+```bash
+make build            # linux/arm64 bootstrap + function.zip
+make upload           # → s3://spawn-binaries-us-east-1/portal-phone-home/
+```
+
+Infrastructure is OpenTofu, not the Makefile: `infra/tofu/portal-phone-home/`
+(Function URL, execution role, the DynamoDB table with PITR + a customer-managed
+CMK, and a second CMK for env encryption).

--- a/lambda/portal-phone-home/lifecycle.go
+++ b/lambda/portal-phone-home/lifecycle.go
@@ -1,0 +1,237 @@
+// lifecycle.go — the account deprovisioning state machine (spawn#457).
+//
+// The problem it solves: onboarding was one-way. Nothing ever concluded "this
+// account is gone", so every artifact left behind was permanent — and one of them
+// (a Route53 A-record whose public IP has returned to the EC2 pool) eventually
+// resolves to a stranger's instance. That is the hazard driving the whole design.
+//
+// The signal is free: the reaper already assumes every account's role every 10
+// minutes, and that probe distinguishes exactly the states that matter — the role
+// is gone (the customer uninstalled) versus the role works but the account is
+// empty (dormant but reachable). No new API and no customer action beyond the
+// uninstall gesture they would already make.
+//
+// The whole file is pure: no AWS, no clock, no I/O. The reaper supplies probe
+// results and `now`; this decides. That is deliberate, because the interesting
+// parts are the two refusals — and a refusal is only trustworthy if you can test
+// it exhaustively without mocking a cloud.
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// Lifecycle states. The set is small on purpose: each state has to answer one
+// question — "is it safe to delete this account's DNS records?" — and only two
+// answers are defensible. Yes (we proved the account is empty, or a human said
+// so) and no (we could not prove anything).
+const (
+	// StatusActive — assume-role works. The normal state.
+	StatusActive = "active"
+	// StatusUnreachable — assume-role has failed K consecutive runs WHILE other
+	// accounts succeeded. Almost certainly an uninstall (deleting the role is the
+	// natural uninstall gesture), but not provable, so this state deletes nothing.
+	// Its job is to stop counting the account into the reaper's Errors total —
+	// that field is supposed to mean "investigate this", and it is worthless once
+	// it contains a permanent, expected failure.
+	StatusUnreachable = "unreachable"
+	// StatusDormant — assume-role WORKS and the account has had zero managed
+	// instances for N. The only inferred state where DNS expiry is safe, precisely
+	// because reachability is what lets DescribeInstances prove emptiness.
+	StatusDormant = "dormant"
+	// StatusOffboarded — a human said so. Intent is stated rather than inferred,
+	// so this state may delete records.
+	StatusOffboarded = "offboarded"
+)
+
+// AccountStatus returns the effective status, treating a row written before the
+// lifecycle fields existed ("") as active. Callers must use this rather than
+// reading .Status directly, or every legacy row looks like an unknown state.
+func (a *Account) AccountStatus() string {
+	if a == nil {
+		return ""
+	}
+	if a.Status == "" {
+		return StatusActive
+	}
+	return a.Status
+}
+
+// ProbeResult is one account's outcome from one reaper run: did the assume-role
+// work, and if so, did the account hold any live managed instances.
+type ProbeResult struct {
+	AccountID string
+	// Reachable is whether the assume-role + DescribeInstances succeeded. A false
+	// here is the only evidence of uninstall we ever get, and it is weak evidence.
+	Reachable bool
+	// LiveInstances is how many live managed instances were found. Meaningful only
+	// when Reachable — a zero from an unreachable probe proves nothing, because we
+	// did not look and could not have.
+	LiveInstances int
+}
+
+// LifecyclePolicy is the K/N tuning from spawn#457.
+type LifecyclePolicy struct {
+	// FailuresBeforeUnreachable (K) — consecutive failed runs before an account is
+	// marked unreachable. 6 runs at the default rate(10 minutes) is one hour, long
+	// enough to ride out a transient STS/API blip.
+	FailuresBeforeUnreachable int
+	// DormantAfter (N) — how long an account must be reachable-and-empty before it
+	// is dormant. 30 days, so a researcher between jobs is not deprovisioned
+	// mid-project.
+	DormantAfter time.Duration
+}
+
+// DefaultLifecyclePolicy is K=6 runs (one hour) and N=30 days — the values
+// suggested in spawn#457.
+func DefaultLifecyclePolicy() LifecyclePolicy {
+	return LifecyclePolicy{FailuresBeforeUnreachable: 6, DormantAfter: 30 * 24 * time.Hour}
+}
+
+// ApplyProbes is the state machine: given the current registry rows and this
+// run's probe results, return only the rows whose lifecycle fields changed.
+//
+// THE CENTRAL SAFETY RULE (spawn#457 trap 1): if EVERY probe failed, change
+// nothing. The reaper's own role ARN embeds a CloudFormation-generated physical
+// ID, so recreating the reaper stack changes that suffix and breaks every
+// customer's trust policy simultaneously. A state machine that acted on
+// assume-role failure alone would then mark the entire customer base unreachable
+// because *we* redeployed. This is the same instinct as the DNS sweep's existing
+// refusal to delete against a partial live set: an observation that could be
+// explained by our own breakage is not evidence about the customer.
+//
+// now is a parameter rather than a clock read so tests can drive the N-day
+// transitions without sleeping.
+func ApplyProbes(existing []Account, probes []ProbeResult, now time.Time, pol LifecyclePolicy) []Account {
+	if len(probes) == 0 {
+		return nil
+	}
+	// Correlated-failure guard. Note this tests probes, not existing rows: the
+	// question is whether OUR probing worked at all, and a single-account
+	// deployment whose one probe failed is exactly as uninformative as a
+	// hundred-account one where all hundred failed.
+	anyReachable := false
+	for _, p := range probes {
+		if p.Reachable {
+			anyReachable = true
+			break
+		}
+	}
+	if !anyReachable {
+		return nil
+	}
+
+	byID := make(map[string]Account, len(existing))
+	for _, a := range existing {
+		byID[a.AccountID] = a
+	}
+	stamp := now.UTC().Format(time.RFC3339)
+
+	var changed []Account
+	for _, p := range probes {
+		// An account being probed but absent from the registry is not an error:
+		// REAPER_ROLE_ARNS predates the registry, so early accounts were onboarded
+		// by hand-editing config. Start its lifecycle from what we just observed.
+		acct, known := byID[p.AccountID]
+		if !known {
+			acct = Account{AccountID: p.AccountID}
+		}
+		before := acct
+
+		if !p.Reachable {
+			// Failed, and at least one other account succeeded — so this is about
+			// this account, not about us.
+			acct.ConsecutiveFailures++
+			acct.LastErrorAt = stamp
+			// Offboarded is excluded alongside unreachable itself: an offboarded
+			// account's role being gone is the EXPECTED outcome of deprovisioning, so
+			// relabeling it "unreachable" would overwrite a stated human decision
+			// with a weaker inferred one — and would strip the DNS-expiry eligibility
+			// that offboarding deliberately granted.
+			if s := acct.AccountStatus(); acct.ConsecutiveFailures >= pol.FailuresBeforeUnreachable &&
+				s != StatusUnreachable && s != StatusOffboarded {
+				setStatus(&acct, StatusUnreachable, stamp, fmt.Sprintf(
+					"assume-role failed %d consecutive runs while other accounts succeeded",
+					acct.ConsecutiveFailures))
+			}
+			if acct != before {
+				changed = append(changed, acct)
+			}
+			continue
+		}
+
+		// Reachable: a liveness observation regardless of instance count.
+		acct.ConsecutiveFailures = 0
+		acct.LastSeenAt = stamp
+
+		switch {
+		case p.LiveInstances > 0:
+			acct.LastInstanceAt = stamp
+			if s := acct.AccountStatus(); s != StatusActive && s != StatusOffboarded {
+				// Recovery: a dormant or unreachable account that runs a spore again
+				// is active. Never auto-revive an offboarded one — that status was a
+				// human decision, and only a human (a re-onboard) should undo it.
+				setStatus(&acct, StatusActive, stamp, "live managed instance observed")
+			}
+
+		case acct.LastInstanceAt == "":
+			// Reachable and empty, but we have never seen an instance here. Seed the
+			// clock from this observation rather than treating "no evidence" as
+			// "empty since forever" — otherwise a freshly onboarded account is
+			// instantly dormant on the strength of nothing at all.
+			//
+			// Behaviorally redundant, and deliberately kept: the default branch below
+			// reaches the same result, because time.Parse of "" errors and lands in its
+			// re-stamp path. Mutation testing confirms no test can tell the two apart.
+			// It stays because "never observed" and "observed but unreadable" are
+			// different facts that happen to share a remedy, and leaning on the empty
+			// string failing to parse would make this correct only by accident.
+			acct.LastInstanceAt = stamp
+
+		default:
+			last, err := time.Parse(time.RFC3339, acct.LastInstanceAt)
+			if err != nil {
+				// Unparseable timestamp: re-stamp rather than guess. Refusing to act
+				// on a value we cannot read is the same instinct as the rest of this file.
+				acct.LastInstanceAt = stamp
+				break
+			}
+			if now.UTC().Sub(last) >= pol.DormantAfter {
+				if s := acct.AccountStatus(); s != StatusDormant && s != StatusOffboarded {
+					setStatus(&acct, StatusDormant, stamp, fmt.Sprintf(
+						"reachable with zero managed instances since %s", acct.LastInstanceAt))
+				}
+			}
+		}
+
+		if acct != before {
+			changed = append(changed, acct)
+		}
+	}
+	return changed
+}
+
+func setStatus(a *Account, status, stamp, reason string) {
+	a.Status = status
+	a.StatusReason = reason
+	a.StatusChangedAt = stamp
+}
+
+// DNSExpiryEligible reports whether it is safe to delete this account's Route53
+// records — the one question the state machine exists to answer.
+//
+// Only dormant (emptiness PROVEN via a working DescribeInstances) and offboarded
+// (a human stated intent) qualify. Unreachable deliberately does not, and that is
+// spawn#457's trap 2: the moment we would most like to clean up is the moment we
+// have lost the ability to verify, because the deleted role is what we would have
+// verified through. Records under an unreachable account stay, and surface via the
+// reaper's report-only unmanaged-subdomain signal for a human to resolve.
+func DNSExpiryEligible(a *Account) bool {
+	switch a.AccountStatus() {
+	case StatusDormant, StatusOffboarded:
+		return true
+	default:
+		return false
+	}
+}

--- a/lambda/portal-phone-home/lifecycle_test.go
+++ b/lambda/portal-phone-home/lifecycle_test.go
@@ -1,0 +1,586 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Fixed clock — ApplyProbes takes `now` as a parameter precisely so the N-day
+// transitions are testable without sleeping.
+var t0 = time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+func rfc(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+
+// find returns the changed row for an account, or nil if ApplyProbes decided
+// nothing about it.
+func find(changed []Account, id string) *Account {
+	for i := range changed {
+		if changed[i].AccountID == id {
+			return &changed[i]
+		}
+	}
+	return nil
+}
+
+// THE central safety property (spawn#457 trap 1): when every probe fails, decide
+// nothing. Recreating the reaper's CloudFormation stack changes its role ARN
+// suffix and breaks every customer's trust policy at once — a state machine that
+// acted on assume-role failure alone would forget the entire customer base
+// because we redeployed.
+func TestApplyProbes_AllUnreachableChangesNothing(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	existing := []Account{
+		{AccountID: "111111111111", Status: StatusActive},
+		{AccountID: "222222222222", Status: StatusActive},
+		{AccountID: "333333333333", Status: StatusActive},
+	}
+	probes := []ProbeResult{
+		{AccountID: "111111111111", Reachable: false},
+		{AccountID: "222222222222", Reachable: false},
+		{AccountID: "333333333333", Reachable: false},
+	}
+	// Even sustained across many runs — K is irrelevant when the evidence is
+	// explainable by our own breakage.
+	for run := 0; run < 20; run++ {
+		if changed := ApplyProbes(existing, probes, t0.Add(time.Duration(run)*10*time.Minute), pol); len(changed) != 0 {
+			t.Fatalf("run %d: total-failure round changed %d row(s); must change none: %+v", run, len(changed), changed)
+		}
+	}
+}
+
+// The single-account deployment is the sharp edge of that guard: with one probe,
+// "all probes failed" and "this one account failed" are the same observation, and
+// the guard must resolve it as uninformative.
+func TestApplyProbes_SingleAccountFailureIsUninformative(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	existing := []Account{{AccountID: "111111111111", Status: StatusActive}}
+	probes := []ProbeResult{{AccountID: "111111111111", Reachable: false}}
+	if changed := ApplyProbes(existing, probes, t0, pol); len(changed) != 0 {
+		t.Errorf("sole-account failure changed %d row(s); cannot distinguish customer uninstall from our own breakage: %+v", len(changed), changed)
+	}
+}
+
+// A failure alongside at least one success IS about that account — but only after
+// K consecutive runs. Below K it accrues a counter and nothing else.
+func TestApplyProbes_UnreachableRequiresKConsecutive(t *testing.T) {
+	pol := DefaultLifecyclePolicy() // K=6
+	const dead = "111111111111"
+	const alive = "222222222222"
+
+	acct := Account{AccountID: dead, Status: StatusActive}
+	for run := 1; run <= pol.FailuresBeforeUnreachable; run++ {
+		probes := []ProbeResult{
+			{AccountID: dead, Reachable: false},
+			{AccountID: alive, Reachable: true, LiveInstances: 1},
+		}
+		changed := ApplyProbes([]Account{acct, {AccountID: alive, Status: StatusActive}},
+			probes, t0.Add(time.Duration(run)*10*time.Minute), pol)
+		got := find(changed, dead)
+		if got == nil {
+			t.Fatalf("run %d: expected a change row for the failing account", run)
+		}
+		if got.ConsecutiveFailures != run {
+			t.Errorf("run %d: consecutiveFailures = %d, want %d", run, got.ConsecutiveFailures, run)
+		}
+		if run < pol.FailuresBeforeUnreachable {
+			if got.AccountStatus() != StatusActive {
+				t.Errorf("run %d: status = %q, want still active below K=%d", run, got.AccountStatus(), pol.FailuresBeforeUnreachable)
+			}
+			if got.StatusChangedAt != "" {
+				t.Errorf("run %d: StatusChangedAt set without a transition", run)
+			}
+		} else {
+			if got.AccountStatus() != StatusUnreachable {
+				t.Errorf("run %d (== K): status = %q, want %q", run, got.AccountStatus(), StatusUnreachable)
+			}
+			if got.StatusReason == "" || got.StatusChangedAt == "" {
+				t.Errorf("run %d: transition must record reason+changedAt, got %+v", run, got)
+			}
+		}
+		acct = *got // carry the durable counter into the next run
+	}
+}
+
+// One success resets the counter — K means *consecutive*, not cumulative.
+func TestApplyProbes_SuccessResetsFailureCounter(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	const id = "111111111111"
+	existing := []Account{{AccountID: id, Status: StatusActive, ConsecutiveFailures: 5}}
+	probes := []ProbeResult{{AccountID: id, Reachable: true, LiveInstances: 0}}
+
+	changed := ApplyProbes(existing, probes, t0, pol)
+	got := find(changed, id)
+	if got == nil {
+		t.Fatal("expected a change row (counter reset + lastSeenAt stamp)")
+	}
+	if got.ConsecutiveFailures != 0 {
+		t.Errorf("consecutiveFailures = %d, want 0 after a successful probe", got.ConsecutiveFailures)
+	}
+	if got.LastSeenAt != rfc(t0) {
+		t.Errorf("lastSeenAt = %q, want %q", got.LastSeenAt, rfc(t0))
+	}
+	if got.AccountStatus() != StatusActive {
+		t.Errorf("status = %q, want active", got.AccountStatus())
+	}
+}
+
+// Dormancy: reachable AND empty for N. The transition needs a working probe,
+// which is what makes emptiness provable rather than assumed.
+func TestApplyProbes_DormantAfterN(t *testing.T) {
+	pol := DefaultLifecyclePolicy() // N=30d
+	const id = "111111111111"
+
+	tests := []struct {
+		name       string
+		emptySince time.Duration // how long ago the last instance was seen
+		want       string
+	}{
+		{"one day empty is not dormant", 24 * time.Hour, StatusActive},
+		{"29 days empty is not dormant", 29 * 24 * time.Hour, StatusActive},
+		{"exactly N is dormant", 30 * 24 * time.Hour, StatusDormant},
+		{"well past N is dormant", 90 * 24 * time.Hour, StatusDormant},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			existing := []Account{{
+				AccountID:      id,
+				Status:         StatusActive,
+				LastInstanceAt: rfc(t0.Add(-tc.emptySince)),
+			}}
+			probes := []ProbeResult{{AccountID: id, Reachable: true, LiveInstances: 0}}
+			changed := ApplyProbes(existing, probes, t0, pol)
+			got := find(changed, id)
+			if got == nil {
+				// No change row means no transition; only valid when we expected none.
+				if tc.want != StatusActive {
+					t.Fatalf("expected a transition to %q, got no change", tc.want)
+				}
+				return
+			}
+			if got.AccountStatus() != tc.want {
+				t.Errorf("status = %q, want %q", got.AccountStatus(), tc.want)
+			}
+		})
+	}
+}
+
+// A never-used account must not be instantly dormant: absent evidence is not
+// evidence of absence, so the N-day clock starts at first observation.
+func TestApplyProbes_NeverUsedAccountSeedsClockNotDormant(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	const id = "111111111111"
+	existing := []Account{{AccountID: id, Status: StatusActive}} // no LastInstanceAt
+	probes := []ProbeResult{{AccountID: id, Reachable: true, LiveInstances: 0}}
+
+	changed := ApplyProbes(existing, probes, t0, pol)
+	got := find(changed, id)
+	if got == nil {
+		t.Fatal("expected a change row seeding lastInstanceAt")
+	}
+	if got.AccountStatus() != StatusActive {
+		t.Errorf("status = %q, want active — a freshly onboarded account must not be dormant on no evidence", got.AccountStatus())
+	}
+	if got.LastInstanceAt != rfc(t0) {
+		t.Errorf("lastInstanceAt = %q, want the observation time %q", got.LastInstanceAt, rfc(t0))
+	}
+	// And it does become dormant N later, from that seeded clock.
+	later := ApplyProbes([]Account{*got}, probes, t0.Add(pol.DormantAfter), pol)
+	if g := find(later, id); g == nil || g.AccountStatus() != StatusDormant {
+		t.Errorf("after N from the seeded clock, want dormant; got %+v", g)
+	}
+}
+
+// Recovery: a dormant or unreachable account that runs a spore again is active.
+func TestApplyProbes_RecoveryToActive(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	for _, from := range []string{StatusDormant, StatusUnreachable} {
+		t.Run(from, func(t *testing.T) {
+			const id = "111111111111"
+			existing := []Account{{AccountID: id, Status: from, ConsecutiveFailures: 9}}
+			probes := []ProbeResult{{AccountID: id, Reachable: true, LiveInstances: 2}}
+			got := find(ApplyProbes(existing, probes, t0, pol), id)
+			if got == nil {
+				t.Fatal("expected a recovery change row")
+			}
+			if got.AccountStatus() != StatusActive {
+				t.Errorf("status = %q, want active after observing a live instance", got.AccountStatus())
+			}
+			if got.ConsecutiveFailures != 0 {
+				t.Errorf("consecutiveFailures = %d, want 0", got.ConsecutiveFailures)
+			}
+			if got.LastInstanceAt != rfc(t0) {
+				t.Errorf("lastInstanceAt = %q, want %q", got.LastInstanceAt, rfc(t0))
+			}
+		})
+	}
+}
+
+// Offboarded is a human decision; no inferred transition may overwrite it.
+// Otherwise a deliberately deprovisioned account silently returns to active the
+// next time a leftover instance is spotted.
+func TestApplyProbes_OffboardedIsNeverAutoRevived(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	const id = "111111111111"
+
+	cases := []struct {
+		name  string
+		probe ProbeResult
+		other ProbeResult
+	}{
+		{"live instance does not revive", ProbeResult{AccountID: id, Reachable: true, LiveInstances: 3}, ProbeResult{AccountID: "999999999999", Reachable: true}},
+		{"empty+reachable does not re-dormant", ProbeResult{AccountID: id, Reachable: true, LiveInstances: 0}, ProbeResult{AccountID: "999999999999", Reachable: true}},
+		{"failure does not mark unreachable", ProbeResult{AccountID: id, Reachable: false}, ProbeResult{AccountID: "999999999999", Reachable: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			existing := []Account{{
+				AccountID:      id,
+				Status:         StatusOffboarded,
+				LastInstanceAt: rfc(t0.Add(-365 * 24 * time.Hour)), // long past N
+			}}
+			// K failures already banked, so the unreachable branch would fire but for
+			// the offboarded guard.
+			existing[0].ConsecutiveFailures = pol.FailuresBeforeUnreachable
+			changed := ApplyProbes(existing, []ProbeResult{tc.probe, tc.other}, t0, pol)
+			if got := find(changed, id); got != nil && got.AccountStatus() != StatusOffboarded {
+				t.Errorf("status = %q, want %q to survive — offboarding is a stated human decision", got.AccountStatus(), StatusOffboarded)
+			}
+		})
+	}
+}
+
+// An account probed but absent from the registry starts its lifecycle from the
+// observation: REAPER_ROLE_ARNS predates the registry, so accounts exist in
+// config that were never phone-home registered.
+func TestApplyProbes_UnknownAccountGetsSeededRow(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	const id = "444444444444"
+	changed := ApplyProbes(nil, []ProbeResult{{AccountID: id, Reachable: true, LiveInstances: 1}}, t0, pol)
+	got := find(changed, id)
+	if got == nil {
+		t.Fatal("expected a seeded row for an account absent from the registry")
+	}
+	if got.AccountID != id || got.LastSeenAt != rfc(t0) {
+		t.Errorf("seeded row = %+v, want accountId %q and lastSeenAt %q", got, id, rfc(t0))
+	}
+}
+
+// Only rows that actually changed come back — the reaper writes one UpdateItem per
+// returned row, so a no-op round must not generate traffic. A reachable account
+// with an instance still updates lastSeenAt/lastInstanceAt, so the genuinely
+// unchanged case is an account absent from this run's probes.
+func TestApplyProbes_UnprobedAccountsAreNotReturned(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	existing := []Account{
+		{AccountID: "111111111111", Status: StatusActive},
+		{AccountID: "222222222222", Status: StatusActive},
+	}
+	changed := ApplyProbes(existing, []ProbeResult{{AccountID: "111111111111", Reachable: true, LiveInstances: 1}}, t0, pol)
+	if find(changed, "222222222222") != nil {
+		t.Error("an account not probed this run must not be written")
+	}
+	if find(changed, "111111111111") == nil {
+		t.Error("the probed account should be written (lastSeenAt advanced)")
+	}
+}
+
+// An unparseable lastInstanceAt must not be guessed at — re-stamp, don't
+// transition. Acting on a value we can't read is how a healthy account gets
+// deprovisioned by a formatting bug.
+func TestApplyProbes_UnparseableTimestampDoesNotTransition(t *testing.T) {
+	pol := DefaultLifecyclePolicy()
+	const id = "111111111111"
+	existing := []Account{{AccountID: id, Status: StatusActive, LastInstanceAt: "not-a-timestamp"}}
+	got := find(ApplyProbes(existing, []ProbeResult{{AccountID: id, Reachable: true}}, t0, pol), id)
+	if got == nil {
+		t.Fatal("expected a re-stamp change row")
+	}
+	if got.AccountStatus() != StatusActive {
+		t.Errorf("status = %q, want active — never transition on an unreadable timestamp", got.AccountStatus())
+	}
+	if got.LastInstanceAt != rfc(t0) {
+		t.Errorf("lastInstanceAt = %q, want re-stamped to %q", got.LastInstanceAt, rfc(t0))
+	}
+}
+
+func TestApplyProbes_NoProbes(t *testing.T) {
+	if changed := ApplyProbes([]Account{{AccountID: "111111111111"}}, nil, t0, DefaultLifecyclePolicy()); changed != nil {
+		t.Errorf("no probes must decide nothing, got %+v", changed)
+	}
+}
+
+// A legacy row (written before the lifecycle fields existed) reads as active, so
+// no backfill migration is needed.
+func TestAccountStatus_LegacyRowIsActive(t *testing.T) {
+	legacy := &Account{AccountID: "111111111111", RoleArn: "arn:aws:iam::111111111111:role/x"}
+	if legacy.AccountStatus() != StatusActive {
+		t.Errorf("legacy row status = %q, want %q", legacy.AccountStatus(), StatusActive)
+	}
+	if DNSExpiryEligible(legacy) {
+		t.Error("a legacy row must NOT be DNS-expiry eligible")
+	}
+}
+
+// The payoff question: which states permit deleting an account's DNS records.
+// Unreachable is the interesting exclusion (spawn#457 trap 2) — it is the state
+// we would most want to clean up, and the one where we can no longer verify
+// anything, because the deleted role is what we would have verified through.
+func TestDNSExpiryEligible(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+		why    string
+	}{
+		{StatusActive, false, "in use"},
+		{StatusUnreachable, false, "emptiness unprovable once the role is gone"},
+		{StatusDormant, true, "emptiness proven via a working DescribeInstances"},
+		{StatusOffboarded, true, "human stated intent"},
+		{"", false, "legacy row reads as active"},
+		{"some-future-status", false, "unknown states must not authorize deletion"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.status, func(t *testing.T) {
+			if got := DNSExpiryEligible(&Account{AccountID: "111111111111", Status: tc.status}); got != tc.want {
+				t.Errorf("DNSExpiryEligible(%q) = %v, want %v (%s)", tc.status, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// ── Persistence ──────────────────────────────────────────────────────────────
+
+// UpdateLifecycle must not disturb the registration fields. A PutAccount here
+// would clobber a concurrent re-onboard's fresh ExternalId with the stale copy
+// this run happened to read.
+func TestUpdateLifecycle_PreservesRegistration(t *testing.T) {
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	orig := &Account{
+		AccountID:    verified,
+		RoleArn:      "arn:aws:iam::123456789012:role/spore-portal-onboard",
+		ExternalId:   "original-external-id",
+		Region:       "us-west-2",
+		RegisteredBy: "arn:aws:iam::123456789012:user/alice",
+	}
+	if err := r.PutAccount(ctx, orig); err != nil {
+		t.Fatalf("PutAccount: %v", err)
+	}
+
+	if err := r.UpdateLifecycle(ctx, &Account{
+		AccountID:       verified,
+		Status:          StatusDormant,
+		LastSeenAt:      rfc(t0),
+		LastInstanceAt:  rfc(t0.Add(-40 * 24 * time.Hour)),
+		StatusReason:    "reachable with zero managed instances",
+		StatusChangedAt: rfc(t0),
+	}); err != nil {
+		t.Fatalf("UpdateLifecycle: %v", err)
+	}
+
+	got, err := r.GetAccount(ctx, verified)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if got.RoleArn != orig.RoleArn || got.ExternalId != orig.ExternalId ||
+		got.Region != orig.Region || got.RegisteredBy != orig.RegisteredBy {
+		t.Errorf("registration was disturbed: got %+v, want the fields of %+v", got, orig)
+	}
+	if got.RegisteredAt == "" {
+		t.Error("registeredAt was cleared by the lifecycle update")
+	}
+	if got.AccountStatus() != StatusDormant {
+		t.Errorf("status = %q, want %q", got.AccountStatus(), StatusDormant)
+	}
+	if got.StatusReason == "" || got.StatusChangedAt == "" || got.LastSeenAt == "" || got.LastInstanceAt == "" {
+		t.Errorf("lifecycle fields not persisted: %+v", got)
+	}
+}
+
+// Empty timestamps must be omitted from the update, not written as "" — an empty
+// string would replace a real prior value with one that parses as neither a time
+// nor "absent", and the dormancy math reads these back.
+func TestUpdateLifecycle_DoesNotBlankExistingTimestamps(t *testing.T) {
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	if err := r.PutAccount(ctx, &Account{
+		AccountID: verified, RoleArn: "arn:aws:iam::123456789012:role/x",
+		ExternalId: "e", Region: "us-east-1",
+	}); err != nil {
+		t.Fatalf("PutAccount: %v", err)
+	}
+	if err := r.UpdateLifecycle(ctx, &Account{
+		AccountID: verified, Status: StatusActive, LastInstanceAt: rfc(t0),
+	}); err != nil {
+		t.Fatalf("seed lastInstanceAt: %v", err)
+	}
+	// A later round with no LastInstanceAt (e.g. an unreachable probe) must leave
+	// the seeded value alone.
+	if err := r.UpdateLifecycle(ctx, &Account{
+		AccountID: verified, Status: StatusActive, ConsecutiveFailures: 2, LastErrorAt: rfc(t0),
+	}); err != nil {
+		t.Fatalf("UpdateLifecycle: %v", err)
+	}
+
+	got, err := r.GetAccount(ctx, verified)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if got.LastInstanceAt != rfc(t0) {
+		t.Errorf("lastInstanceAt = %q, want the preserved %q", got.LastInstanceAt, rfc(t0))
+	}
+	if got.ConsecutiveFailures != 2 {
+		t.Errorf("consecutiveFailures = %d, want 2", got.ConsecutiveFailures)
+	}
+}
+
+func TestOffboard(t *testing.T) {
+	r := newTestRegistry(t)
+	ctx := context.Background()
+	if err := r.PutAccount(ctx, &Account{
+		AccountID: verified, RoleArn: "arn:aws:iam::123456789012:role/x",
+		ExternalId: "e", Region: "us-east-1",
+	}); err != nil {
+		t.Fatalf("PutAccount: %v", err)
+	}
+	if err := r.Offboard(ctx, verified, "arn:aws:iam::123456789012:user/operator", t0); err != nil {
+		t.Fatalf("Offboard: %v", err)
+	}
+	got, err := r.GetAccount(ctx, verified)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if got.AccountStatus() != StatusOffboarded {
+		t.Errorf("status = %q, want %q", got.AccountStatus(), StatusOffboarded)
+	}
+	if !DNSExpiryEligible(got) {
+		t.Error("an offboarded account should be DNS-expiry eligible (stated intent)")
+	}
+	// Offboarding must not destroy the audit trail.
+	if got.RoleArn == "" || got.RegisteredAt == "" {
+		t.Errorf("offboard erased the registration/audit trail: %+v", got)
+	}
+}
+
+func TestOffboard_RequiresAccountID(t *testing.T) {
+	r := newTestRegistry(t)
+	if err := r.Offboard(context.Background(), "", "operator", t0); err == nil {
+		t.Error("expected an error for an empty accountId")
+	}
+}
+
+func TestUpdateLifecycle_RequiresAccountID(t *testing.T) {
+	r := newTestRegistry(t)
+	if err := r.UpdateLifecycle(context.Background(), &Account{Status: StatusActive}); err == nil {
+		t.Error("expected an error for an empty accountId")
+	}
+	if err := r.UpdateLifecycle(context.Background(), nil); err == nil {
+		t.Error("expected an error for a nil account")
+	}
+}
+
+// ListAccounts feeds ApplyProbes; a truncated result would read as "these
+// accounts no longer exist", the exact false conclusion this work avoids.
+func TestListAccounts(t *testing.T) {
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	ids := []string{"111111111111", "222222222222", "333333333333"}
+	for _, id := range ids {
+		if err := r.PutAccount(ctx, &Account{
+			AccountID: id, RoleArn: "arn:aws:iam::" + id + ":role/x",
+			ExternalId: "e", Region: "us-east-1",
+		}); err != nil {
+			t.Fatalf("PutAccount %s: %v", id, err)
+		}
+	}
+	got, err := r.ListAccounts(ctx)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	if len(got) != len(ids) {
+		t.Fatalf("ListAccounts returned %d rows, want %d", len(got), len(ids))
+	}
+	seen := map[string]bool{}
+	for _, a := range got {
+		seen[a.AccountID] = true
+		if a.RoleArn == "" {
+			t.Errorf("row %s came back without its roleArn", a.AccountID)
+		}
+	}
+	for _, id := range ids {
+		if !seen[id] {
+			t.Errorf("account %s missing from ListAccounts", id)
+		}
+	}
+}
+
+func TestListAccounts_Empty(t *testing.T) {
+	r := newTestRegistry(t)
+	got, err := r.ListAccounts(context.Background())
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("want no rows, got %d", len(got))
+	}
+}
+
+// End-to-end over the pure machine plus persistence: an account goes quiet, rides
+// out K-1 failures, is marked unreachable at K, and is still NOT DNS-eligible.
+func TestLifecycle_QuietAccountEndToEnd(t *testing.T) {
+	r := newTestRegistry(t)
+	ctx := context.Background()
+	pol := DefaultLifecyclePolicy()
+	const dead = "111111111111"
+	const alive = "222222222222"
+
+	for _, id := range []string{dead, alive} {
+		if err := r.PutAccount(ctx, &Account{
+			AccountID: id, RoleArn: "arn:aws:iam::" + id + ":role/x",
+			ExternalId: "e", Region: "us-east-1",
+		}); err != nil {
+			t.Fatalf("PutAccount %s: %v", id, err)
+		}
+	}
+
+	for run := 1; run <= pol.FailuresBeforeUnreachable; run++ {
+		rows, err := r.ListAccounts(ctx)
+		if err != nil {
+			t.Fatalf("run %d ListAccounts: %v", run, err)
+		}
+		changed := ApplyProbes(rows, []ProbeResult{
+			{AccountID: dead, Reachable: false},
+			{AccountID: alive, Reachable: true, LiveInstances: 1},
+		}, t0.Add(time.Duration(run)*10*time.Minute), pol)
+		for i := range changed {
+			if err := r.UpdateLifecycle(ctx, &changed[i]); err != nil {
+				t.Fatalf("run %d UpdateLifecycle %s: %v", run, changed[i].AccountID, err)
+			}
+		}
+	}
+
+	got, err := r.GetAccount(ctx, dead)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if got.AccountStatus() != StatusUnreachable {
+		t.Errorf("status = %q, want %q after K=%d failures", got.AccountStatus(), StatusUnreachable, pol.FailuresBeforeUnreachable)
+	}
+	if got.ConsecutiveFailures != pol.FailuresBeforeUnreachable {
+		t.Errorf("consecutiveFailures = %d, want %d (the counter must survive across runs)", got.ConsecutiveFailures, pol.FailuresBeforeUnreachable)
+	}
+	if DNSExpiryEligible(got) {
+		t.Error("an unreachable account must NOT be DNS-expiry eligible — emptiness is unprovable once the role is gone")
+	}
+	// The still-live account stays active and keeps its registration.
+	liveRow, err := r.GetAccount(ctx, alive)
+	if err != nil {
+		t.Fatalf("GetAccount alive: %v", err)
+	}
+	if liveRow.AccountStatus() != StatusActive || liveRow.ExternalId != "e" {
+		t.Errorf("live account row = %+v, want active with its registration intact", liveRow)
+	}
+}

--- a/lambda/portal-phone-home/registry.go
+++ b/lambda/portal-phone-home/registry.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,6 +25,39 @@ type Account struct {
 	Region       string `json:"region" dynamodbav:"region"`
 	RegisteredBy string `json:"registeredBy" dynamodbav:"registeredBy"`
 	RegisteredAt string `json:"registeredAt" dynamodbav:"registeredAt"`
+
+	// ── Lifecycle (spawn#457) ────────────────────────────────────────────────
+	// Onboarding used to be one-way — PutAccount/GetAccount and nothing else — so
+	// there was no state in which spore.host could ever conclude "this account is
+	// gone". These fields make the registry the durable home of that judgment.
+	// See lifecycle.go for the state machine that owns them.
+	//
+	// They are deliberately NOT set by the phone-home handler: registration only
+	// ever means "reachable right now", and the reaper is what actually probes
+	// every account every 10 minutes. omitempty throughout, so a row written
+	// before this change unmarshals to the zero value and reads as StatusActive
+	// via AccountStatus() — no backfill migration needed.
+
+	// Status is the lifecycle state: "" (legacy, treated as active), or one of the
+	// Status* constants in lifecycle.go.
+	Status string `json:"status,omitempty" dynamodbav:"status,omitempty"`
+	// LastSeenAt is the last time an assume-role into this account SUCCEEDED
+	// (RFC3339) — the liveness signal. Distinct from RegisteredAt, which never
+	// changes after onboarding.
+	LastSeenAt string `json:"lastSeenAt,omitempty" dynamodbav:"lastSeenAt,omitempty"`
+	// LastErrorAt/ConsecutiveFailures track the unreachable path. The counter is
+	// what makes "K consecutive runs" durable: a stateless Lambda cannot otherwise
+	// tell one blip from a sustained pattern.
+	LastErrorAt         string `json:"lastErrorAt,omitempty" dynamodbav:"lastErrorAt,omitempty"`
+	ConsecutiveFailures int    `json:"consecutiveFailures,omitempty" dynamodbav:"consecutiveFailures,omitempty"`
+	// LastInstanceAt is the last time this account had a live managed instance.
+	// Dormancy is "reachable AND empty for N days", which is only measurable
+	// against a timestamp of last non-emptiness.
+	LastInstanceAt string `json:"lastInstanceAt,omitempty" dynamodbav:"lastInstanceAt,omitempty"`
+	// StatusReason is the human-readable why, for whoever reads the row.
+	StatusReason string `json:"statusReason,omitempty" dynamodbav:"statusReason,omitempty"`
+	// StatusChangedAt is when Status last transitioned (RFC3339).
+	StatusChangedAt string `json:"statusChangedAt,omitempty" dynamodbav:"statusChangedAt,omitempty"`
 }
 
 type Registry struct {
@@ -79,4 +115,106 @@ func (r *Registry) GetAccount(ctx context.Context, accountID string) (*Account, 
 		return nil, fmt.Errorf("unmarshal account: %w", err)
 	}
 	return &acct, nil
+}
+
+// ListAccounts returns every registration. The reaper needs the whole set per run
+// to feed ApplyProbes, and the table holds one row per onboarded account — tens,
+// not millions — so a Scan is the right shape here. Paginated anyway: a truncated
+// Scan would silently look like "these accounts no longer exist", the exact class
+// of false conclusion this lifecycle work exists to avoid.
+func (r *Registry) ListAccounts(ctx context.Context) ([]Account, error) {
+	var out []Account
+	var start map[string]dynamodbtypes.AttributeValue
+	for {
+		page, err := r.client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:         aws.String(r.accountTable),
+			ExclusiveStartKey: start,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scan accounts: %w", err)
+		}
+		var batch []Account
+		if err := attributevalue.UnmarshalListOfMaps(page.Items, &batch); err != nil {
+			return nil, fmt.Errorf("unmarshal accounts: %w", err)
+		}
+		out = append(out, batch...)
+		if page.LastEvaluatedKey == nil || len(page.LastEvaluatedKey) == 0 {
+			return out, nil
+		}
+		start = page.LastEvaluatedKey
+	}
+}
+
+// UpdateLifecycle persists ONLY the lifecycle fields (spawn#457), leaving the
+// registration — roleArn, externalId, region, registeredBy/At — untouched.
+//
+// An UpdateItem rather than PutAccount, and that distinction is load-bearing in
+// two directions. A Put would clobber a concurrent re-onboard's fresh
+// ExternalId/roleArn with the copy this reaper run happened to read; and because
+// UpdateItem upserts, a Put would also resurrect a row for an account that was
+// deliberately deleted between the Scan and the write. Only the fields the state
+// machine owns are written.
+//
+// "status" is a DynamoDB reserved word, hence the #s alias.
+func (r *Registry) UpdateLifecycle(ctx context.Context, acct *Account) error {
+	if acct == nil || acct.AccountID == "" {
+		return fmt.Errorf("UpdateLifecycle: accountId is required")
+	}
+	names := map[string]string{"#s": "status"}
+	values := map[string]dynamodbtypes.AttributeValue{
+		":s":  &dynamodbtypes.AttributeValueMemberS{Value: acct.AccountStatus()},
+		":cf": &dynamodbtypes.AttributeValueMemberN{Value: strconv.Itoa(acct.ConsecutiveFailures)},
+	}
+	set := []string{"#s = :s", "consecutiveFailures = :cf"}
+
+	// The timestamps are set only when non-empty: writing an empty string would
+	// replace a real prior value with one that parses as neither a time nor
+	// "absent", and the dormancy math reads these back.
+	for alias, pair := range map[string]struct{ attr, val string }{
+		":ls":  {"lastSeenAt", acct.LastSeenAt},
+		":le":  {"lastErrorAt", acct.LastErrorAt},
+		":li":  {"lastInstanceAt", acct.LastInstanceAt},
+		":sr":  {"statusReason", acct.StatusReason},
+		":sca": {"statusChangedAt", acct.StatusChangedAt},
+	} {
+		if pair.val == "" {
+			continue
+		}
+		values[alias] = &dynamodbtypes.AttributeValueMemberS{Value: pair.val}
+		set = append(set, pair.attr+" = "+alias)
+	}
+	// Deterministic expression order — map iteration is randomized, and a stable
+	// string keeps logs and test assertions readable.
+	sort.Strings(set)
+
+	_, err := r.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(r.accountTable),
+		Key: map[string]dynamodbtypes.AttributeValue{
+			"accountId": &dynamodbtypes.AttributeValueMemberS{Value: acct.AccountID},
+		},
+		UpdateExpression:          aws.String("SET " + strings.Join(set, ", ")),
+		ExpressionAttributeNames:  names,
+		ExpressionAttributeValues: values,
+	})
+	if err != nil {
+		return fmt.Errorf("update lifecycle for %s: %w", acct.AccountID, err)
+	}
+	return nil
+}
+
+// Offboard marks an account offboarded — the explicit, human-initiated
+// deprovision. Unlike every other transition this one is stated rather than
+// inferred, which is exactly why it is the only path (besides proven dormancy)
+// that makes an account's DNS records eligible for deletion.
+func (r *Registry) Offboard(ctx context.Context, accountID, by string, now time.Time) error {
+	if accountID == "" {
+		return fmt.Errorf("Offboard: accountId is required")
+	}
+	stamp := now.UTC().Format(time.RFC3339)
+	return r.UpdateLifecycle(ctx, &Account{
+		AccountID:       accountID,
+		Status:          StatusOffboarded,
+		StatusReason:    "offboarded by " + by,
+		StatusChangedAt: stamp,
+	})
 }


### PR DESCRIPTION
Implements the second checkbox of spore-host/spawn#457 — registry lifecycle fields plus the K/N dormancy state machine. The first checkbox (the report-only orphan-subdomain signal) shipped as spawn#458.

## Why

Onboarding was one-way. `registry.go` exposed `PutAccount` and `GetAccount` and nothing else, so there was no state in which spore.host could conclude "this account is gone" — and everything left behind was therefore permanent.

Most of that residue is harmless. One piece is not: a Route53 A-record under `{base36}.spore.host` outlives the instance it named, and the public IP it points at returns to the general EC2 pool. Once AWS reassigns that address, the record resolves to a stranger's instance. That inverts the usual instinct — the security consequence argues for expiring DNS records **sooner**, not keeping them around just in case.

Note what we *cannot* expire: `spawn-ttl-reaper-ec2` is created in the **customer's** account and we hold only the trust relationship. Only they can delete it, and an inert IAM role is free, so no cost pressure ever forces the issue.

## The signal is already paid for

The reaper assumes every account's role every 10 minutes. That probe already distinguishes exactly the states that matter — assume succeeds with zero instances for N days (*dormant but reachable*) versus assume fails while other accounts succeed (*the customer uninstalled*; deleting the role is the natural uninstall gesture). No new API, and no customer action beyond what they would already do.

## The four states

Each exists to answer one question: **is it safe to delete this account's DNS records?**

| Status | Meaning | DNS expiry eligible |
|---|---|---|
| `active` | assume-role works (also any legacy row with no `status`) | no — in use |
| `unreachable` | failed K consecutive runs *while others succeeded* | **no** — see trap 2 |
| `dormant` | assume-role **works**, zero managed instances for N | yes — emptiness proven |
| `offboarded` | a human said so | yes — intent stated |

`DNSExpiryEligible()` is the single gate, and unknown/future status values return false, so a typo can never authorize a deletion.

## The two refusals that are the actual design

**1. Correlated failure is indistinguishable from mass uninstall.** The reaper's role ARN embeds a CloudFormation-generated physical ID (`…TTLReaperFunctionRole-ZJ84YZ2dCPei`), so recreating that stack changes the suffix and breaks **every** customer's trust policy simultaneously. A machine acting on assume-role failure alone would then forget the entire customer base because *we* redeployed. So `ApplyProbes` changes nothing when every probe fails — an observation explainable by our own breakage is not evidence about the customer. Same instinct as the DNS sweep's existing refusal to delete against a partial live set.

The sharp edge is the single-account deployment, where "all probes failed" and "this one account failed" are the same observation. The guard resolves it as uninformative, deliberately.

**2. We lose the ability to verify at the exact moment we would act.** Proving "nothing left but the role" requires a *working* assume-role, because `DescribeInstances` is how emptiness is established. So `unreachable` deletes nothing: it is simultaneously the state we would most like to clean up and the state where we can no longer prove anything. Those records surface instead through the report-only unmanaged-subdomain signal from spawn#458, for a human to resolve.

`ApplyProbes` is pure — no AWS, no clock (`now` is a parameter) — because a refusal is only trustworthy if it can be tested exhaustively without mocking a cloud.

## Policy

`DefaultLifecyclePolicy()` is **K=6** consecutive failed runs (one hour at the reaper's `rate(10 minutes)`, enough to ride out a transient STS blip) and **N=30 days** reachable-and-empty (enough that a researcher between jobs is not deprovisioned mid-project). Both configurable on `LifecyclePolicy`.

Smaller properties worth knowing:
- `unreachable` stops counting into the reaper's `Errors`. That field means "investigate this" and is worthless once it holds a permanent expected failure.
- A never-used account is not instantly dormant — absent evidence is not evidence of absence, so the N-day clock seeds from first observation.
- Recovery is automatic, revival is not. A `dormant`/`unreachable` account that runs a spore again returns to `active`; an `offboarded` one never does.
- An unparseable timestamp never triggers a transition — acting on a value we cannot read is how a healthy account gets deprovisioned by a formatting bug.

## Schema compatibility

Every lifecycle field is `omitempty`, so rows written before this change unmarshal to the zero value, and `AccountStatus()` maps `""` → `active`. **No backfill migration.**

## Persistence

`UpdateItem`, not `Put`, and that matters in two directions: a Put would clobber a concurrent re-onboard's fresh ExternalId/roleArn with the stale copy a reaper run happened to read, and since UpdateItem upserts, it would also resurrect a row deliberately deleted between the Scan and the write. Empty timestamps are omitted rather than written as `""`, since the dormancy math reads them back. No `DeleteItem` — the row costs nothing and is the audit trail.

`ListAccounts` paginates, because a truncated Scan would look exactly like "these accounts no longer exist" — the precise false conclusion this work exists to prevent.

## Verification

45 tests pass (`go test ./...`); `go vet`, `go build`, `gofmt`, and `tofu fmt -check` all clean. Pure logic needs no AWS; persistence runs against substrate's in-memory DynamoDB.

Mutation-verified — each of these fails a test when reverted:

| Mutation | Caught by |
|---|---|
| neuter the correlated-failure guard | `AllUnreachableChangesNothing`, `SingleAccountFailureIsUninformative` |
| K threshold `>=` → `>` | `UnreachableRequiresKConsecutive`, `QuietAccountEndToEnd` |
| N threshold `>=` → `>` | `DormantAfterN/exactly_N`, `NeverUsedAccountSeedsClock` |
| drop `offboarded` guard on the dormant path | `OffboardedIsNeverAutoRevived/empty+reachable` |
| drop `offboarded` guard on the recovery path | `OffboardedIsNeverAutoRevived/live_instance` |
| write blank timestamps instead of omitting | `DoesNotBlankExistingTimestamps` |

Mutation testing also **caught a real bug** while writing this: the unreachable branch guarded against re-entering its own state but not against overwriting `offboarded` — which would have downgraded a stated human decision to a weaker inferred one and stripped the DNS-expiry eligibility that offboarding deliberately granted. Fixed, with the reasoning in the code.

One mutant **survived** and is documented in place rather than papered over: the never-used-account clock seed reaches the same result as the unparseable-timestamp branch (`time.Parse("")` errors and re-stamps identically), so no test can tell them apart. It stays because "never observed" and "observed but unreadable" are different facts that happen to share a remedy, and leaning on the empty string failing to parse would make this correct only by accident.

## Not yet wired — deliberately

`ApplyProbes` has no production caller. The reaper lives in the `spawn` repo and would need to collect `ProbeResult`s per run, plus `dynamodb:Scan` and `dynamodb:UpdateItem` on this table in **its** execution role. Those IAM grants land with that wiring rather than in this PR, so the policy never carries permissions with no caller. That leaves spawn#457 open for the cross-repo step.

Also added: a `README.md` for the lambda (it had none), carrying the design rationale and the existing SigV4-verified-principal registration model.