### PR TITLE
feat(web): nav bar uses the real wordmark image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Changed
+- **The site nav bar now shows the real `spore ● host` wordmark image** (across
+  the landing page and the developer/library page), replacing the CSS-text +
+  gradient-circle lockup. Sized to sit in the 56px nav.
+
 ### Fixed
 - **Site CSS changes no longer take up to 24h to reach returning visitors.** The
   deploy cached all static assets (including the hand-copied, unhashed

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -137,7 +137,11 @@ section + section { border-top: 1px solid var(--border); }
   max-width: var(--max-width); margin: 0 auto; padding: 0 1.5rem;
   display: flex; align-items: center; gap: 2rem; height: 56px;
 }
-/* ── Logo mark ── */
+/* ── Logo mark ──
+   The marketing nav (index/library) now uses the real wordmark image
+   (.nav-logo-img). These CSS-text-lockup rules are retained because dashboard.html
+   still uses them (it's not part of this build's dist output, so it's out of scope
+   for this change). */
 .logo-spore {
   background: linear-gradient(to right, var(--brand-blue), var(--brand-teal));
   -webkit-background-clip: text;
@@ -161,7 +165,13 @@ section + section { border-top: 1px solid var(--border); }
   display: flex; align-items: center; gap: 0.5rem;
   flex-shrink: 0;
 }
-.nav-brand a { text-decoration: none; }
+.nav-brand a { text-decoration: none; display: inline-flex; align-items: center; }
+/* Real wordmark in the nav — sized to sit inside the 56px bar with breathing room.
+   The wordmark PNG carries the mascot orb + a faint tentacle glow, so a little
+   extra height reads well without crowding. */
+.nav-logo-img {
+  height: 30px; width: auto; display: block;
+}
 .nav-links {
   display: flex; align-items: center; gap: 1.5rem;
   margin-left: auto; font-size: 0.9rem;

--- a/web/index.html
+++ b/web/index.html
@@ -30,7 +30,7 @@
     <div class="nav-inner">
       <div class="nav-brand">
         <a href="/" aria-label="spore.host home">
-          <span class="logo-spore">spore</span><img class="logo-orb" src="assets/brand/spore-host-mascot.png" alt="" aria-hidden="true" width="500" height="500"><span class="logo-host">host</span>
+          <img class="nav-logo-img" src="assets/brand/spore-host-logo.png" alt="spore.host" width="1983" height="793">
         </a>
       </div>
       <button class="hamburger" id="hamburger-btn" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-links">

--- a/web/library.html
+++ b/web/library.html
@@ -18,7 +18,7 @@
   <nav class="nav" role="navigation" aria-label="Main navigation">
     <div class="nav-inner">
       <div class="nav-brand">
-        <a href="/" aria-label="spore.host home"><span class="logo-spore">spore</span><img class="logo-orb" src="assets/brand/spore-host-mascot.png" alt="" aria-hidden="true" width="500" height="500"><span class="logo-host">host</span></a>
+        <a href="/" aria-label="spore.host home"><img class="nav-logo-img" src="assets/brand/spore-host-logo.png" alt="spore.host" width="1983" height="793"></a>
       </div>
       <button class="hamburger" id="hamburger-btn" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-links">
         <span></span><span></span><span></span>


### PR DESCRIPTION
The top nav bar showed a CSS-text 'spore·host' + gradient-circle stand-in. Swaps it for the real transparent wordmark image (`.nav-logo-img`, 30px, sized for the 56px nav) on the landing page and the developer/library page.

- Old `.logo-spore`/`.logo-host`/`.logo-orb` CSS is retained: `dashboard.html` still uses that lockup and isn't part of this build's `dist/` output, so it's out of scope here.
- Build passes; both navs reference the wordmark in `dist/`.

Addresses the 'hero bar is still the same' feedback (the nav still showed the text logo). Follow-up to #495/#496/#497. Same visual-review caveat — I can't screenshot; the nav logo is 30px tall, easy to tweak in `.nav-logo-img`.