### PR TITLE
fix(web): bigger nav wordmark (45px) + left-align hero trust line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ own changelogs for CLI releases.
 ### Changed
 - **The site nav bar now shows the real `spore ● host` wordmark image** (across
   the landing page and the developer/library page), replacing the CSS-text +
-  gradient-circle lockup. Sized to sit in the 56px nav.
+  gradient-circle lockup. Sized 45px to sit in the nav.
+- **Hero "Runs in your AWS account…" trust line is now left-aligned** with the
+  rest of the hero copy (was centered by an `auto` block margin).
 
 ### Fixed
 - **Site CSS changes no longer take up to 24h to reach returning visitors.** The

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -170,7 +170,7 @@ section + section { border-top: 1px solid var(--border); }
    The wordmark PNG carries the mascot orb + a faint tentacle glow, so a little
    extra height reads well without crowding. */
 .nav-logo-img {
-  height: 30px; width: auto; display: block;
+  height: 45px; width: auto; display: block;
 }
 .nav-links {
   display: flex; align-items: center; gap: 1.5rem;
@@ -340,7 +340,7 @@ h2.section-title {
 
 /* Hero trust strip */
 .trust-strip {
-  margin: 1rem auto 0;
+  margin: 1rem 0 0;
   font-size: 0.85rem;
   color: var(--text-muted);
   max-width: 46rem;


### PR DESCRIPTION
Two small hero/nav polish fixes from feedback:
- **Nav wordmark was ~50% too small** — bumped `.nav-logo-img` height 30px → 45px.
- **'Runs in your AWS account…' trust line was centered** (an `auto` horizontal block margin) — changed to `margin: 1rem 0 0` so it's left-aligned like the rest of the hero copy.

CSS-only; build passes. (CSS now short-cached per #497, so this shows up on the live site within ~1 min of deploy, not 24h.)