### PR TITLE
fix(web): try full wordmark in hero (20% smaller)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,8 @@ own changelogs for CLI releases.
 
 ### Changed
 - **Marketing site (`web/`) now uses the real spore.host brand art.** The landing
-  hero leads with the **jellyfish mascot** shown large (replacing the small
-  wordmark image); the nav orb across `index.html` / `library.html` is the real
-  mascot (replacing the CSS-text + SVG-circle stand-in). Added Open Graph /
+  hero leads with the full **`spore ● host` wordmark** (width-sized); the nav shows
+  the real wordmark image (replacing the CSS-text + SVG-circle stand-in). Added Open Graph /
   Twitter social-card meta pointing at `spore-host-og.png`, so links unfurl with
   the brand card. Brand assets live under `web/assets/brand/` (logo, jellyfish
   mascot, hero, OG). The mascot and wordmark are the clean, transparent-background

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -206,9 +206,11 @@ section + section { border-top: 1px solid var(--border); }
   display: flex; justify-content: center;
   margin-bottom: 1.5rem;
 }
-.hero-mascot-img {
-  height: clamp(180px, 30vw, 340px);
-  width: auto; max-width: 100%;
+/* Hero wordmark — the full `spore ● host` lockup (wide image), sized by WIDTH
+   since it's ~2.5:1. Baseline presence ~640px, shown 20% smaller (×0.8 ≈ 512px). */
+.hero-wordmark-img {
+  width: clamp(240px, 55vw, 512px);
+  height: auto; max-width: 100%;
   display: block;
   filter: drop-shadow(0 8px 28px rgba(51, 222, 249, 0.28));
 }

--- a/web/index.html
+++ b/web/index.html
@@ -53,7 +53,7 @@
     <div class="hero">
       <div class="hero-inner">
         <div class="hero-mascot">
-          <img src="assets/brand/spore-host-jellyfish.png" alt="spore.host" class="hero-mascot-img" width="1254" height="1254">
+          <img src="assets/brand/spore-host-logo.png" alt="spore.host" class="hero-wordmark-img" width="1983" height="793">
         </div>
         <span class="hero-eyebrow">Open Source · Apache 2.0</span>
         <h1>Compute that manages itself</h1>


### PR DESCRIPTION
Iteration per feedback: use the full `spore ● host` wordmark in the hero instead of just the jellyfish mascot, 20% smaller.

- Hero image → `spore-host-logo.png` (wordmark), class `.hero-wordmark-img`.
- Sized by **width** (`clamp(240px, 55vw, 512px)`) since the wordmark is ~2.5:1 — 512px ≈ 20% below a ~640px baseline. Kept the soft glow.
- Old `.hero-mascot-img` rule removed (renamed).

Heads-up for the visual check: the nav and hero now both show the wordmark (plus the h1 headline) — flagging in case that reads as too repetitive; easy to revert to the mascot or drop the h1. CSS/markup only; build passes.