### PR TITLE
feat(web): progressive disclosure — guided / standard / expert

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -57,6 +57,10 @@ const sidebar = {
         { text: 'Overview', link: '/guides/' },
         { text: 'Which execution tool?', link: '/guides/choosing-execution' },
         { text: 'Finding the right instance', link: '/guides/finding-instances' },
+        // The browser counterpart to the page above — same catalog, same queries,
+        // three densities. Sits next to it rather than in Start Here, which is the
+        // CLI install path.
+        { text: 'Portal detail levels', link: '/guides/portal-detail-levels' },
         { text: 'Interactive workstation', link: '/guides/jupyter' },
         { text: 'GPU training jobs', link: '/guides/gpu-training' },
         { text: 'Spot instances', link: '/guides/spot-instances' },

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -94,6 +94,7 @@ capacity](/guides/waiting-for-capacity).
 | I want to… | Go to |
 |------------|-------|
 | Find the right instance type & compare prices | [Finding the right instance](/guides/finding-instances) |
+| Launch from a browser without learning the CLI | [Portal detail levels](/guides/portal-detail-levels) |
 | Run Jupyter or RStudio in the browser | [Interactive workstation](/guides/jupyter) |
 | Train a model on a GPU | [GPU training jobs](/guides/gpu-training) |
 | Save up to 90% with Spot | [Spot instances](/guides/spot-instances) |

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -1,0 +1,118 @@
+---
+description: "The spore.host portal has one control that decides how much of the interface you see — Guided, Standard, or Expert. What each level shows, and why Guided works with no AI and no credentials."
+---
+
+# Portal detail levels
+
+The [portal](https://spore.host/app) has one control in its header, labelled
+**Detail**, with three settings. It decides how much of the interface you see.
+
+| Level | What you get |
+|---|---|
+| **Guided** | One question — "What are you doing?" — a short list to pick from, and the machine, cost and shutdown time chosen for you. |
+| **Standard** | The instance search box, the full launch form (type, spot, time limit), and the instance list. |
+| **Expert** | Everything above, plus per-instance-type detail: physical cores vs threads, GPU vendor and total VRAM, family, nested-virt support, and whether each price came from a live AWS pull or a hand estimate. |
+
+The setting is **remembered** and applies **across the whole portal**, not
+per-page. Changing it re-renders whatever you're looking at.
+
+## Guided mode
+
+Guided mode asks *"What are you doing?"* in ordinary words and answers with one
+machine:
+
+> **A small analysis** — Notebooks, scripts, modest data. The usual starting point.
+> `t4g.xlarge` — 4 vCPU · 16 GiB
+> about $0.54 for 4 hours ($0.1344/hr)
+
+The cost leads with the **total for the whole run**, not the hourly rate. "$0.1344
+per hour" is a number a first-time user cannot act on; "about $0.54" is.
+
+Picking one gets a single confirmation screen — machine, region, *"Shuts down
+automatically after 4 hours, whatever happens"*, the cost — and one **Start it**
+button. `← Something else` goes back without launching.
+
+Every guided launch gets a **time limit** — 4 hours for CPU shapes, 2 for GPU ones
+— and none of them use spot. Both are deliberate:
+
+- **The time limit is not optional.** An instance nobody remembered to stop is the
+  most expensive mistake this interface makes available. The limit is enforced by
+  `spored` *on the machine*, so it holds even if you close the tab — which is
+  exactly what the confirmation screen says, because a user who closes the tab
+  must not be left guessing whether their instance now runs forever or was killed.
+- **Spot is off.** A spot instance can be reclaimed mid-run. That's a good trade
+  once you understand it and a baffling one before you do. See
+  [Spot instances](/guides/spot-instances) for when to take it.
+
+Guided mode hides the launch form but **never** the instance list. Being able to
+start an instance without being able to see or stop it is the one simplification
+that would cost real money.
+
+**I know what I need →** at the bottom of the list moves you to Standard. Guided is
+a starting point, not a cage.
+
+### Guided mode needs nothing but the portal
+
+No AI, no model access, no credentials, no network. The curated list resolves
+against truffle-ts's bundled instance catalog, which ships with the page.
+
+This is the right way round, and it's worth being explicit about why: the
+beginner's entry point must not be the thing that breaks first. If the simplest
+mode depended on an AI backend, the one path a first-time user takes would be the
+one most likely to be broken — and the one nobody developing the portal is ever in,
+so nobody would notice.
+
+When an AI advisor *is* available it replaces the fixed list with a free-text
+question **in the same slot**. Better answer, same place, and the list is still
+there when it isn't. The advisor is never a prerequisite.
+
+Two things the guided picker does that are easy to get wrong:
+
+- **It re-sorts by price.** truffle treats `4 vcpus 16gb` as a *minimum* and ranks
+  by its own size preference, so its first result for that query is an
+  `r8g.12xlarge` at $2.83/hr. Taking the top hit would quote 21× the right price.
+- **It won't hand a non-GPU shape a GPU.** `8 vcpus 128gb` otherwise matches
+  `g3.4xlarge`, charging someone who asked for memory for a decade-old accelerator
+  they can't use.
+
+## Standard mode
+
+The search box takes plain language — `nvidia h100`, `8 gpus a100`,
+`32 vcpus arm` — and the launch form exposes instance type, spot, and the time
+limit. This is the level most people stay at. The same catalog and the same
+queries are documented at [Finding the right instance](/guides/finding-instances).
+
+## Expert mode
+
+Expert adds, per result, the fields a capacity or topology decision actually turns
+on:
+
+```
+family            g6
+physical cores    24
+threads/core      2
+memory            196608 MiB
+GPU vendor        nvidia
+GPU memory        91552 MiB (total)
+nested virt       no
+price source      live AWS pull
+```
+
+`physical cores` matters because an MPI rank count is cores, not vCPUs.
+`price source` matters because a few catalog entries are hand estimates rather than
+live figures, and an estimate shown as a price is a small lie — expert is the level
+that can act on knowing which it is. A field the catalog genuinely doesn't carry is
+**omitted**, not rendered as `0` or `—`; a zero where the real answer is "unknown"
+states something false about the hardware to the user most likely to act on it.
+
+Standard hides all of this because it's noise when you're comparing two boxes.
+
+## Notes
+
+- The default for a first-time visitor is **Guided**. If the default were Standard,
+  the mode built for the least-experienced user would be the one they never see.
+- Signing out doesn't reset it. Someone who has set Expert shouldn't be dropped
+  back to Guided by an expired session.
+- The level is stored in `localStorage` under `spore.disclosure`. It's a
+  preference, not a credential — your AWS credentials never leave the tab's memory
+  (see [Security, credentials & data flow](/architecture)).

--- a/web/app/disclosure.test.ts
+++ b/web/app/disclosure.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  atLeast,
+  DEFAULT_LEVEL,
+  isLevel,
+  LEVEL_INFO,
+  LEVELS,
+  loadLevel,
+  saveLevel,
+  type DisclosureLevel,
+} from "./disclosure.js";
+
+/** An in-memory Storage stand-in, so no test depends on the real localStorage. */
+function fakeStorage(initial?: Record<string, string>) {
+  const map = new Map(Object.entries(initial ?? {}));
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    /** Test-only peek. */
+    _map: map,
+  };
+}
+
+/** A Storage that throws on every access — Safari private mode, blocked cookies. */
+const throwingStorage = {
+  getItem(): string | null {
+    throw new Error("SecurityError");
+  },
+  setItem(): void {
+    throw new Error("SecurityError");
+  },
+};
+
+describe("atLeast", () => {
+  it("is true at the level itself", () => {
+    for (const l of LEVELS) expect(atLeast(l, l)).toBe(true);
+  });
+
+  it("is true above and false below", () => {
+    expect(atLeast("expert", "standard")).toBe(true);
+    expect(atLeast("expert", "guided")).toBe(true);
+    expect(atLeast("standard", "guided")).toBe(true);
+    expect(atLeast("guided", "standard")).toBe(false);
+    expect(atLeast("guided", "expert")).toBe(false);
+    expect(atLeast("standard", "expert")).toBe(false);
+  });
+
+  // The ordering is the contract every surface depends on. If LEVELS is ever
+  // reordered, the whole portal silently inverts — hence a direct assertion
+  // rather than trusting the array's declaration order.
+  it("orders guided < standard < expert", () => {
+    expect(LEVELS).toEqual(["guided", "standard", "expert"]);
+  });
+});
+
+describe("isLevel", () => {
+  it("accepts exactly the known levels", () => {
+    for (const l of LEVELS) expect(isLevel(l)).toBe(true);
+  });
+
+  it("rejects everything else", () => {
+    for (const v of ["", "GUIDED", "mom", "space-shuttle", null, undefined, 0, 1, {}, []]) {
+      expect(isLevel(v)).toBe(false);
+    }
+  });
+});
+
+describe("loadLevel / saveLevel", () => {
+  it("round-trips through storage", () => {
+    const s = fakeStorage();
+    saveLevel("expert", s);
+    expect(loadLevel(s)).toBe("expert");
+  });
+
+  it("defaults to guided when nothing is stored", () => {
+    expect(loadLevel(fakeStorage())).toBe("guided");
+    expect(DEFAULT_LEVEL).toBe("guided");
+  });
+
+  // The reason the default is guided, asserted so a later "nicer default"
+  // refactor has to argue with a test: if the default were standard, the mode
+  // built for the least-experienced user is the one they'd never see.
+  it("defaults to the LEAST revealing level", () => {
+    expect(DEFAULT_LEVEL).toBe(LEVELS[0]);
+  });
+
+  it("ignores a stored value that isn't a level", () => {
+    // A hand-edited or stale localStorage entry must not become the level: every
+    // atLeast() comparison against an unknown string reads as below-guided, which
+    // would hide the whole portal with no visible cause.
+    expect(loadLevel(fakeStorage({ "spore.disclosure": "cockpit" }))).toBe("guided");
+    expect(loadLevel(fakeStorage({ "spore.disclosure": "" }))).toBe("guided");
+  });
+
+  it("survives storage that throws", () => {
+    // A portal that fails to load because it couldn't read a UI preference is a
+    // worse outcome than one that starts in guided mode.
+    expect(() => loadLevel(throwingStorage)).not.toThrow();
+    expect(loadLevel(throwingStorage)).toBe("guided");
+    expect(() => saveLevel("expert", throwingStorage)).not.toThrow();
+  });
+
+  it("survives storage being absent entirely", () => {
+    expect(loadLevel(null)).toBe("guided");
+    expect(() => saveLevel("expert", null)).not.toThrow();
+  });
+});
+
+describe("LEVEL_INFO", () => {
+  it("describes every level", () => {
+    for (const l of LEVELS) {
+      expect(LEVEL_INFO[l].label.length).toBeGreaterThan(0);
+      // The blurb is what the picker shows; a level with no explanation is a
+      // control the user has to guess at.
+      expect(LEVEL_INFO[l].blurb.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no entries beyond LEVELS", () => {
+    expect(Object.keys(LEVEL_INFO).sort()).toEqual([...LEVELS].sort());
+  });
+
+  it("is exhaustive by type", () => {
+    // Compile-time companion to the runtime check above: adding a level to the
+    // union without an entry here is a type error, not a blank tooltip.
+    const check: Record<DisclosureLevel, unknown> = LEVEL_INFO;
+    expect(check).toBeTruthy();
+  });
+});

--- a/web/app/disclosure.ts
+++ b/web/app/disclosure.ts
@@ -1,0 +1,105 @@
+// Progressive disclosure: one portal-wide control from "anyone's mom could use
+// this" out to "space shuttle cockpit".
+//
+// Three levels, and ONE global setting rather than per-surface. A per-surface
+// level would silently change meaning as the user navigates — they'd set
+// "expert" on the instance list, move to costs, and find themselves back in a
+// simplified view with no indication why. One setting, shown in the header, is
+// the whole state.
+//
+// The levels are ordered, so a surface asks "am I at least standard?" rather
+// than switching on an exact value. That matters for adding a fourth level
+// later: `atLeast(level, "standard")` keeps working, whereas
+// `level === "standard" || level === "expert"` silently excludes it.
+
+export type DisclosureLevel = "guided" | "standard" | "expert";
+
+/** Ordered least- to most-revealing. Index is the comparison key. */
+export const LEVELS: readonly DisclosureLevel[] = ["guided", "standard", "expert"] as const;
+
+/** Human labels + one line of what each level is FOR, shown in the picker. */
+export const LEVEL_INFO: Record<DisclosureLevel, { label: string; blurb: string }> = {
+  guided: {
+    label: "Guided",
+    blurb: "Pick what you're doing; we choose the machine and show the cost.",
+  },
+  standard: {
+    label: "Standard",
+    blurb: "Choose the instance type, spot, and how long it lives.",
+  },
+  expert: {
+    label: "Expert",
+    blurb: "Everything: AZ, quotas, placement, tags, the raw spec.",
+  },
+};
+
+/**
+ * True when `level` is at or above `min`.
+ *
+ * The single place levels are compared. Surfaces must not each invent a policy —
+ * that's how one surface ends up treating "guided" as "hide the whole thing" and
+ * another as "show a simplified version", which reads to the user as the control
+ * being broken.
+ */
+export function atLeast(level: DisclosureLevel, min: DisclosureLevel): boolean {
+  return LEVELS.indexOf(level) >= LEVELS.indexOf(min);
+}
+
+/** Exported so tests assert against the real key rather than a copied literal. */
+export const STORAGE_KEY = "spore.disclosure";
+
+/**
+ * The default for a first-time or signed-out visitor.
+ *
+ * Deliberately `guided`, not `standard`. If the default were `standard`, the mode
+ * built for the least-experienced user would be the one they never see — they'd
+ * have to know it existed and go looking for it, which is precisely the knowledge
+ * they don't have.
+ */
+export const DEFAULT_LEVEL: DisclosureLevel = "guided";
+
+/**
+ * Read the remembered level from localStorage.
+ *
+ * localStorage is right here and wrong for credentials: this is a UI preference,
+ * not a secret, and it should survive a reload the way any preference does. (The
+ * session's AWS creds stay in memory only — see `session.ts`.)
+ *
+ * A storage failure returns the default rather than throwing. Safari's private
+ * mode and a blocked-cookies configuration both make localStorage throw on
+ * access, and a portal that fails to load because it couldn't read a preference
+ * is a worse outcome than one that starts in guided mode.
+ */
+export function loadLevel(storage: Pick<Storage, "getItem" | "setItem"> | null = safeStorage()): DisclosureLevel {
+  try {
+    const v = storage?.getItem(STORAGE_KEY);
+    return isLevel(v) ? v : DEFAULT_LEVEL;
+  } catch {
+    return DEFAULT_LEVEL;
+  }
+}
+
+/** Persist the level. Silently tolerates unavailable storage, as above. */
+export function saveLevel(
+  level: DisclosureLevel,
+  storage: Pick<Storage, "getItem" | "setItem"> | null = safeStorage(),
+): void {
+  try {
+    storage?.setItem(STORAGE_KEY, level);
+  } catch {
+    // A preference that can't be remembered is a small loss; a thrown error
+    // during a click handler is a broken control.
+  }
+}
+
+export function isLevel(v: unknown): v is DisclosureLevel {
+  return typeof v === "string" && (LEVELS as readonly string[]).includes(v);
+}
+
+function safeStorage(): Storage | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/web/app/guided/launch.test.ts
+++ b/web/app/guided/launch.test.ts
@@ -1,0 +1,197 @@
+// The guided launch panel, driven against a stub SpawnClient.
+//
+// The real path needs federated AWS credentials and would bill for an instance, so
+// launch() is stubbed and what's asserted is the *shape of the request* — which is
+// where the cost-safety properties live. A guided launch with no TTL, or on spot,
+// would be a real defect that no amount of live clicking would reveal until it
+// cost someone money.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SpawnClient } from "@spore-host/spawn-ts";
+import { mountGuidedLaunch } from "./launch.js";
+import { GUIDED_SHAPES } from "./shapes.js";
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+/** A SpawnClient stand-in exposing only what the panel calls. */
+function stubClient(impl?: (input: unknown) => Promise<unknown>) {
+  const launch = vi.fn(
+    impl ?? (async (input: any) => ({ instanceId: "i-0abc", name: input.name })),
+  );
+  return { client: { launch } as unknown as SpawnClient, launch };
+}
+
+describe("mountGuidedLaunch", () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+  });
+
+  async function pickFirst(client: SpawnClient, onEscape = vi.fn()) {
+    const dispose = mountGuidedLaunch(host, { client, region: "us-east-1", onEscape });
+    await settle();
+    host.querySelector<HTMLButtonElement>(".guided-card")!.click();
+    await settle();
+    return dispose;
+  }
+
+  it("shows the picker first", async () => {
+    const { client } = stubClient();
+    const dispose = mountGuidedLaunch(host, { client, region: "us-east-1", onEscape: vi.fn() });
+    await settle();
+    expect(host.querySelectorAll(".guided-card")).toHaveLength(GUIDED_SHAPES.length);
+    expect(host.querySelector(".guided-confirm")).toBeNull();
+    dispose();
+  });
+
+  it("confirms with the machine, region, cost and shutdown before launching", async () => {
+    const { client, launch } = stubClient();
+    const dispose = await pickFirst(client);
+
+    const confirm = host.querySelector<HTMLElement>(".guided-confirm")!;
+    expect(confirm).toBeTruthy();
+    const text = confirm.textContent!.replace(/\s+/g, " ");
+    expect(text).toMatch(/t4g|[a-z0-9-]+\.[a-z0-9]+/); // a real instance type
+    expect(text).toContain("us-east-1");
+    expect(text).toMatch(/\$\d/);
+    // The shutdown promise is the one thing a guided user must see before they
+    // commit — it's what makes an unattended instance safe.
+    expect(text).toMatch(/hours/);
+    expect(text.toLowerCase()).toContain("automatically");
+    // Nothing launched yet: confirmation is a step, not a formality.
+    expect(launch).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("says the limit is enforced on the machine, not by the tab", async () => {
+    // A user who closes the tab must not be left thinking their instance now runs
+    // forever — nor thinking it was killed. Both are wrong.
+    const { client } = stubClient();
+    const dispose = await pickFirst(client);
+    expect(host.querySelector(".guided-reassure")!.textContent).toContain("close this tab");
+    dispose();
+  });
+
+  it("launches with a TTL and without spot", async () => {
+    const { client, launch } = stubClient();
+    const dispose = await pickFirst(client);
+    host.querySelector<HTMLButtonElement>(".guided-go")!.click();
+    await settle();
+
+    expect(launch).toHaveBeenCalledTimes(1);
+    const input = launch.mock.calls[0]![0] as any;
+    const shape = GUIDED_SHAPES[0]!;
+    // A TTL is the hard cost backstop; a guided launch must never be unbounded.
+    expect(input.ttl).toBe(`${shape.defaultTtlHours}h`);
+    // Not spot: a beginner's first instance should not vanish mid-run with no
+    // explanation they could act on.
+    expect(input.spot).toBe(false);
+    expect(input.region).toBe("us-east-1");
+    expect(input.instanceType).toMatch(/^[a-z0-9-]+\.[a-z0-9]+$/);
+    // The price travels with the launch so the Dashboard's cost meter reflects
+    // THIS instance instead of its hardcoded default.
+    expect(input.pricePerHour).toBeGreaterThan(0);
+    dispose();
+  });
+
+  it("names the instance distinguishably", async () => {
+    // A guided user will click the same shape twice, and two instances with the
+    // same name are indistinguishable at exactly the moment they need to terminate
+    // one of them.
+    const { client, launch } = stubClient();
+    const d1 = await pickFirst(client);
+    host.querySelector<HTMLButtonElement>(".guided-go")!.click();
+    await settle();
+    const name = (launch.mock.calls[0]![0] as any).name as string;
+    expect(name).toContain(GUIDED_SHAPES[0]!.id);
+    expect(name.length).toBeGreaterThan(GUIDED_SHAPES[0]!.id.length + 1);
+    d1();
+  });
+
+  it("reports success with the instance id", async () => {
+    const { client } = stubClient();
+    const dispose = await pickFirst(client);
+    host.querySelector<HTMLButtonElement>(".guided-go")!.click();
+    await settle();
+    const msg = host.querySelector<HTMLElement>(".guided-msg")!;
+    expect(msg.className).toContain("ok");
+    expect(msg.textContent).toContain("i-0abc");
+    dispose();
+  });
+
+  it("surfaces the real error text on failure and re-enables the button", async () => {
+    // A guided user is the least able to diagnose a vague error, so "couldn't
+    // start it" alone is the least helpful thing we could say — a quota failure
+    // and a permission failure both land here and read completely differently.
+    const { client } = stubClient(async () => {
+      throw new Error("VcpuLimitExceeded: you have requested more vCPU capacity");
+    });
+    const dispose = await pickFirst(client);
+    const go = host.querySelector<HTMLButtonElement>(".guided-go")!;
+    go.click();
+    await settle();
+
+    const msg = host.querySelector<HTMLElement>(".guided-msg")!;
+    expect(msg.className).toContain("error");
+    expect(msg.textContent).toContain("VcpuLimitExceeded");
+    // Retryable: a quota bump or a different shape may well work.
+    expect(go.disabled).toBe(false);
+    dispose();
+  });
+
+  it("disables the button while launching so one click is one instance", async () => {
+    let release!: () => void;
+    const { client, launch } = stubClient(
+      () => new Promise((r) => (release = () => r({ instanceId: "i-1", name: "n" }))),
+    );
+    const dispose = await pickFirst(client);
+    const go = host.querySelector<HTMLButtonElement>(".guided-go")!;
+    go.click();
+    await settle();
+    expect(go.disabled).toBe(true);
+    go.click(); // an impatient second click must not launch a second instance
+    go.click();
+    await settle();
+    expect(launch).toHaveBeenCalledTimes(1);
+    release();
+    await settle();
+    dispose();
+  });
+
+  it("lets the user go back to the picker without launching", async () => {
+    const { client, launch } = stubClient();
+    const dispose = await pickFirst(client);
+    host.querySelector<HTMLButtonElement>(".guided-back")!.click();
+    await settle();
+    expect(host.querySelectorAll(".guided-card")).toHaveLength(GUIDED_SHAPES.length);
+    expect(host.querySelector(".guided-confirm")).toBeNull();
+    expect(launch).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("passes the escape hatch through", async () => {
+    const onEscape = vi.fn();
+    const { client } = stubClient();
+    const dispose = mountGuidedLaunch(host, { client, region: "us-east-1", onEscape });
+    await settle();
+    host.querySelector<HTMLButtonElement>(".guided-escape")!.click();
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it("does not write a result into a detached DOM after dispose", async () => {
+    let release!: () => void;
+    const { client } = stubClient(
+      () => new Promise((r) => (release = () => r({ instanceId: "i-2", name: "n" }))),
+    );
+    const dispose = await pickFirst(client);
+    host.querySelector<HTMLButtonElement>(".guided-go")!.click();
+    await settle();
+    dispose();
+    release();
+    await settle();
+    expect(host.querySelector(".guided-launch")).toBeNull();
+  });
+});

--- a/web/app/guided/launch.ts
+++ b/web/app/guided/launch.ts
@@ -1,0 +1,148 @@
+// The guided launch panel: the picker, then one confirmation showing what it is,
+// what it costs, and when it shuts itself off. Then a single button.
+//
+// It launches through the SAME SpawnClient the Dashboard is driven by, so the
+// resulting instance appears in the Dashboard's own list via its existing event
+// subscription. No second list, no polling of our own — the composition is the
+// point, and duplicating the list is how the two views drift apart.
+
+import type { SpawnClient } from "@spore-host/spawn-ts";
+import { mountGuidedPicker, type GuidedChoice } from "./picker.js";
+
+export interface GuidedLaunchOptions {
+  client: SpawnClient;
+  /** The region, shown in the confirmation — a cost figure without a region is half a fact. */
+  region: string;
+  /** "I know what I need" — hand control back to the caller (raise the level). */
+  onEscape(): void;
+}
+
+/** Render the guided launch flow into `host`. Returns a dispose fn. */
+export function mountGuidedLaunch(host: HTMLElement, opts: GuidedLaunchOptions): () => void {
+  const root = document.createElement("div");
+  root.className = "guided-launch";
+  host.appendChild(root);
+
+  let disposeStep: (() => void) | null = null;
+  let live = true;
+
+  const showPicker = (): void => {
+    disposeStep?.();
+    root.innerHTML = "";
+    disposeStep = mountGuidedPicker(root, {
+      onChoose: (choice) => showConfirm(choice),
+      onEscape: opts.onEscape,
+    });
+  };
+
+  const showConfirm = (choice: GuidedChoice): void => {
+    disposeStep?.();
+    disposeStep = null;
+    const { shape, rec } = choice;
+    const i = rec.pick.instance;
+
+    // The cost line is deliberately the total, and deliberately says "up to":
+    // the TTL is a ceiling, not a prediction — an instance that finishes early
+    // and is stopped costs less, and promising the exact figure would be wrong in
+    // the user's favour right up until it wasn't.
+    const cost =
+      rec.pricePerHour == null
+        ? `<p class="guided-cost unknown">We don't have a price for
+             <code>${escapeHtml(i.instanceType)}</code> in the offline catalog, so we
+             can't tell you what this costs. Check the AWS pricing page before you
+             launch.</p>`
+        : `<p class="guided-cost">Up to <b>$${rec.estimatedTotal!.toFixed(2)}</b>
+             — $${rec.pricePerHour.toFixed(4)} per hour${
+               rec.priceIsEstimate ? " (estimated)" : ""
+             }, for at most ${shape.defaultTtlHours} hours.</p>`;
+
+    root.innerHTML = `
+      <div class="guided-confirm">
+        <h2>${escapeHtml(shape.label)}</h2>
+        <dl class="guided-facts">
+          <dt>Machine</dt><dd><code>${escapeHtml(i.instanceType)}</code> —
+            ${i.vcpus} vCPU, ${(i.memoryMib / 1024).toFixed(0)} GiB${
+              i.gpus ? `, ${i.gpus}× ${escapeHtml(i.gpuModel ?? "GPU")}` : ""
+            }</dd>
+          <dt>Region</dt><dd>${escapeHtml(opts.region)}</dd>
+          <dt>Shuts down</dt><dd>automatically after
+            ${shape.defaultTtlHours} hours, whatever happens</dd>
+        </dl>
+        ${cost}
+        <p class="guided-reassure">The time limit is enforced on the machine itself, so
+          it applies even if you close this tab.</p>
+        <div class="guided-actions">
+          <button class="guided-back" type="button">← Something else</button>
+          <button class="guided-go" type="button">Start it</button>
+        </div>
+        <div class="guided-msg" aria-live="polite"></div>
+      </div>`;
+
+    const back = root.querySelector<HTMLButtonElement>(".guided-back")!;
+    const go = root.querySelector<HTMLButtonElement>(".guided-go")!;
+    const msg = root.querySelector<HTMLElement>(".guided-msg")!;
+
+    back.addEventListener("click", () => showPicker());
+    go.addEventListener("click", () => {
+      go.disabled = true;
+      back.disabled = true;
+      msg.className = "guided-msg";
+      msg.textContent = "Starting…";
+      void opts.client
+        .launch({
+          name: instanceName(shape.id),
+          instanceType: i.instanceType,
+          region: opts.region,
+          spot: false, // A beginner's first instance should not vanish mid-run.
+          ttl: `${shape.defaultTtlHours}h`,
+          // Pass the price through so the Dashboard's cost meter reflects THIS
+          // instance rather than its hardcoded default. Zero when unknown is
+          // correct here: it disables the meter's math instead of inventing a rate.
+          pricePerHour: rec.pricePerHour ?? 0,
+        })
+        .then((inst) => {
+          if (!live) return;
+          msg.className = "guided-msg ok";
+          msg.textContent = `Started ${inst.name} (${inst.instanceId}). It's in the list below.`;
+        })
+        .catch((err: unknown) => {
+          if (!live) return;
+          // Show the real error. A guided user is the least able to diagnose a
+          // vague one, so "couldn't start it" alone is the least helpful thing we
+          // could say — quota and permission failures both land here and read
+          // completely differently.
+          msg.className = "guided-msg error";
+          msg.textContent = `Couldn't start it: ${(err as Error).message}`;
+          go.disabled = false;
+          back.disabled = false;
+        });
+    });
+  };
+
+  showPicker();
+
+  return () => {
+    live = false;
+    disposeStep?.();
+    root.remove();
+  };
+}
+
+/**
+ * A name the user can recognise in the list later.
+ *
+ * Suffixed with a timestamp because a guided user will click the same shape twice
+ * and two instances called "gpu" are indistinguishable in the list — which is
+ * exactly the moment they need to tell them apart to terminate the right one.
+ */
+function instanceName(shapeId: string): string {
+  const stamp = new Date().toISOString().slice(5, 16).replace(/[-:T]/g, "");
+  return `${shapeId}-${stamp}`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}

--- a/web/app/guided/picker.test.ts
+++ b/web/app/guided/picker.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GUIDED_SHAPES } from "./shapes.js";
+import { mountGuidedPicker } from "./picker.js";
+
+/** Let the per-card resolveShape promises settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe("mountGuidedPicker", () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+  });
+
+  it("renders one card per curated shape", async () => {
+    const dispose = mountGuidedPicker(host, { onChoose: vi.fn(), onEscape: vi.fn() });
+    await settle();
+    expect(host.querySelectorAll(".guided-card")).toHaveLength(GUIDED_SHAPES.length);
+    dispose();
+  });
+
+  it("resolves every card to a real machine and a price", async () => {
+    // The plan's headline check, at the DOM level: guided mode with no advisor,
+    // no credentials and no network still shows real instance types and prices.
+    const dispose = mountGuidedPicker(host, { onChoose: vi.fn(), onEscape: vi.fn() });
+    await settle();
+
+    const cards = [...host.querySelectorAll<HTMLButtonElement>(".guided-card")];
+    cards.forEach((card, i) => {
+      const id = GUIDED_SHAPES[i]!.id;
+      expect(card.classList.contains("ready"), id).toBe(true);
+      expect(card.classList.contains("loading"), id).toBe(false);
+      expect(card.disabled, id).toBe(false);
+      const text = card.querySelector(".guided-card-machine")!.textContent!;
+      expect(text, id).toMatch(/[a-z0-9-]+\.[a-z0-9]+/); // an instance type
+      expect(text, id).toMatch(/\$\d/); // a price
+      expect(text, id).not.toMatch(/\$0\.00 for/); // never "free"
+    });
+    dispose();
+  });
+
+  it("reports the chosen shape and its resolved machine", async () => {
+    const onChoose = vi.fn();
+    const dispose = mountGuidedPicker(host, { onChoose, onEscape: vi.fn() });
+    await settle();
+
+    host.querySelector<HTMLButtonElement>(".guided-card")!.click();
+    expect(onChoose).toHaveBeenCalledTimes(1);
+    const choice = onChoose.mock.calls[0]![0];
+    expect(choice.shape.id).toBe(GUIDED_SHAPES[0]!.id);
+    expect(choice.rec.pick.instance.instanceType).toBeTruthy();
+    dispose();
+  });
+
+  it("offers an escape to a denser mode", async () => {
+    // Guided mode must not be a trap: a user who outgrows it mid-task needs a way
+    // out that isn't "hunt for the setting in the header".
+    const onEscape = vi.fn();
+    const dispose = mountGuidedPicker(host, { onChoose: vi.fn(), onEscape });
+    await settle();
+    host.querySelector<HTMLButtonElement>(".guided-escape")!.click();
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it("shows a lookup failure as a failure, not as no match", async () => {
+    // The #63 invariant at the pixel level: a broken catalog and an empty catalog
+    // must not render the same, because they call for different user action
+    // (retry vs pick something else). This is the branch the real catalog never
+    // exercises, so it's the one most likely to ship broken.
+    const onChoose = vi.fn();
+    const dispose = mountGuidedPicker(host, {
+      onChoose,
+      onEscape: vi.fn(),
+      shapes: [GUIDED_SHAPES[0]!],
+      finder: async () => {
+        throw new Error("catalog unreadable");
+      },
+    });
+    await settle();
+
+    const card = host.querySelector<HTMLButtonElement>(".guided-card")!;
+    expect(card.classList.contains("errored")).toBe(true);
+    expect(card.classList.contains("unresolved")).toBe(false);
+    expect(card.querySelector(".guided-card-machine")!.textContent).toContain("catalog unreadable");
+    // An errored card must not be clickable — there is nothing to launch.
+    expect(card.disabled).toBe(true);
+    card.click();
+    expect(onChoose).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("shows no-match distinctly from a failure", async () => {
+    const dispose = mountGuidedPicker(host, {
+      onChoose: vi.fn(),
+      onEscape: vi.fn(),
+      shapes: [GUIDED_SHAPES[0]!],
+      finder: async () => [],
+    });
+    await settle();
+
+    const card = host.querySelector<HTMLButtonElement>(".guided-card")!;
+    expect(card.classList.contains("unresolved")).toBe(true);
+    expect(card.classList.contains("errored")).toBe(false);
+    expect(card.querySelector(".guided-card-machine")!.textContent).toContain("no machine");
+    expect(card.disabled).toBe(true);
+    dispose();
+  });
+
+  it("does not write into a detached DOM after dispose", async () => {
+    // dispose() can land while five resolveShape promises are in flight. Writing
+    // into removed nodes is harmless-looking until one of those writes is an
+    // error message the user can no longer see, on a surface they've left.
+    const dispose = mountGuidedPicker(host, { onChoose: vi.fn(), onEscape: vi.fn() });
+    dispose();
+    await settle();
+    expect(host.querySelector(".guided-picker")).toBeNull();
+    expect(host.querySelectorAll(".guided-card")).toHaveLength(0);
+  });
+
+  it("removes its listeners on dispose", async () => {
+    const onEscape = vi.fn();
+    const dispose = mountGuidedPicker(host, { onChoose: vi.fn(), onEscape });
+    await settle();
+    const escape = host.querySelector<HTMLButtonElement>(".guided-escape")!;
+    dispose();
+    escape.click(); // detached, but click the retained node anyway
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it("escapes shape text rather than injecting it", async () => {
+    const dispose = mountGuidedPicker(host, { onChoose: vi.fn(), onEscape: vi.fn() });
+    await settle();
+    expect(host.innerHTML).not.toContain("<script");
+    dispose();
+  });
+});

--- a/web/app/guided/picker.ts
+++ b/web/app/guided/picker.ts
@@ -1,0 +1,151 @@
+// The guided picker's rendering: "what are you doing?" as a short list of
+// recognisable shapes, each resolved to a real instance type with a real price.
+//
+// Kept separate from shapes.ts so the selection logic (which is the part with
+// correctness rules and upstream data caveats) stays free of DOM code.
+//
+// This renders in the same slot advisor-ts will eventually occupy with a free-text
+// question. The slot is the same; the dependency is not — this needs only the
+// bundled catalog, so it works with no credentials, no network, and no model
+// access. That's the right way round: the beginner's entry point must not be the
+// one that breaks first.
+
+import { find } from "@spore-host/truffle-ts";
+import {
+  GUIDED_SHAPES,
+  resolveShape,
+  type GuidedRecommendation,
+  type GuidedShape,
+} from "./shapes.js";
+
+/** What the picker reports when the user commits to a shape. */
+export interface GuidedChoice {
+  shape: GuidedShape;
+  rec: GuidedRecommendation;
+}
+
+export interface GuidedPickerOptions {
+  /** Called when the user picks a shape and clicks through. */
+  onChoose(choice: GuidedChoice): void;
+  /**
+   * Called for "I know what I need" — the exit to a denser mode. Guided mode must
+   * not be a trap: a user who outgrows it mid-task needs a way out that isn't
+   * "hunt for the setting in the header".
+   */
+  onEscape(): void;
+  /**
+   * Catalog lookup, injected. Defaults to truffle-ts's `find`.
+   *
+   * Present so the no-match and lookup-failed branches are testable — they are
+   * the two states most likely to ship broken, because the real catalog never
+   * produces either.
+   */
+  finder?: typeof find;
+  /** Shapes to offer. Defaults to the curated list; overridable for tests. */
+  shapes?: readonly GuidedShape[];
+}
+
+/**
+ * Render the picker into `host`. Returns a dispose fn.
+ *
+ * Each card resolves independently and renders as soon as it can, rather than
+ * awaiting all five: a `find()` over the bundled catalog is fast, but one slow or
+ * failed shape must not hold the whole list blank.
+ */
+export function mountGuidedPicker(host: HTMLElement, opts: GuidedPickerOptions): () => void {
+  const root = document.createElement("div");
+  root.className = "guided-picker";
+  root.innerHTML = `
+    <h2>What are you doing?</h2>
+    <p class="guided-hint">Pick the closest match. We'll choose a machine, show what
+      it costs per hour, and shut it down for you when the time's up.</p>
+    <div class="guided-cards"></div>
+    <button class="guided-escape" type="button">I know what I need →</button>`;
+  host.appendChild(root);
+
+  const cards = root.querySelector<HTMLElement>(".guided-cards")!;
+  const escape = root.querySelector<HTMLButtonElement>(".guided-escape")!;
+  const onEscape = () => opts.onEscape();
+  escape.addEventListener("click", onEscape);
+
+  // Track so dispose() can't leave a resolved promise writing into a detached DOM.
+  let live = true;
+
+  for (const shape of opts.shapes ?? GUIDED_SHAPES) {
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className = "guided-card loading";
+    card.disabled = true;
+    card.innerHTML = `
+      <span class="guided-card-label">${escapeHtml(shape.label)}</span>
+      <span class="guided-card-blurb">${escapeHtml(shape.blurb)}</span>
+      <span class="guided-card-machine">finding a machine…</span>`;
+    cards.appendChild(card);
+
+    void resolveShape(shape, opts.finder ?? find)
+      .then((rec) => {
+        if (!live) return;
+        card.classList.remove("loading");
+        if (!rec) {
+          // Say which fact is missing. "Unavailable" alone would leave the user
+          // unable to tell a catalog gap from a broken portal.
+          card.classList.add("unresolved");
+          card.querySelector(".guided-card-machine")!.textContent =
+            "no machine in the catalog matches this — try another option";
+          return;
+        }
+        card.classList.add("ready");
+        card.disabled = false;
+        card.querySelector(".guided-card-machine")!.innerHTML = describe(rec);
+        card.addEventListener("click", () => opts.onChoose({ shape, rec }));
+      })
+      .catch((err: unknown) => {
+        if (!live) return;
+        // A thrown find() is a failure, and it must not render as "no match" —
+        // that would report a fact about the catalog's contents that we don't have.
+        card.classList.remove("loading");
+        card.classList.add("errored");
+        card.querySelector(".guided-card-machine")!.textContent =
+          `couldn't look this up: ${(err as Error).message}`;
+      });
+  }
+
+  return () => {
+    live = false;
+    escape.removeEventListener("click", onEscape);
+    root.remove();
+  };
+}
+
+/**
+ * The one line of hardware the guided user sees.
+ *
+ * Leads with the total, not the hourly rate: "$0.54 for 4 hours" is the number a
+ * person can decide against, whereas $0.1344/hr requires them to do arithmetic
+ * about a duration they haven't been told about yet.
+ *
+ * An unknown price says so. Rendering "$0.00" or omitting the cost entirely would
+ * both read as "free".
+ */
+function describe(rec: GuidedRecommendation): string {
+  const i = rec.pick.instance;
+  const gib = (i.memoryMib / 1024).toFixed(i.memoryMib % 1024 === 0 ? 0 : 1);
+  const gpu = i.gpus ? ` · ${i.gpus}× ${escapeHtml(i.gpuModel ?? "GPU")}` : "";
+  const specs = `${escapeHtml(i.instanceType)} — ${i.vcpus} vCPU · ${gib} GiB${gpu}`;
+
+  if (rec.pricePerHour == null) {
+    return `<b>${specs}</b><span class="guided-card-cost unknown">price unknown for this
+      type — check before launching</span>`;
+  }
+  const est = rec.priceIsEstimate ? " (estimated)" : "";
+  return `<b>${specs}</b><span class="guided-card-cost">about
+    $${rec.estimatedTotal!.toFixed(2)} for ${rec.shape.defaultTtlHours} hours
+    ($${rec.pricePerHour.toFixed(4)}/hr${est})</span>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}

--- a/web/app/guided/shapes.test.ts
+++ b/web/app/guided/shapes.test.ts
@@ -1,0 +1,216 @@
+// These tests run against truffle-ts's REAL bundled catalog, not a fixture.
+//
+// That's deliberate and it's the point of the file. The plan's headline check is
+// "set the level to guided with the advisor absent and confirm the curated picker
+// still returns real instance types and live prices" — a fixture would pass that
+// check while the shipped portal quoted a fabricated $0.20/hr B200. The catalog is
+// offline and bundled, so there is no network cost to using the real thing.
+//
+// The trade-off is that a catalog regeneration can turn these red. That is the
+// intended behaviour: a shape whose query stops matching, or whose cheapest match
+// becomes a $55/hr box, is a defect in the portal's most vulnerable path and
+// should fail loudly rather than ship.
+
+import { describe, expect, it } from "vitest";
+import type { FindResult } from "@spore-host/truffle-ts";
+import { GUIDED_SHAPES, resolveAllShapes, resolveShape } from "./shapes.js";
+
+describe("GUIDED_SHAPES", () => {
+  it("has unique ids", () => {
+    const ids = GUIDED_SHAPES.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("gives every shape a TTL", () => {
+    // A guided launch with no time limit is the single most expensive mistake
+    // available in this UI, and "I forgot it was running" is the normal way it
+    // happens. There is no valid zero here.
+    for (const s of GUIDED_SHAPES) {
+      expect(s.defaultTtlHours, s.id).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps GPU shapes on shorter TTLs than CPU shapes", () => {
+    // At H100 prices the TTL *is* the cost control: a forgotten p5 costs more per
+    // hour than most of the others cost per day.
+    const gpuMax = Math.max(...GUIDED_SHAPES.filter((s) => s.wantsGpu).map((s) => s.defaultTtlHours));
+    const cpuMin = Math.min(...GUIDED_SHAPES.filter((s) => !s.wantsGpu).map((s) => s.defaultTtlHours));
+    expect(gpuMax).toBeLessThanOrEqual(cpuMin);
+  });
+
+  it("labels shapes in user vocabulary, not hardware vocabulary", () => {
+    // The whole reason guided mode exists is that "gpu with 80gb for training" is
+    // only writable by someone who already knows what they need. A label carrying
+    // an instance type would reintroduce exactly that.
+    for (const s of GUIDED_SHAPES) {
+      expect(s.label, s.id).not.toMatch(/\b[a-z]\d[a-z]*\.\w+\b/);
+      expect(s.blurb.length, s.id).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("resolveShape against the real bundled catalog", () => {
+  it("resolves every curated shape to a real instance type", async () => {
+    // THE headline test. Every shape must produce a machine — an unresolvable
+    // entry in the beginner's only menu is a dead end for the user least equipped
+    // to work around it.
+    const recs = await resolveAllShapes();
+    expect(recs).toHaveLength(GUIDED_SHAPES.length);
+    recs.forEach((rec, i) => {
+      const shape = GUIDED_SHAPES[i]!;
+      expect(rec, `${shape.id} resolved to nothing — query "${shape.query}" matched no instance`).toBeDefined();
+      expect(rec!.pick.instance.instanceType, shape.id).toMatch(/^[a-z0-9-]+\.[a-z0-9]+$/);
+      expect(rec!.totalMatches, shape.id).toBeGreaterThan(0);
+    });
+  });
+
+  it("quotes a usable price and a total for every shape", async () => {
+    const recs = await resolveAllShapes();
+    for (const rec of recs) {
+      // A zero would sort first and read as free; a null would leave the guided
+      // user with no cost information at all. Both are failures here.
+      expect(rec!.pricePerHour, rec!.shape.id).toBeGreaterThan(0);
+      expect(rec!.estimatedTotal, rec!.shape.id).toBeCloseTo(
+        rec!.pricePerHour! * rec!.shape.defaultTtlHours,
+        6,
+      );
+    }
+  });
+
+  it("picks the CHEAPEST match, not truffle's first", async () => {
+    // truffle-ts treats vcpus/memory as MINIMUMS and ranks by its own size
+    // preference: find("4 vcpus 16gb") returns r8g.12xlarge (48 vCPU, 384 GiB,
+    // ~$2.83/hr) first, while t4g.xlarge (exactly 4/16, ~$0.13/hr) is further
+    // down. Handing over truffle's first result would quote 21× the right cost.
+    const small = GUIDED_SHAPES.find((s) => s.id === "small-analysis")!;
+    const rec = (await resolveShape(small))!;
+
+    const { find } = await import("@spore-host/truffle-ts");
+    const raw = await find(small.query);
+    const rawFirstPrice = raw[0]!.instance.onDemandPrice;
+
+    expect(rec.pricePerHour).toBeLessThanOrEqual(rawFirstPrice ?? Infinity);
+    // And it must beat every other priced, non-quarantined candidate.
+    const better = raw.filter(
+      (r) => usable(r) && r.instance.onDemandPrice! < rec.pricePerHour! && !isQuarantined(r),
+    );
+    expect(better.map((r) => r.instance.instanceType)).toEqual([]);
+  });
+
+  it("does not hand a non-GPU shape a GPU instance", async () => {
+    // With the bad-price types quarantined, "8 vcpus 128gb" otherwise picks
+    // g3.4xlarge (1× M60) — charging a user who asked for memory for a
+    // decade-old accelerator they cannot use.
+    const recs = await resolveAllShapes();
+    for (const rec of recs) {
+      if (rec!.shape.wantsGpu) continue;
+      expect(rec!.pick.instance.gpus ?? 0, `${rec!.shape.id} → ${rec!.pick.instance.instanceType}`).toBe(0);
+    }
+  });
+
+  it("gives GPU shapes an actual GPU", async () => {
+    const recs = await resolveAllShapes();
+    for (const rec of recs) {
+      if (!rec!.shape.wantsGpu) continue;
+      expect(rec!.pick.instance.gpus ?? 0, rec!.shape.id).toBeGreaterThan(0);
+    }
+  });
+
+  it("excludes the known-bad catalog prices", async () => {
+    // truffle-ts#39 (p6e-gb200.36xlarge at $0.2000/hr for 72× B200) and #42
+    // (p5.4xlarge at onDemandPrice 0) both WIN a naive price sort. A price-ranked
+    // picker is maximally exposed to a fabricated low price.
+    const recs = await resolveAllShapes();
+    const picked = recs.map((r) => r!.pick.instance.instanceType);
+    expect(picked).not.toContain("p6e-gb200.36xlarge");
+    expect(picked).not.toContain("p5.4xlarge");
+  });
+
+  it("keeps the cheap CPU shape genuinely cheap", async () => {
+    // A regression fence, not a spec. If a catalog change makes the beginner's
+    // first instance cost dollars per hour, that must fail here rather than
+    // surprise a first-time user.
+    const rec = (await resolveShape(GUIDED_SHAPES.find((s) => s.id === "small-analysis")!))!;
+    expect(rec.pricePerHour).toBeLessThan(0.5);
+  });
+});
+
+describe("resolveShape error and absence handling", () => {
+  it("returns undefined for a query that matches nothing", async () => {
+    const rec = await resolveShape(GUIDED_SHAPES[0]!, async () => []);
+    expect(rec).toBeUndefined();
+  });
+
+  it("propagates a finder failure instead of reporting no matches", async () => {
+    // The #63 invariant: an error must never be indistinguishable from an absence
+    // of data. "The catalog is broken" and "nothing matches your query" are
+    // different facts and the second one is a claim we can't support here.
+    await expect(
+      resolveShape(GUIDED_SHAPES[0]!, async () => {
+        throw new Error("catalog unreadable");
+      }),
+    ).rejects.toThrow("catalog unreadable");
+  });
+
+  it("falls back to the top match with an unknown price when nothing is priced", async () => {
+    const shape = GUIDED_SHAPES[0]!;
+    const rec = (await resolveShape(shape, async () => [
+      stub({ instanceType: "x1.unknown", onDemandPrice: undefined }),
+      stub({ instanceType: "x2.unknown", onDemandPrice: 0 }),
+    ]))!;
+    expect(rec.pick.instance.instanceType).toBe("x1.unknown");
+    // Reported as unknown, not invented and not zero: zero would render as free.
+    expect(rec.pricePerHour).toBeUndefined();
+    expect(rec.estimatedTotal).toBeUndefined();
+  });
+
+  it("treats a zero price as missing data", async () => {
+    const rec = (await resolveShape(GUIDED_SHAPES[0]!, async () => [
+      stub({ instanceType: "free.lie", onDemandPrice: 0 }),
+      stub({ instanceType: "real.one", onDemandPrice: 1.5 }),
+    ]))!;
+    // No EC2 type costs nothing per hour, so a zero can only be an artifact —
+    // and it would otherwise sort first and win.
+    expect(rec.pick.instance.instanceType).toBe("real.one");
+    expect(rec.pricePerHour).toBe(1.5);
+  });
+
+  it("still recommends a GPU box when a non-GPU shape has no CPU-only match", async () => {
+    // Narrowing to CPU-only must not turn into "no recommendation": an unexpected
+    // accelerator whose price we can show beats a dead card.
+    const cpuShape = GUIDED_SHAPES.find((s) => !s.wantsGpu)!;
+    const rec = (await resolveShape(cpuShape, async () => [
+      stub({ instanceType: "g9.big", onDemandPrice: 3, gpus: 1 }),
+    ]))!;
+    expect(rec.pick.instance.instanceType).toBe("g9.big");
+  });
+
+  it("marks an estimated price as estimated", async () => {
+    const rec = (await resolveShape(GUIDED_SHAPES[0]!, async () => [
+      stub({ instanceType: "e1.guess", onDemandPrice: 2, estimatedPrice: true }),
+    ]))!;
+    // An estimate presented as a price is the same defect as a fabricated one,
+    // just smaller — so the flag has to survive to the UI.
+    expect(rec.priceIsEstimate).toBe(true);
+  });
+});
+
+const QUARANTINED = new Set(["p6e-gb200.36xlarge", "p5.4xlarge"]);
+const isQuarantined = (r: FindResult) => QUARANTINED.has(r.instance.instanceType);
+const usable = (r: FindResult) =>
+  typeof r.instance.onDemandPrice === "number" && r.instance.onDemandPrice > 0;
+
+/** A minimal FindResult for the stubbed-finder cases. */
+function stub(over: Partial<FindResult["instance"]>): FindResult {
+  return {
+    instance: {
+      instanceType: "t0.test",
+      instanceFamily: "t0",
+      vcpus: 2,
+      memoryMib: 4096,
+      architecture: "x86_64",
+      ...over,
+    },
+    reasons: [],
+  } as FindResult;
+}

--- a/web/app/guided/shapes.ts
+++ b/web/app/guided/shapes.ts
@@ -1,0 +1,250 @@
+// The curated picker — guided mode's answer to "what are you doing?" when there
+// is no AI available.
+//
+// This is the load-bearing piece of progressive disclosure, and the dependency
+// direction is the point: **the simplest mode has the fewest dependencies.** It
+// needs truffle-ts's offline catalog and nothing else — no Bedrock, no model
+// access, no credentials, not even a network. advisor-ts, when present, replaces
+// the fixed list with a free-text question in the same slot; it does not become a
+// prerequisite for the beginner's entry point.
+//
+// The wrong way round would be to make guided mode the AI mode, because then the
+// path a first-time user takes is the one most likely to be broken — and it's the
+// one nobody developing the portal is ever in, so nobody would notice.
+//
+// Every shape here is a real truffle-ts query whose results were checked, not a
+// plausible-looking string. A query that returns nothing renders as an honest
+// "couldn't resolve this" rather than an empty card.
+
+import { find, type FindResult } from "@spore-host/truffle-ts";
+
+export interface GuidedShape {
+  id: string;
+  /** What the user recognises about their own work — not hardware vocabulary. */
+  label: string;
+  /** One line on what this is for, in the same register as the label. */
+  blurb: string;
+  /**
+   * The truffle-ts query. Phrased as MINIMUMS (truffle treats vcpus/memory as
+   * ">=") and then price-ranked, so the user gets the cheapest machine that
+   * clears the bar rather than the largest one that matches.
+   */
+  query: string;
+  /**
+   * A sensible time limit in hours, pre-filled so the beginner's launch has a
+   * cost ceiling without them having to think about TTL. Every guided launch gets
+   * one: an instance with no TTL is the single most expensive mistake available
+   * here, and "I forgot it was running" is the normal way it happens.
+   */
+  defaultTtlHours: number;
+  /**
+   * Whether this shape is actually asking for an accelerator.
+   *
+   * When false, GPU instances are excluded from the pick even if one is cheapest.
+   * This is not a preference — it's a correctness rule. `find("8 vcpus 128gb")`
+   * returns `g3.4xlarge` (16 vCPU, 128 GiB, 1×M60) as the cheapest priced match,
+   * so a user who asked for memory would be handed a decade-old GPU box and
+   * charged for an accelerator they never wanted and cannot use. Filtering to
+   * CPU-only yields `r7g.4xlarge` — the right answer to the question asked.
+   */
+  wantsGpu: boolean;
+}
+
+/**
+ * The curated list. Ordered cheapest-intent first, because the list is read top
+ * to bottom and the first plausible match tends to get picked.
+ *
+ * "I know what I need" is deliberately the last entry and is not a shape — it's
+ * the exit to standard mode. Guided mode must not be a trap.
+ */
+export const GUIDED_SHAPES: readonly GuidedShape[] = [
+  {
+    id: "small-analysis",
+    label: "A small analysis",
+    blurb: "Notebooks, scripts, modest data. The usual starting point.",
+    query: "4 vcpus 16gb",
+    defaultTtlHours: 4,
+    wantsGpu: false,
+  },
+  {
+    id: "lots-of-memory",
+    label: "Something that needs a lot of memory",
+    blurb: "A big table or genome that has to fit in RAM at once.",
+    query: "8 vcpus 128gb",
+    defaultTtlHours: 4,
+    wantsGpu: false,
+  },
+  {
+    id: "lots-of-cores",
+    label: "Lots of CPU cores",
+    blurb: "Work that splits across many cores on one machine.",
+    query: "64 vcpus",
+    defaultTtlHours: 4,
+    wantsGpu: false,
+  },
+  {
+    id: "gpu",
+    label: "Something with a GPU",
+    blurb: "Training, inference, or anything CUDA. Starts with a smaller GPU.",
+    // Named part rather than bare "gpu": bare "gpu" parses to an unknown token
+    // and "80gb" filters system RAM rather than VRAM (truffle-ts#37). An L4 is
+    // the right first GPU — real, current, and not $55/hr.
+    query: "nvidia l4",
+    defaultTtlHours: 2,
+    wantsGpu: true,
+  },
+  {
+    id: "big-gpu",
+    label: "A big GPU for training",
+    blurb: "H100-class. Expensive — check the hourly cost before you launch.",
+    query: "nvidia h100",
+    // Two hours, not four: at H100 prices the TTL is the cost control, and a
+    // forgotten instance here costs more per hour than most of the others cost
+    // per day.
+    defaultTtlHours: 2,
+    wantsGpu: true,
+  },
+] as const;
+
+/** A resolved recommendation: the shape, the machine, and what it costs. */
+export interface GuidedRecommendation {
+  shape: GuidedShape;
+  /** The cheapest catalog match that clears the shape's minimums. */
+  pick: FindResult;
+  /** $/hr for `pick`, or undefined when the catalog has no usable price. */
+  pricePerHour?: number;
+  /** pricePerHour × defaultTtlHours, when a price is known. */
+  estimatedTotal?: number;
+  /**
+   * True when the catalog flagged this price as an estimate rather than a pulled
+   * figure. Surfaced so the UI can mark it — an estimate presented as a price is
+   * the same defect as a fabricated one, just smaller.
+   */
+  priceIsEstimate: boolean;
+  /**
+   * How many types matched before we picked one. Shown so "we chose this" doesn't
+   * read as "this is the only option".
+   */
+  totalMatches: number;
+}
+
+/**
+ * Resolve one shape to a concrete recommendation.
+ *
+ * Returns undefined when the query matches nothing, so the caller can say so
+ * rather than render an empty card. Does NOT catch errors — a broken catalog is a
+ * failure and must not look like "no matches", which is a fact about the catalog's
+ * contents.
+ */
+export async function resolveShape(
+  shape: GuidedShape,
+  finder: typeof find = find,
+): Promise<GuidedRecommendation | undefined> {
+  const found = await finder(shape.query);
+  if (found.length === 0) return undefined;
+
+  const pick = cheapest(found, shape.wantsGpu) ?? found[0]!;
+  const price = usablePrice(pick);
+
+  return {
+    shape,
+    pick,
+    pricePerHour: price,
+    estimatedTotal: price != null ? price * shape.defaultTtlHours : undefined,
+    priceIsEstimate: pick.instance.estimatedPrice === true,
+    totalMatches: found.length,
+  };
+}
+
+/** Resolve every shape, preserving list order. */
+export async function resolveAllShapes(
+  finder: typeof find = find,
+  shapes: readonly GuidedShape[] = GUIDED_SHAPES,
+): Promise<Array<GuidedRecommendation | undefined>> {
+  return Promise.all(shapes.map((s) => resolveShape(s, finder)));
+}
+
+/**
+ * Instance types whose bundled catalog price is known-wrong, excluded from price
+ * ranking until the upstream data is fixed.
+ *
+ * A price-ranked picker is *maximally* exposed to a fabricated low price — a
+ * wrong-but-cheap entry doesn't just appear in the list, it **wins**. Both entries
+ * here are filed upstream:
+ *
+ * - `p6e-gb200.36xlarge` — listed at **$0.2000/hr** for 72×B200 (truffle-ts#39).
+ *   It wins the price sort for both `8 vcpus 128gb` and `64 vcpus`.
+ * - `p5.4xlarge` — `onDemandPrice: 0`, no `estimatedPrice` flag (truffle-ts#42).
+ *   Caught by `usablePrice` too; listed here so one lookup covers both defects.
+ *
+ * **A named quarantine, not a plausibility threshold** — and that choice was
+ * forced by the data. A per-vCPU floor cannot separate these: `t4g.nano` is
+ * legitimately $0.0021/vCPU while the bad B200 entry is $0.00139/vCPU, only 34%
+ * apart. Any threshold that catches the fabrication also rejects real cheap
+ * instances, and one that spares the cheap instances lets the fabrication through.
+ * So this is deliberately a short list tied to issue numbers, which stays honest
+ * as it goes stale: an entry that gets fixed upstream costs us one needlessly
+ * excluded type, whereas an invented threshold would silently mis-price the whole
+ * catalog.
+ *
+ * Delete each entry when its issue closes.
+ */
+const QUARANTINED_TYPES: ReadonlySet<string> = new Set([
+  "p6e-gb200.36xlarge", // truffle-ts#39
+  "p5.4xlarge", // truffle-ts#42
+]);
+
+/**
+ * A price we're willing to show, or undefined.
+ *
+ * Rejects zero as well as null. truffle-ts's bundled catalog currently carries
+ * `p5.4xlarge` with `onDemandPrice: 0` and no `estimatedPrice` flag
+ * (truffle-ts#42) — a 1×H100 machine claiming to be free. Zero is worse than
+ * absent because it *sorts first*: a naive "cheapest option" picker recommends
+ * the H100 box, at no charge, ahead of a $0.13 t4g. No EC2 type costs nothing per
+ * hour, so a zero can only be a missing-data artifact and is treated as one.
+ *
+ * Remove this guard when truffle-ts#42 lands, not before.
+ */
+function usablePrice(r: FindResult): number | undefined {
+  const p = r.instance.onDemandPrice;
+  return typeof p === "number" && p > 0 ? p : undefined;
+}
+
+/**
+ * The cheapest match with a usable price, honouring the shape's GPU intent.
+ *
+ * This re-sort is necessary, not redundant. truffle-ts treats `vcpus`/`memory` as
+ * MINIMUMS and ranks by its own size preference, so `find("4 vcpus 16gb")`
+ * returns `r8g.12xlarge` (48 vCPU, 384 GiB, **$2.83/hr**) first out of 194
+ * matches — while `t4g.xlarge` (exactly 4 vCPU / 16 GiB, **$0.13/hr**) is further
+ * down. Handing the user truffle's first result would quote them 21× the cost of
+ * the right answer for the thing they asked for.
+ *
+ * Returns undefined when nothing survives the filters, so the caller falls back to
+ * the top match and reports the price as unknown rather than inventing one.
+ */
+function cheapest(found: FindResult[], wantsGpu: boolean): FindResult | undefined {
+  let candidates = found.filter(
+    (r) => usablePrice(r) != null && !QUARANTINED_TYPES.has(r.instance.instanceType),
+  );
+
+  if (!wantsGpu) {
+    const cpuOnly = candidates.filter((r) => !r.instance.gpus);
+    // Only narrow if something remains: a shape that *only* matches GPU boxes
+    // should still get an answer, and "no recommendation" would be a worse
+    // outcome than an unexpected accelerator we can at least show the price of.
+    if (cpuOnly.length > 0) candidates = cpuOnly;
+  }
+
+  let best: FindResult | undefined;
+  let bestPrice = Infinity;
+  for (const r of candidates) {
+    const p = usablePrice(r)!;
+    if (p < bestPrice) {
+      best = r;
+      bestPrice = p;
+    }
+  }
+  return best;
+}

--- a/web/app/session.test.ts
+++ b/web/app/session.test.ts
@@ -1,0 +1,83 @@
+// Only the disclosure-level half of SessionController is covered here. The
+// credential half needs STS and is exercised by driving the real portal.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionController } from "./session.js";
+import { STORAGE_KEY } from "./disclosure.js";
+
+/** An in-memory Storage stand-in — happy-dom provides no localStorage. */
+function fakeStorage(initial?: Record<string, string>) {
+  const map = new Map(Object.entries(initial ?? {}));
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+  };
+}
+
+describe("SessionController disclosure level", () => {
+  let storage: ReturnType<typeof fakeStorage>;
+
+  beforeEach(() => {
+    storage = fakeStorage();
+  });
+
+  it("starts at guided for a first-time visitor", () => {
+    expect(new SessionController("us-east-1", storage).level).toBe("guided");
+  });
+
+  it("adopts a remembered level", () => {
+    expect(new SessionController("us-east-1", fakeStorage({ [STORAGE_KEY]: "expert" })).level).toBe(
+      "expert",
+    );
+  });
+
+  it("persists a change", () => {
+    const s = new SessionController("us-east-1", storage);
+    s.setLevel("standard");
+    expect(storage.getItem(STORAGE_KEY)).toBe("standard");
+    // A preference must survive a reload the way any preference does.
+    expect(new SessionController("us-east-1", storage).level).toBe("standard");
+  });
+
+  it("works with persistence disabled", () => {
+    const s = new SessionController("us-east-1", null);
+    s.setLevel("expert");
+    expect(s.level).toBe("expert");
+  });
+
+  it("notifies listeners on a change", () => {
+    const s = new SessionController("us-east-1", storage);
+    const fn = vi.fn();
+    s.onLevelChange(fn);
+    s.setLevel("expert");
+    expect(fn).toHaveBeenCalledWith("expert");
+  });
+
+  it("stays silent on a no-op change", () => {
+    // The shell re-mounts the current surface on every notification. Firing for a
+    // set-to-same would tear down and rebuild a surface — losing whatever the user
+    // had typed into it — for no change at all.
+    const s = new SessionController("us-east-1", storage);
+    const fn = vi.fn();
+    s.onLevelChange(fn);
+    s.setLevel(s.level);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes", () => {
+    const s = new SessionController("us-east-1", storage);
+    const fn = vi.fn();
+    s.onLevelChange(fn)();
+    s.setLevel("expert");
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the level across a sign-out", () => {
+    // An experienced user who signs out and back in must not be dropped into
+    // guided mode — which is why the level lives on the session rather than being
+    // rebuilt with the credentials.
+    const s = new SessionController("us-east-1", storage);
+    s.setLevel("expert");
+    s.clear();
+    expect(s.level).toBe("expert");
+  });
+});

--- a/web/app/session.ts
+++ b/web/app/session.ts
@@ -1,11 +1,16 @@
 // The portal's session: the signed-in user's AWS credentials (in memory only —
-// never localStorage), the account they resolve to, and an expiry timer that
-// warns/tears-down before the STS creds lapse. Surfaces subscribe via onExpiry.
+// never localStorage), the account they resolve to, an expiry timer that
+// warns/tears-down before the STS creds lapse, and the disclosure level.
+// Surfaces subscribe via onExpiry.
 import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
 import type { AwsCreds } from "@spore-host/spawn-ts/auth";
+import { type DisclosureLevel, loadLevel, saveLevel } from "./disclosure.js";
 
 /** Fires when creds are within the warn window or already expired. */
 export type ExpiryListener = (state: "warning" | "expired") => void;
+
+/** Fires when the disclosure level changes, so the shell can re-render. */
+export type LevelListener = (level: DisclosureLevel) => void;
 
 // Re-auth this long before the hard expiration so an in-flight action doesn't
 // die mid-request.
@@ -17,13 +22,48 @@ export class SessionController {
   private _region: string;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private expiryListeners = new Set<ExpiryListener>();
+  private levelListeners = new Set<LevelListener>();
+  // Read once at construction, not per-access: localStorage is synchronous and
+  // every surface render asks for the level.
+  private _level: DisclosureLevel;
 
-  constructor(region: string) {
+  /**
+   * `storage` is injected so the level's persistence is testable without a DOM
+   * shim's localStorage (happy-dom doesn't provide one) — and so a caller can pass
+   * null to opt out entirely. Defaults to `undefined`, which means "use
+   * localStorage if it exists", the browser path.
+   */
+  constructor(region: string, private storage?: Pick<Storage, "getItem" | "setItem"> | null) {
     this._region = region;
+    this._level = storage === undefined ? loadLevel() : loadLevel(storage);
   }
 
   get region(): string {
     return this._region;
+  }
+
+  /**
+   * How much of the portal to reveal. Lives here rather than on the Shell because
+   * it must survive a sign-out — an experienced user who signs out and back in
+   * should not be dropped into guided mode.
+   */
+  get level(): DisclosureLevel {
+    return this._level;
+  }
+
+  /** Set + persist the level and notify listeners. A no-op change stays silent. */
+  setLevel(level: DisclosureLevel): void {
+    if (level === this._level) return;
+    this._level = level;
+    if (this.storage === undefined) saveLevel(level);
+    else saveLevel(level, this.storage);
+    for (const fn of this.levelListeners) fn(level);
+  }
+
+  /** Subscribe to level changes; returns an unsubscribe fn. */
+  onLevelChange(fn: LevelListener): () => void {
+    this.levelListeners.add(fn);
+    return () => this.levelListeners.delete(fn);
   }
 
   get accountId(): string | null {

--- a/web/app/shell.ts
+++ b/web/app/shell.ts
@@ -5,6 +5,7 @@ import { surfaces, findSurface } from "./surfaces/registry.js";
 import type { PortalConfig, SurfaceContext, Disposable } from "./surfaces/types.js";
 import type { SessionController } from "./session.js";
 import { startSignIn } from "./auth/globus-login.js";
+import { isLevel, LEVEL_INFO, LEVELS } from "./disclosure.js";
 
 export class Shell {
   private navEl!: HTMLElement;
@@ -23,6 +24,18 @@ export class Shell {
     this.render();
     window.addEventListener("hashchange", () => void this.route());
     this.session.onExpiry((state) => this.showExpiry(state));
+    // A level change re-mounts the current surface. Surfaces therefore read
+    // ctx.level once at mount instead of subscribing — one update mechanism, and
+    // it reuses route()'s existing dispose/mount path.
+    //
+    // The control is re-rendered too, not just the surface: a surface can raise the
+    // level itself (guided mode's "I know what I need"), and without this the
+    // header would still read "Guided" while the user was looking at the standard
+    // view — the control lying about the one piece of state it exists to show.
+    this.session.onLevelChange(() => {
+      this.renderLevel();
+      void this.route({ remount: true });
+    });
     void this.route();
   }
 
@@ -36,6 +49,7 @@ export class Shell {
           <img class="portal-brand-img" src="../assets/brand/spore-host-logo-header.png"
                alt="spore.host" width="195" height="78">
         </a>
+        <div class="portal-level"></div>
         <div class="portal-account"></div>
       </header>
       <div class="portal-banner" hidden></div>
@@ -47,7 +61,40 @@ export class Shell {
     this.mainEl = this.root.querySelector(".portal-main")!;
     this.bannerEl = this.root.querySelector(".portal-banner")!;
     this.renderNav();
+    this.renderLevel();
     this.renderAccount();
+  }
+
+  /**
+   * The one portal-wide disclosure control, in the header beside the account block.
+   *
+   * A single visible control is the whole state — no per-surface toggles, which
+   * would leave the user unable to say what mode they were in. The blurb is
+   * rendered as the option's title so the choice explains itself; "Guided" alone
+   * doesn't tell a first-timer what they'd get.
+   */
+  private renderLevel(): void {
+    const el = this.root.querySelector<HTMLElement>(".portal-level")!;
+    const current = this.session.level;
+    const opts = LEVELS.map(
+      (l) =>
+        `<option value="${l}"${l === current ? " selected" : ""} title="${escapeHtml(
+          LEVEL_INFO[l].blurb,
+        )}">${escapeHtml(LEVEL_INFO[l].label)}</option>`,
+    ).join("");
+    el.innerHTML = `
+      <label class="portal-level-label" for="portal-level-select">Detail</label>
+      <select class="portal-level-select" id="portal-level-select"
+              title="${escapeHtml(LEVEL_INFO[current].blurb)}">${opts}</select>`;
+    const select = el.querySelector<HTMLSelectElement>(".portal-level-select")!;
+    select.addEventListener("change", () => {
+      // Guard rather than cast: a stale bookmarked value or a hand-edited DOM
+      // must not put an unknown string into the level, where every atLeast()
+      // comparison would silently read as below-guided.
+      if (!isLevel(select.value)) return;
+      this.session.setLevel(select.value);
+      select.title = LEVEL_INFO[select.value].blurb;
+    });
   }
 
   private renderNav(): void {
@@ -89,11 +136,18 @@ export class Shell {
     return id || surfaces[0]?.id || "";
   }
 
-  private async route(): Promise<void> {
+  /**
+   * Mount the surface for the current hash.
+   *
+   * `remount` forces a fresh mount of the *same* surface — needed when something
+   * the surface read at mount time (the disclosure level) has changed. Without it
+   * the `already mounted` short-circuit below would swallow the update.
+   */
+  private async route(opts: { remount?: boolean } = {}): Promise<void> {
     const id = this.currentId();
     const surface = findSurface(id);
     // Dispose the outgoing surface first.
-    if (this.current && this.current.id !== id) {
+    if (this.current && (this.current.id !== id || opts.remount)) {
       this.current.disposable.dispose();
       this.current = null;
     }
@@ -113,6 +167,7 @@ export class Shell {
     const ctx: SurfaceContext = {
       session: this.session,
       config: this.config,
+      level: this.session.level,
       navigate: (sid) => {
         location.hash = `#/${sid}`;
       },

--- a/web/app/surfaces/instances.ts
+++ b/web/app/surfaces/instances.ts
@@ -9,6 +9,8 @@ import { Dashboard, confirmDialog } from "@spore-host/spawn-ts/ui";
 // so they don't fight the portal's brand theme). Loaded with the instances chunk.
 import "@spore-host/spawn-ts/ui/style.css";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+import { atLeast } from "../disclosure.js";
+import { mountGuidedLaunch } from "../guided/launch.js";
 
 export const instancesSurface: ToolSurface = {
   id: "instances",
@@ -33,7 +35,31 @@ export const instancesSurface: ToolSurface = {
     });
     client.startMonitor();
 
+    // Guided mode replaces the Dashboard's launch form with the picker + a single
+    // confirmation, but keeps the instance list: a beginner still needs to see
+    // what's running and be able to stop it — hiding that would be the one
+    // simplification that costs real money.
+    //
+    // The Dashboard's own form is not conditionally rendered here (it lives inside
+    // the prebuilt component in spawn-ts). At `guided` we hide it via a class on
+    // the container and mount ours above; from `standard` up the Dashboard is
+    // untouched. Doing it in CSS rather than reaching into the component's DOM
+    // keeps this surface out of spawn-ts's internals.
+    const guided = !atLeast(ctx.level, "standard");
+
     const dashboard = new Dashboard(client, confirmDialog);
+    let disposeGuided: (() => void) | null = null;
+
+    if (guided) {
+      host.classList.add("guided-instances");
+      const panel = document.createElement("div");
+      host.appendChild(panel);
+      disposeGuided = mountGuidedLaunch(panel, {
+        client,
+        region: ctx.session.region,
+        onEscape: () => ctx.session.setLevel("standard"),
+      });
+    }
     host.appendChild(dashboard.el);
 
     // Tear the client's polling down if the session's creds expire.
@@ -45,6 +71,8 @@ export const instancesSurface: ToolSurface = {
       dispose() {
         offExpiry();
         client.stopMonitor();
+        disposeGuided?.();
+        host.classList.remove("guided-instances");
         dashboard.el.remove();
       },
     };

--- a/web/app/surfaces/truffle.test.ts
+++ b/web/app/surfaces/truffle.test.ts
@@ -1,0 +1,124 @@
+// Per-level rendering of the truffle surface. This is the surface where the
+// disclosure axis is most visible — guided replaces the query box entirely — so it
+// carries the assertions that the level is actually honoured rather than merely
+// passed around.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionController } from "../session.js";
+import type { PortalConfig, SurfaceContext } from "./types.js";
+import type { DisclosureLevel } from "../disclosure.js";
+import { truffleSurface } from "./truffle.js";
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+const config = { region: "us-east-1" } as PortalConfig;
+
+function ctxAt(level: DisclosureLevel, navigate = vi.fn()): SurfaceContext {
+  const session = new SessionController("us-east-1", null);
+  session.setLevel(level);
+  return { session, config, level, navigate };
+}
+
+describe("truffleSurface disclosure", () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+  });
+
+  it("shows the curated picker and NO query box at guided", async () => {
+    // A free-text query is the wrong first question: "gpu with 80gb for training"
+    // is only writable by someone who already knows what they need.
+    const d = await truffleSurface.mount(host, ctxAt("guided"));
+    await settle();
+    expect(host.querySelector(".truffle-q")).toBeNull();
+    expect(host.querySelectorAll(".guided-card").length).toBeGreaterThan(0);
+    d.dispose();
+  });
+
+  it("shows the query box and NO picker from standard up", async () => {
+    for (const level of ["standard", "expert"] as const) {
+      host.innerHTML = "";
+      const d = await truffleSurface.mount(host, ctxAt(level));
+      await settle();
+      expect(host.querySelector(".truffle-q"), level).not.toBeNull();
+      expect(host.querySelector(".guided-card"), level).toBeNull();
+      d.dispose();
+    }
+  });
+
+  it("raises the level rather than navigating on the guided escape", async () => {
+    // The user is saying "show me more", and the query box is one level up on this
+    // very surface — navigating elsewhere would answer a different question.
+    const navigate = vi.fn();
+    const ctx = ctxAt("guided", navigate);
+    const d = await truffleSurface.mount(host, ctx);
+    await settle();
+    host.querySelector<HTMLButtonElement>(".guided-escape")!.click();
+    expect(ctx.session.level).toBe("standard");
+    expect(navigate).not.toHaveBeenCalled();
+    d.dispose();
+  });
+
+  it("navigates to instances when a guided shape is chosen", async () => {
+    // This surface is auth-free by design, so there's no session to launch into —
+    // the instances surface mounts the same picker with a live client behind it.
+    const navigate = vi.fn();
+    const d = await truffleSurface.mount(host, ctxAt("guided", navigate));
+    await settle();
+    host.querySelector<HTMLButtonElement>(".guided-card")!.click();
+    expect(navigate).toHaveBeenCalledWith("instances");
+    d.dispose();
+  });
+
+  it("adds per-row detail only at expert", async () => {
+    // If expert rendered identically to standard, the third level would be a lie.
+    for (const [level, expected] of [
+      ["standard", 0],
+      ["expert", 1],
+    ] as const) {
+      host.innerHTML = "";
+      const d = await truffleSurface.mount(host, ctxAt(level));
+      await settle();
+      host.querySelector<HTMLInputElement>(".truffle-q")!.value = "nvidia h100";
+      host.querySelector<HTMLFormElement>(".truffle-form")!.dispatchEvent(
+        new Event("submit", { cancelable: true }),
+      );
+      await settle();
+      expect(host.querySelectorAll(".truffle-row").length, level).toBeGreaterThan(0);
+      expect(
+        host.querySelectorAll(".truffle-detail").length > 0,
+        `${level} expected detail: ${expected === 1}`,
+      ).toBe(expected === 1);
+      d.dispose();
+    }
+  });
+
+  it("states where an expert-level price came from", async () => {
+    // An estimate presented as a price is the same defect as a fabricated one, and
+    // expert is the level that can act on knowing which it is.
+    const d = await truffleSurface.mount(host, ctxAt("expert"));
+    await settle();
+    host.querySelector<HTMLInputElement>(".truffle-q")!.value = "nvidia h100";
+    host.querySelector<HTMLFormElement>(".truffle-form")!.dispatchEvent(
+      new Event("submit", { cancelable: true }),
+    );
+    await settle();
+    expect(host.querySelector(".truffle-detail")!.textContent).toMatch(/live AWS pull|estimate/);
+    d.dispose();
+  });
+
+  it("cleans up at every level", async () => {
+    for (const level of ["guided", "standard", "expert"] as const) {
+      host.innerHTML = "";
+      const d = await truffleSurface.mount(host, ctxAt(level));
+      await settle();
+      d.dispose();
+      // The shell disposes on every level change, so a leaked node here would
+      // stack up a duplicate surface each time the user touched the control.
+      expect(host.querySelector(".truffle-surface"), level).toBeNull();
+      expect(host.querySelector(".guided-picker"), level).toBeNull();
+    }
+  });
+});

--- a/web/app/surfaces/truffle.ts
+++ b/web/app/surfaces/truffle.ts
@@ -2,8 +2,15 @@
 // and auth-free. truffle-ts ships pure logic + a bundled catalog (no UI), so this
 // mounts a thin search box over find() and renders the ranked results + match
 // reasons. No AWS creds, no network — browse/compare before you ever sign in.
+//
+// Disclosure: at `guided` this surface is NOT a search box at all. A free-text
+// query is the wrong first question — "gpu with 80gb for training" is only
+// writable by someone who already knows what they need — so guided mode shows the
+// curated picker instead. `standard` and up get the query box.
 import { find, CATALOG_AS_OF, type FindResult } from "@spore-host/truffle-ts";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+import { atLeast, type DisclosureLevel } from "../disclosure.js";
+import { mountGuidedPicker } from "../guided/picker.js";
 
 export const truffleSurface: ToolSurface = {
   id: "truffle",
@@ -11,7 +18,10 @@ export const truffleSurface: ToolSurface = {
   accent: "--truffle",
   requiresAuth: false,
 
-  async mount(host: HTMLElement, _ctx: SurfaceContext): Promise<Disposable> {
+  async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+    if (!atLeast(ctx.level, "standard")) {
+      return mountGuided(host, ctx);
+    }
     const root = document.createElement("div");
     root.className = "truffle-surface";
     root.innerHTML = `
@@ -48,7 +58,7 @@ export const truffleSurface: ToolSurface = {
       try {
         const found = await find(query);
         if (mine !== seq) return; // a newer search superseded this one
-        renderResults(results, found);
+        renderResults(results, found, ctx.level);
       } catch (err) {
         if (mine !== seq) return;
         results.innerHTML = `<div class="truffle-status error">${escapeHtml((err as Error).message)}</div>`;
@@ -70,11 +80,39 @@ export const truffleSurface: ToolSurface = {
   },
 };
 
-function renderResults(host: HTMLElement, found: FindResult[]): void {
+/**
+ * Guided mode: the curated picker instead of a query box.
+ *
+ * Choosing a shape here can't launch anything — this surface is auth-free by
+ * design and there's no session to launch into — so it hands the user to the
+ * instances surface, which mounts the same picker with a live client behind it.
+ */
+function mountGuided(host: HTMLElement, ctx: SurfaceContext): Disposable {
+  const root = document.createElement("div");
+  root.className = "truffle-surface guided";
+  host.appendChild(root);
+
+  const dispose = mountGuidedPicker(root, {
+    onChoose: () => ctx.navigate("instances"),
+    // The escape hatch raises the level rather than navigating: the user is saying
+    // "show me more", and the query box is one level up on this very surface.
+    onEscape: () => ctx.session.setLevel("standard"),
+  });
+
+  return {
+    dispose() {
+      dispose();
+      root.remove();
+    },
+  };
+}
+
+function renderResults(host: HTMLElement, found: FindResult[], level: DisclosureLevel): void {
   if (found.length === 0) {
     host.innerHTML = `<div class="truffle-status">no matches — try relaxing the query</div>`;
     return;
   }
+  const expert = atLeast(level, "expert");
   const rows = found
     .slice(0, 50)
     .map((r) => {
@@ -83,6 +121,12 @@ function renderResults(host: HTMLElement, found: FindResult[]): void {
       const price = i.onDemandPrice != null ? `$${i.onDemandPrice.toFixed(4)}/hr${i.estimatedPrice ? "*" : ""}` : "—";
       const gpu = i.gpus ? `${i.gpus}× ${escapeHtml(i.gpuModel ?? "GPU")}` : "";
       const reasons = r.reasons.map((x) => `<li>${escapeHtml(x)}</li>`).join("");
+      // Expert gets the fields a capacity/topology decision actually turns on —
+      // physical cores vs threads (an MPI rank count is cores, not vCPUs), the GPU
+      // vendor + VRAM (a framework requirement, not a preference), the family for
+      // a quota lookup, and nested-virt support. They're in the catalog already;
+      // standard hides them because they're noise to someone comparing two boxes.
+      const detail = expert ? `<dl class="truffle-detail">${expertFields(r)}</dl>` : "";
       return `
         <div class="truffle-row">
           <div class="truffle-row-head">
@@ -91,11 +135,37 @@ function renderResults(host: HTMLElement, found: FindResult[]): void {
             <span class="truffle-price">${price}</span>
           </div>
           <ul class="truffle-reasons">${reasons}</ul>
+          ${detail}
         </div>`;
     })
     .join("");
   const note = found.some((r) => r.instance.estimatedPrice) ? `<div class="truffle-note">* estimated price (type not in the live-pulled region)</div>` : "";
   host.innerHTML = `<div class="truffle-count">${found.length} match${found.length === 1 ? "" : "es"}${found.length > 50 ? " (showing 50)" : ""}</div>${rows}${note}`;
+}
+
+/**
+ * The expert-only field list for one result.
+ *
+ * Only fields the catalog actually carries are rendered. An absent field is
+ * omitted rather than shown as "—" or 0: `physicalCores` is genuinely unknown for
+ * some entries, and printing a zero there would state something false about the
+ * hardware to the one user most likely to act on it.
+ */
+function expertFields(r: FindResult): string {
+  const i = r.instance;
+  const rows: Array<[string, string]> = [["family", i.instanceFamily]];
+  if (i.physicalCores != null) rows.push(["physical cores", String(i.physicalCores)]);
+  if (i.threadsPerCore != null) rows.push(["threads/core", String(i.threadsPerCore)]);
+  rows.push(["memory", `${i.memoryMib} MiB`]);
+  if (i.gpuManufacturer) rows.push(["GPU vendor", i.gpuManufacturer]);
+  if (i.gpuMemoryMib != null) rows.push(["GPU memory", `${i.gpuMemoryMib} MiB (total)`]);
+  if (i.nestedVirt != null) rows.push(["nested virt", i.nestedVirt ? "yes" : "no"]);
+  // Say where the price came from. An estimate presented as a price is the same
+  // defect as a fabricated one, and expert is the level that can act on knowing.
+  rows.push(["price source", i.estimatedPrice ? "hand seed (estimate)" : "live AWS pull"]);
+  return rows
+    .map(([k, v]) => `<dt>${escapeHtml(k)}</dt><dd>${escapeHtml(v)}</dd>`)
+    .join("");
 }
 
 function escapeHtml(s: string): string {

--- a/web/app/surfaces/types.ts
+++ b/web/app/surfaces/types.ts
@@ -2,12 +2,23 @@
 // up in the portal as one ToolSurface. Adding a tool later = write one
 // surfaces/<tool>.ts and append it to the registry — the shell never changes.
 import type { SessionController } from "../session.js";
+import type { DisclosureLevel } from "../disclosure.js";
 
 export interface SurfaceContext {
   /** The signed-in session (creds in memory, accountId, expiry). */
   session: SessionController;
   /** Build-time + URL-override config (region, role ARN, client id…). */
   config: PortalConfig;
+  /**
+   * How much to reveal, from "guided" out to "expert". Passed on the context that
+   * every surface already receives, so adding disclosure changed no surface
+   * signature. Compare it with `atLeast()` from ../disclosure.js rather than
+   * `===`, so a future fourth level doesn't silently drop out of every check.
+   *
+   * The shell re-mounts the current surface when this changes, so a surface reads
+   * it once at mount and need not subscribe.
+   */
+  level: DisclosureLevel;
   /** Navigate to another surface by id (updates the hash router). */
   navigate(surfaceId: string): void;
 }

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -547,6 +547,11 @@ footer {
    the width follows the intrinsic ratio. width/height stay on the <img> so the
    aspect box is reserved before the image loads (no layout shift). */
 .portal-brand-img { height: 26px; width: auto; display: block; }
+/* The disclosure control. margin-left:auto pulls it out of the header's
+   space-between centre and parks it beside the account block — the two things
+   that say "who you are" and "how much you're shown" belong together. */
+.portal-level { display: flex; align-items: center; gap: 0.4rem; margin-left: auto; margin-right: 1.25rem; font-size: 0.85rem; color: var(--text-muted); }
+.portal-level-select { font: inherit; padding: 0.25rem 0.4rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
 .portal-account { display: flex; align-items: center; gap: 0.75rem; font-size: 0.9rem; color: var(--text-muted); }
 .portal-account .acct b { color: var(--text); }
 .portal-account button, .portal-gate button, .portal-banner button {
@@ -775,3 +780,63 @@ footer {
 .lagotto-match-next a { color: var(--lagotto); font-weight: 600; }
 .lagotto-log { list-style: none; margin: 1rem 0 0; padding: 0; font-family: ui-monospace, monospace; font-size: 0.8rem; color: var(--text-muted); max-height: 260px; overflow: auto; }
 .lagotto-log li { padding: 0.2rem 0; border-bottom: 1px solid var(--border); }
+
+/* ── Guided mode (app/guided/) — the "anyone could use this" end of the
+   disclosure axis. Bigger targets, fewer of them, and the cost always visible:
+   the one thing a first-time user must not be able to miss is what it costs and
+   that it stops by itself. ── */
+.guided-picker, .guided-launch { max-width: 760px; }
+.guided-hint { color: var(--text-muted); font-size: 0.95rem; max-width: 56ch; }
+.guided-cards { display: grid; gap: 0.75rem; margin: 1.25rem 0; }
+.guided-card {
+  display: grid; gap: 0.25rem; text-align: left; font: inherit; cursor: pointer;
+  padding: 0.9rem 1.1rem; border-radius: var(--radius);
+  border: 1px solid var(--border-strong); background: var(--bg-card); color: var(--text);
+}
+.guided-card:hover:not(:disabled) { border-color: var(--spawn); }
+.guided-card:disabled { cursor: default; }
+.guided-card.loading, .guided-card.unresolved { opacity: 0.7; }
+.guided-card-label { font-weight: 700; font-size: 1.05rem; }
+.guided-card-blurb { color: var(--text-muted); font-size: 0.9rem; }
+.guided-card-machine { font-size: 0.85rem; color: var(--text-muted); margin-top: 0.3rem; }
+.guided-card-machine b { font-family: ui-monospace, monospace; color: var(--text); font-weight: 600; }
+.guided-card-cost { display: block; margin-top: 0.15rem; font-variant-numeric: tabular-nums; }
+/* An unknown or errored price is called out rather than left to blend in — a
+   missing number that looks like a normal one is the failure mode this whole
+   surface is trying to avoid. */
+.guided-card-cost.unknown, .guided-card.errored .guided-card-machine { color: var(--accent-red); }
+.guided-escape {
+  font: inherit; cursor: pointer; padding: 0.4rem 0; border: 0; background: none;
+  color: var(--text-muted); text-decoration: underline;
+}
+.guided-escape:hover { color: var(--spawn); }
+
+.guided-confirm { max-width: 620px; }
+.guided-facts { display: grid; grid-template-columns: auto 1fr; gap: 0.35rem 1rem; margin: 1rem 0; font-size: 0.9rem; }
+.guided-facts dt { color: var(--text-muted); }
+.guided-facts dd { margin: 0; }
+.guided-cost { font-size: 1.1rem; }
+.guided-cost b { font-variant-numeric: tabular-nums; }
+.guided-cost.unknown { font-size: 0.95rem; color: var(--accent-red); }
+.guided-reassure { color: var(--text-muted); font-size: 0.85rem; }
+.guided-actions { display: flex; gap: 0.75rem; align-items: center; margin-top: 1.25rem; }
+.guided-actions button { font: inherit; cursor: pointer; padding: 0.55rem 1.2rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+.guided-go { border-color: var(--spawn) !important; background: var(--spawn) !important; color: #fff !important; font-weight: 600; }
+.guided-actions button:disabled { opacity: 0.6; cursor: default; }
+.guided-msg { margin-top: 0.75rem; font-size: 0.9rem; color: var(--text-muted); min-height: 1.2em; }
+.guided-msg.ok { color: var(--spawn); }
+.guided-msg.error { color: var(--accent-red); }
+
+/* Guided instances: hide the Dashboard's own launch/sweep/queue forms — our
+   picker stands in for them — but KEEP the instance list, meters and log. A
+   beginner who can start an instance and not see or stop it is the one
+   simplification that costs real money. Done as a class on the host rather than
+   by reaching into the prebuilt component's DOM, so spawn-ts owns its markup. */
+.guided-instances .dash-section.launch,
+.guided-instances .dash-section.sweep,
+.guided-instances .dash-section.queue { display: none; }
+/* Expert-only detail on a truffle row: the fields a capacity or topology decision
+   turns on, hidden below expert because they're noise when comparing two boxes. */
+.truffle-detail { display: grid; grid-template-columns: auto 1fr; gap: 0.15rem 0.75rem; margin: 0.5rem 0 0; padding-top: 0.5rem; border-top: 1px solid var(--border); font-size: 0.8rem; }
+.truffle-detail dt { color: var(--text-muted); }
+.truffle-detail dd { margin: 0; font-family: ui-monospace, monospace; }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,8 +14,10 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "happy-dom": "^20.11.1",
         "typescript": "^5.6.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@aws-sdk/client-ec2": {
@@ -828,6 +830,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -1354,6 +1363,109 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -1369,10 +1481,118 @@
         "addons/*"
       ]
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -1417,6 +1637,26 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1450,6 +1690,49 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/happy-dom": {
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -1467,6 +1750,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -1563,6 +1863,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1572,6 +1879,34 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -1588,6 +1923,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1688,6 +2053,1151 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,8 @@
     "build": "vite build && node scripts/copy-static.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "deploy": "npm run build && ./deploy.sh"
   },
   "dependencies": {
@@ -18,7 +20,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "happy-dom": "^20.11.1",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,7 @@
-import { defineConfig } from "vite";
+// vitest/config re-exports Vite's own defineConfig with the `test` key typed, so
+// one config serves both the build and the test run (the convention the three
+// -ts libraries already use).
+import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 
 // Vite builds ONLY the portal SPA (app/) — it's the sole page with a module
@@ -17,5 +20,12 @@ export default defineConfig({
     rollupOptions: {
       input: { app: resolve(__dirname, "app/index.html") },
     },
+  },
+  test: {
+    // happy-dom, not jsdom: the portal's own tests only need document/localStorage
+    // and it's what the three -ts libraries already use, so one DOM shim across
+    // the whole stack.
+    environment: "happy-dom",
+    include: ["app/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
Phase 4. One portal-wide **Detail** control in the header, three ordered levels,
from something anyone could use out to the full cockpit.

| level | what you get |
|---|---|
| **guided** | "What are you doing?" → a short curated list, machine + cost + shutdown chosen for you |
| **standard** | the search box, the full launch form (type, spot, TTL), the instance list |
| **expert** | + per-result physical cores vs threads, GPU vendor + VRAM, family, nested virt, and the **price source** |

The level is **global**, not per-surface — a per-surface level would silently
change meaning as the user navigated. It lives on `SessionController`
(localStorage-backed, so it survives sign-out: an expert who signs out must not
be dropped into guided) and reaches surfaces via the `SurfaceContext` seam they
already receive, so **no surface signature changes**.

## Guided mode's defining property is that it has the fewest dependencies

No AI, no model access, no credentials, no network. It resolves a curated 5-shape
list against truffle-ts's **bundled** catalog, which ships with the page.

This ordering is the whole point. If the simplest mode depended on a backend, the
one path a first-time user takes would be the one most likely to be broken — and
the one nobody developing the portal is ever in, so nobody would notice.
advisor-ts, when present, **replaces the fixed list in the same slot**; it is
never a prerequisite.

## Three correctness properties the picker enforces — none cosmetic

- **Re-sort by price.** truffle treats vcpus/memory as *minimums* and ranks by its
  own size preference, so `find("4 vcpus 16gb")` returns `r8g.12xlarge`
  ($2.83/hr) ahead of `t4g.xlarge` ($0.1344/hr). Taking the top hit would quote
  **21× the real cost**.
- **Never hand a non-GPU shape a GPU.** `8 vcpus 128gb` otherwise matches
  `g3.4xlarge`, charging a memory-seeking user for an unusable 2016 accelerator.
- **Quarantine two catalog entries by name** — truffle-ts#39 (fabricated
  $0.20/hr on `p6e-gb200.36xlarge`) and truffle-ts#42 (`onDemandPrice: 0` on
  `p5.4xlarge`). A per-vCPU plausibility *floor* cannot separate them:
  `t4g.nano` is legitimately $0.0021/vCPU vs the bad B200's $0.00139, only 34%
  apart. So this is a named list with issue links — removable when those land —
  rather than a threshold that would also reject real data. Zero is treated as
  missing **because zero sorts first**.

Cost is quoted as the **total for the run** ("about $0.54 for 4 hours"), not the
hourly rate: an hourly figure isn't something a first-timer can act on. An
unknown price says so rather than rendering `$0.00`.

## Cost safety

Every guided launch carries a TTL (4h CPU / 2h GPU) and `spot: false`. The
confirmation screen states the shutdown is enforced **on the machine**, so it
holds if the tab closes — a user must not be left guessing whether their instance
now runs forever or was already killed.

Guided hides the launch/sweep/queue forms but **keeps the instance list**. Being
able to start an instance without being able to see or stop it is the one
simplification that costs real money.

## Errors stay distinguishable from absent data

The #63 invariant, applied throughout: a thrown `find()` renders `.errored` with
the real message; an empty result renders `.unresolved` with "no machine".
Different classes, different words, because they call for different user action.
Same on launch failure — a guided user is the least able to diagnose a vague
error, and `VcpuLimitExceeded` vs an IAM denial read completely differently.

Expert's `price source` ("hand seed (estimate)" vs "live AWS pull") is the same
principle: an estimate presented as a price is the same defect as a fabricated
one. Absent fields are omitted, never rendered as `0`.

## A real bug this caught, found only by driving the portal

After guided mode's escape hatch raised the level programmatically, the header
select still read **Guided** while the standard view was showing — the control
lying about the one piece of state it exists to show. `onLevelChange` now
re-renders the control as well as remounting the surface.

## Verification

**66 tests** across 6 files; `npx tsc --noEmit` clean; `vitepress build` clean
(it fails on dead links, so both new doc links resolve).

`shapes.test.ts` deliberately runs against the **real bundled catalog** rather
than a fixture — a fixture would have passed while the shipped portal quoted the
fabricated B200 price.

And verified live, which is what the plan asked for: dev server driven with
Playwright at all three levels, **signed out, with no credentials and the advisor
absent**, confirming the curated picker still returns real instance types and real
prices:

```
default level: guided
  [ready] A small analysis        t4g.xlarge — 4 vCPU · 16 GiB      about $0.54 for 4 hours
  [ready] …a lot of memory        r7g.4xlarge — 16 vCPU · 128 GiB   about $3.43 for 4 hours
  [ready] Lots of CPU cores       hpc7g.16xlarge — 64 vCPU · 128 GiB about $6.73 for 4 hours
  [ready] Something with a GPU    g6.xlarge — 4 vCPU · 16 GiB · 1× L4 about $1.61 for 2 hours
  [ready] A big GPU for training  p5.48xlarge — 192 vCPU · 8× H100  about $110.08 for 2 hours
query box present at guided? false     after escape → level: standard
expert on truffle → query box? true, picker? false, detail blocks 8/8
console errors: none
```

Docs: `docs/guides/portal-detail-levels.md`, in **Common Workflows** beside
"Finding the right instance" — its browser counterpart, same catalog, same
queries.