### PR TITLE
ci(web): gate the portal on its own tests, pre-merge and pre-deploy

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -41,11 +41,20 @@ jobs:
         working-directory: web
         run: npm ci
 
-      # Typecheck before deploying — the portal's only PR gate today. A type
-      # error here means the bundle is wrong; better to fail than ship it.
+      # Typecheck before deploying. A type error here means the bundle is wrong;
+      # better to fail than ship it. web-ci.yml now gates this pre-merge too, so
+      # this is the second line of defence rather than the only one.
       - name: Typecheck portal
         working-directory: web
         run: npm run typecheck
+
+      # Test before deploying. This step was missing entirely: the portal's suite
+      # ran on developer machines and nowhere else, so a regression in the guided
+      # launch defaults (TTL present, spot: false) would deploy to spore.host
+      # unnoticed (spore-host#506).
+      - name: Test portal
+        working-directory: web
+        run: npm test
 
       # Emits web/dist: hashed portal SPA under app/ + assets/, marketing pages
       # and css/assets/cloudformation copied verbatim (scripts/copy-static.mjs).

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,74 @@
+name: Web CI
+
+# PR gate for the portal (web/). Before this workflow web/ had NO pre-merge gate:
+# ci.yml covers the Lambda modules and the docs build, and deploy-site.yaml runs
+# typecheck + build only AFTER merge, on its way to publishing to S3. So a broken
+# portal merged green and the failure surfaced during the deploy — or not at all,
+# since deploy-site.yaml never ran `npm test` either (fixed there too).
+#
+# Its own file rather than a job in ci.yml because GitHub Actions has no per-job
+# `paths:` filter, and ci.yml must keep running on Go/docs PRs. Same split as
+# deploy-site.yaml.
+#
+# Lives here rather than being folded into #505 so the disclosure work wasn't held
+# up behind a new workflow (spore-host#506).
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  web-tests:
+    name: Portal typecheck + test + build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      # Node 22 to match deploy-site.yaml — the gate and the deploy must build on
+      # the same runtime, or a version-specific failure escapes the gate.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: web
+        run: npm run typecheck
+
+      # The suite that motivated this workflow. Several of these tests guard
+      # defects that are invisible on inspection and expensive in production:
+      # guided/shapes.test.ts runs against the REAL bundled truffle-ts catalog
+      # (deliberately, not a fixture — a fixture would have passed while the
+      # shipped portal quoted a fabricated $0.20/hr for a 72xB200), and
+      # guided/launch.test.ts asserts every guided launch carries a TTL and
+      # spot: false. A regression in the latter bills someone real money and no
+      # amount of clicking reveals it before the invoice.
+      #
+      # This is also the job that catches a truffle-ts version bump breaking the
+      # portal — the change most likely to break these tests, and exactly the kind
+      # that gets merged on a green tick.
+      - name: Test
+        working-directory: web
+        run: npm test
+
+      # A passing suite over a bundle that doesn't build still ships nothing. The
+      # build is cheap here and it's what deploy-site.yaml will run on main.
+      - name: Build
+        working-directory: web
+        run: npm run build


### PR DESCRIPTION
Closes #506.

`web/` had **no pre-merge gate at all**. `ci.yml` covers the Lambda modules and the docs build; `deploy-site.yaml` ran typecheck + build only **after** merge, on its way to publishing to S3. And `deploy-site.yaml` never ran `npm test` either — so the 66 tests #505 added ran on developer machines and nowhere else, and a regression both **merged green and deployed to spore.host**.

That second hole is the one the issue didn't anticipate. #506 asked for a PR gate; while adding it I found the deploy path was equally uncovered, so both are fixed here.

## Changes

- **New `.github/workflows/web-ci.yml`** — typecheck + test + build on any PR touching `web/**`. Its own file rather than a job in `ci.yml` because Actions has no per-job `paths:` filter and `ci.yml` must keep running on Go and docs PRs — the same split `deploy-site.yaml` already uses. Node 22 to match the deploy, so a version-specific failure can't pass the gate and then fail the deploy.
- **`deploy-site.yaml` gains a `Test portal` step**, so the deploy path is covered too if a push reaches `main` another way.

## Why gate on this suite specifically

Parts of it guard defects that are invisible on inspection and expensive in production:

- `guided/shapes.test.ts` runs against the **real bundled truffle-ts catalog**, not a fixture — deliberately, because a fixture would have passed while the shipped portal quoted a fabricated $0.20/hr for a 72×B200.
- `guided/launch.test.ts` asserts every guided launch carries a TTL and `spot: false`. A regression there bills someone real money and nothing reveals it before the invoice.

It also catches the change most likely to break those tests: **a truffle-ts version bump** — exactly the kind of PR that gets merged on a green tick. That's not hypothetical; truffle-ts v0.5.0 is queued right now (spore-host/truffle-ts#44), and bumping the portal's pin is the next change to `web/`.

## Verification

Ran the three steps locally exactly as the workflow will:

```
npm run typecheck   → clean
npm test            → 66 passed (6 files)
npm run build       → dist/ emitted, ✓ built in 7.72s
```