### PR TITLE
chore(web): truffle-ts 0.5.0 — drop the price quarantine, restore the GPU example

### DIFF
--- a/web/app/guided/shapes.test.ts
+++ b/web/app/guided/shapes.test.ts
@@ -90,17 +90,20 @@ describe("resolveShape against the real bundled catalog", () => {
     const rawFirstPrice = raw[0]!.instance.onDemandPrice;
 
     expect(rec.pricePerHour).toBeLessThanOrEqual(rawFirstPrice ?? Infinity);
-    // And it must beat every other priced, non-quarantined candidate.
-    const better = raw.filter(
-      (r) => usable(r) && r.instance.onDemandPrice! < rec.pricePerHour! && !isQuarantined(r),
-    );
+    // And it must beat every other priced candidate. This filter carried a
+    // `!isQuarantined(r)` exemption until truffle-ts 0.5.0 fixed the two
+    // fabricated prices (truffle-ts#39, #42); with the data correct, the
+    // assertion holds over the whole result set, which is the stronger claim.
+    const better = raw.filter((r) => usable(r) && r.instance.onDemandPrice! < rec.pricePerHour!);
     expect(better.map((r) => r.instance.instanceType)).toEqual([]);
   });
 
   it("does not hand a non-GPU shape a GPU instance", async () => {
-    // With the bad-price types quarantined, "8 vcpus 128gb" otherwise picks
-    // g3.4xlarge (1× M60) — charging a user who asked for memory for a
-    // decade-old accelerator they cannot use.
+    // Without the CPU-only narrowing, "8 vcpus 128gb" picks g3.4xlarge (1× M60)
+    // — charging a user who asked for memory for a decade-old accelerator they
+    // cannot use. truffle-ts 0.5.0 makes this MORE likely, not less: g3 now
+    // carries its real $1.14 rather than the old $0.80 guess, but it's still the
+    // cheapest thing matching that query.
     const recs = await resolveAllShapes();
     for (const rec of recs) {
       if (rec!.shape.wantsGpu) continue;
@@ -195,8 +198,6 @@ describe("resolveShape error and absence handling", () => {
   });
 });
 
-const QUARANTINED = new Set(["p6e-gb200.36xlarge", "p5.4xlarge"]);
-const isQuarantined = (r: FindResult) => QUARANTINED.has(r.instance.instanceType);
 const usable = (r: FindResult) =>
   typeof r.instance.onDemandPrice === "number" && r.instance.onDemandPrice > 0;
 

--- a/web/app/guided/shapes.ts
+++ b/web/app/guided/shapes.ts
@@ -165,46 +165,29 @@ export async function resolveAllShapes(
 }
 
 /**
- * Instance types whose bundled catalog price is known-wrong, excluded from price
- * ranking until the upstream data is fixed.
- *
- * A price-ranked picker is *maximally* exposed to a fabricated low price — a
- * wrong-but-cheap entry doesn't just appear in the list, it **wins**. Both entries
- * here are filed upstream:
- *
- * - `p6e-gb200.36xlarge` — listed at **$0.2000/hr** for 72×B200 (truffle-ts#39).
- *   It wins the price sort for both `8 vcpus 128gb` and `64 vcpus`.
- * - `p5.4xlarge` — `onDemandPrice: 0`, no `estimatedPrice` flag (truffle-ts#42).
- *   Caught by `usablePrice` too; listed here so one lookup covers both defects.
- *
- * **A named quarantine, not a plausibility threshold** — and that choice was
- * forced by the data. A per-vCPU floor cannot separate these: `t4g.nano` is
- * legitimately $0.0021/vCPU while the bad B200 entry is $0.00139/vCPU, only 34%
- * apart. Any threshold that catches the fabrication also rejects real cheap
- * instances, and one that spares the cheap instances lets the fabrication through.
- * So this is deliberately a short list tied to issue numbers, which stays honest
- * as it goes stale: an entry that gets fixed upstream costs us one needlessly
- * excluded type, whereas an invented threshold would silently mis-price the whole
- * catalog.
- *
- * Delete each entry when its issue closes.
- */
-const QUARANTINED_TYPES: ReadonlySet<string> = new Set([
-  "p6e-gb200.36xlarge", // truffle-ts#39
-  "p5.4xlarge", // truffle-ts#42
-]);
-
-/**
  * A price we're willing to show, or undefined.
  *
- * Rejects zero as well as null. truffle-ts's bundled catalog currently carries
- * `p5.4xlarge` with `onDemandPrice: 0` and no `estimatedPrice` flag
- * (truffle-ts#42) — a 1×H100 machine claiming to be free. Zero is worse than
- * absent because it *sorts first*: a naive "cheapest option" picker recommends
- * the H100 box, at no charge, ahead of a $0.13 t4g. No EC2 type costs nothing per
- * hour, so a zero can only be a missing-data artifact and is treated as one.
+ * Rejects zero as well as null, and both halves still earn their keep:
  *
- * Remove this guard when truffle-ts#42 lands, not before.
+ * - **Null** is the normal case for a type with no on-demand row at all — since
+ *   truffle-ts 0.5.0, `p6e-gb200.36xlarge` and `p5e.48xlarge` carry no price
+ *   rather than a guessed one, so a price-ranked picker must skip them instead of
+ *   ranking them at 0.
+ * - **Zero** is defence in depth. truffle-ts now refuses to write a non-positive
+ *   price (truffle-ts#42), so this shouldn't fire — but a zero is the single most
+ *   damaging wrong price here, because it *sorts first*: a naive "cheapest option"
+ *   picker recommends an H100 box, at no charge, ahead of a $0.13 t4g. That's a
+ *   one-line guard against an upstream regression that no amount of clicking would
+ *   reveal, so it stays.
+ *
+ * This replaced a named quarantine of `p6e-gb200.36xlarge` (fabricated at
+ * $0.2000/hr for 72×B200) and `p5.4xlarge` (`onDemandPrice: 0`), removed once
+ * truffle-ts#39 and #42 landed in 0.5.0. Worth recording *why* that list was
+ * names rather than a plausibility threshold: no per-vCPU floor could separate
+ * those entries from real cheap instances — `t4g.nano` is legitimately
+ * $0.0021/vCPU against the bad B200's $0.00139, only 34% apart — so any threshold
+ * strict enough to catch the fabrication also rejected honest bargains. If a
+ * future bad price shows up, name it again; don't invent a threshold.
  */
 function usablePrice(r: FindResult): number | undefined {
   const p = r.instance.onDemandPrice;
@@ -225,9 +208,7 @@ function usablePrice(r: FindResult): number | undefined {
  * the top match and reports the price as unknown rather than inventing one.
  */
 function cheapest(found: FindResult[], wantsGpu: boolean): FindResult | undefined {
-  let candidates = found.filter(
-    (r) => usablePrice(r) != null && !QUARANTINED_TYPES.has(r.instance.instanceType),
-  );
+  let candidates = found.filter((r) => usablePrice(r) != null);
 
   if (!wantsGpu) {
     const cpuOnly = candidates.filter((r) => !r.instance.gpus);

--- a/web/app/surfaces/lagotto.ts
+++ b/web/app/surfaces/lagotto.ts
@@ -166,7 +166,7 @@ export const lagottoSurface: ToolSurface = {
           <div class="lagotto-match-head">
             <span class="lagotto-match-type">${escapeHtml(m.instanceType)}</span>
             <span class="lagotto-match-kind">${spot ? "Spot" : "on-demand"}</span>
-            <span class="lagotto-match-price">$${m.price.toFixed(4)}/hr</span>
+            <span class="lagotto-match-price">${m.price != null ? `$${m.price.toFixed(4)}/hr` : "price unknown"}</span>
           </div>
           <dl class="lagotto-match-meta">
             <dt>Region</dt><dd>${escapeHtml(m.region)}</dd>

--- a/web/app/surfaces/truffle.test.ts
+++ b/web/app/surfaces/truffle.test.ts
@@ -109,6 +109,53 @@ describe("truffleSurface disclosure", () => {
     d.dispose();
   });
 
+  // Every example in the hint must return results. `gpu with 80gb for training`
+  // shipped here while it silently returned CPU-only Graviton instances
+  // (truffle-ts#37/#38) — an example query is the first thing a new user runs, so
+  // a broken one is worse than none: it teaches them the tool doesn't work. It was
+  // pulled, fixed upstream in 0.5.0, and restored, so this drives each example
+  // through the real surface rather than trusting the version bump.
+  //
+  // Extracted from the hint rather than hardcoded, so adding an example to the copy
+  // without checking it fails here instead of in front of a user.
+  it("returns results for every example query in the hint", async () => {
+    const d = await truffleSurface.mount(host, ctxAt("standard"));
+    await settle();
+    const examples = [...host.querySelectorAll(".truffle-hint code")].map((c) => c.textContent!);
+    expect(examples.length).toBeGreaterThan(0);
+
+    for (const q of examples) {
+      host.querySelector<HTMLInputElement>(".truffle-q")!.value = q;
+      host.querySelector<HTMLFormElement>(".truffle-form")!.dispatchEvent(
+        new Event("submit", { cancelable: true }),
+      );
+      await settle();
+      expect(host.querySelectorAll(".truffle-row").length, `example "${q}" matched nothing`)
+        .toBeGreaterThan(0);
+    }
+    d.dispose();
+  });
+
+  it("does not answer a GPU query with CPU-only instances", async () => {
+    // The precise shape of truffle-ts#37: the query parsed, ran, and returned a
+    // ranked list of r8g/c7g boxes with no accelerator at all. It looked like a
+    // working search, which is why it survived. A count assertion alone would
+    // still pass on that output.
+    const d = await truffleSurface.mount(host, ctxAt("standard"));
+    await settle();
+    host.querySelector<HTMLInputElement>(".truffle-q")!.value = "gpu with 80gb for training";
+    host.querySelector<HTMLFormElement>(".truffle-form")!.dispatchEvent(
+      new Event("submit", { cancelable: true }),
+    );
+    await settle();
+    const rows = [...host.querySelectorAll(".truffle-row")];
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.textContent, `${row.textContent} has no GPU`).toMatch(/gpu/i);
+    }
+    d.dispose();
+  });
+
   it("cleans up at every level", async () => {
     for (const level of ["guided", "standard", "expert"] as const) {
       host.innerHTML = "";

--- a/web/app/surfaces/truffle.ts
+++ b/web/app/surfaces/truffle.ts
@@ -28,12 +28,15 @@ export const truffleSurface: ToolSurface = {
       <div class="truffle-search">
         <h2>Find an instance type</h2>
         <!-- Examples must be queries that actually work today. "gpu with 80gb for
-             training" was here and silently returned CPU-only Graviton instances:
-             bare "gpu" parses to an unknown token and "80gb" filters system RAM,
-             not VRAM (truffle-ts#37). Name a vendor or a part until that lands. -->
-        <p class="truffle-hint">Natural language — e.g. <code>nvidia h100</code>,
-          <code>8 gpus a100</code>, <code>32 vcpus arm</code>. Offline catalog (as of
-          ${escapeHtml(CATALOG_AS_OF)}).</p>
+             training" was pulled from this list because it silently returned
+             CPU-only Graviton instances: bare "gpu" parsed to an unknown token and
+             "80gb" filtered system RAM, not VRAM. truffle-ts#37/#38 fixed both in
+             0.5.0 (bare "gpu" now sets requireGpu, and a bare memory figure beside
+             it reads as VRAM **per card**), so it's restored — it's the example
+             worth leading with, being the one a researcher would actually type. -->
+        <p class="truffle-hint">Natural language — e.g. <code>gpu with 80gb for training</code>,
+          <code>nvidia h100</code>, <code>8 gpus a100</code>, <code>32 vcpus arm</code>.
+          Offline catalog (as of ${escapeHtml(CATALOG_AS_OF)}).</p>
         <form class="truffle-form">
           <input class="truffle-q" type="search" placeholder="describe what you need…" autocomplete="off" />
           <button type="submit">Search</button>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@spore-host/lagotto-ts": "^0.1.0",
         "@spore-host/spawn-ts": "^0.6.1",
-        "@spore-host/truffle-ts": "^0.4.2"
+        "@spore-host/truffle-ts": "^0.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -1336,7 +1336,7 @@
         "@xterm/xterm": "^6.0.0"
       }
     },
-    "node_modules/@spore-host/truffle-ts": {
+    "node_modules/@spore-host/spawn-ts/node_modules/@spore-host/truffle-ts": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@spore-host/truffle-ts/-/truffle-ts-0.4.2.tgz",
       "integrity": "sha512-EnxoLGvy/hozcqD4Gg2e8bdavXlAwqsvb9oG3KAy58DZDFWfNUKwmDXwfqaUqDjqNGr/utbpL9N6hvkstDV+mQ==",
@@ -1344,6 +1344,17 @@
       "optionalDependencies": {
         "@aws-sdk/client-ec2": "^3.700.0",
         "@aws-sdk/client-pricing": "^3.700.0"
+      }
+    },
+    "node_modules/@spore-host/truffle-ts": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@spore-host/truffle-ts/-/truffle-ts-0.5.0.tgz",
+      "integrity": "sha512-+RfcgDUxwKyJoVoYj32AyEH9hmx/i7S9OGW3aLRfCPxhR8wc9kK9csdjTkPRzImAyM8P5nQ8awpAY9rFK0rkvA==",
+      "license": "Apache-2.0",
+      "optionalDependencies": {
+        "@aws-sdk/client-ec2": "^3.700.0",
+        "@aws-sdk/client-pricing": "^3.700.0",
+        "@aws-sdk/client-service-quotas": "^3.700.0"
       }
     },
     "node_modules/@types/estree": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "spore-host-web",
       "version": "0.1.0",
       "dependencies": {
-        "@spore-host/lagotto-ts": "^0.1.0",
+        "@spore-host/lagotto-ts": "^0.2.0",
         "@spore-host/spawn-ts": "^0.6.1",
         "@spore-host/truffle-ts": "^0.5.0"
       },
@@ -1308,12 +1308,12 @@
       }
     },
     "node_modules/@spore-host/lagotto-ts": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@spore-host/lagotto-ts/-/lagotto-ts-0.1.0.tgz",
-      "integrity": "sha512-rFKVj2s1IDKqhQf6ZoBgySvK/JlMd9FOSqQuM/l4FP9v5tegOiLTy6757yZMxNupYlR9MtMCHAuXLX8PRRdlCQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@spore-host/lagotto-ts/-/lagotto-ts-0.2.0.tgz",
+      "integrity": "sha512-1//lfbx1TPBu94bYG7dxANN2FO18ensjQTpe9K5h+Bmeek/ilE3Irh5BqGcLCtgxvO0Kr8P4Qem1E4y1XVLRCA==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@spore-host/truffle-ts": "^0.4.0"
+        "@spore-host/truffle-ts": "^0.4.0 || ^0.5.0"
       },
       "peerDependenciesMeta": {
         "@spore-host/truffle-ts": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "deploy": "npm run build && ./deploy.sh"
   },
   "dependencies": {
-    "@spore-host/lagotto-ts": "^0.1.0",
+    "@spore-host/lagotto-ts": "^0.2.0",
     "@spore-host/spawn-ts": "^0.6.1",
     "@spore-host/truffle-ts": "^0.5.0"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@spore-host/lagotto-ts": "^0.1.0",
     "@spore-host/spawn-ts": "^0.6.1",
-    "@spore-host/truffle-ts": "^0.4.2"
+    "@spore-host/truffle-ts": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
Bumps the portal to `@spore-host/truffle-ts@^0.5.0` and removes the two workarounds that version exists to make unnecessary.

This is also the first real exercise of the CI gate added in #507 — a truffle-ts bump is precisely the change that gate was argued for.

## What the bump lets us delete

**`QUARANTINED_TYPES`** (`web/app/guided/shapes.ts`) existed solely to stop `p6e-gb200.36xlarge` ($0.2000/hr for 72×B200) and `p5.4xlarge` ($0.00 for an H100) from **winning** the guided picker's price sort. A price-ranked picker is maximally exposed to a fabricated low price: a wrong-but-cheap entry doesn't merely appear in the list, it comes first. truffle-ts 0.5.0 now ships **no price at all** for types it can't price, so the null half of `usablePrice()` covers them.

**The `!isQuarantined(r)` exemption** in `shapes.test.ts` is gone too, so *"picks the CHEAPEST match"* now asserts over the **whole** result set instead of the set minus two known-bad entries. Strictly stronger.

## What deliberately stays

`usablePrice()`'s **zero** check. truffle-ts now refuses to write a non-positive price, so it shouldn't fire — but a zero *sorts first*, which makes it the one bad value that turns a "cheapest option" picker into a recommendation for a free H100. A one-line guard against an upstream regression that nothing else would catch is worth keeping; the comment says why it's defence in depth rather than live logic.

## The restored example query

`gpu with 80gb for training` is back as the leading example. It was pulled because it silently returned CPU-only Graviton boxes (truffle-ts#37/#38). It now returns **13 real GPU types, each ≥80 GiB per card**, with a reason line stating it:

```
g7e.12xlarge  48 vCPU · 512 GiB · 2× RTX PRO Server 6000  $8.2861/hr
   GPUs: 2 × RTX PRO Server 6000 | GPU memory: 96 GiB/GPU >= 80 GiB
```

## Two new tests

A broken example query is worse than no example — it teaches a first-time user the tool doesn't work, and that's exactly how the old one survived unnoticed.

1. **Every `<code>` example in the hint is driven through the real surface** and must return rows. Extracted from the DOM rather than hardcoded, so adding an example to the copy without checking it fails here instead of in front of a user.
2. **A GPU query must not answer with CPU-only rows.** Verified **non-vacuous** before relying on it: a CPU-only query (`32 vcpus arm`) renders 25 rows, **0** of which match `/gpu/i` — so this assertion would have failed on the #37 output, while a row-count check alone would have passed on it.

## Verification

Drove the live portal at all three levels, signed out, no credentials:

| level | result |
|---|---|
| guided (default) | 5 curated cards, all priced; no query box |
| standard | `gpu with 80gb for training` → 13 rows, **0** without a GPU, **0** quoting `$0.0000` |
| expert | `cheapest 64gb` → `r7g.2xlarge` $0.4284, `r8g.2xlarge` $0.4713, `r7i.2xlarge` $0.5292, each marked "live AWS pull" |

That last row is the #39 reproduction: a real Graviton at $0.43 tops the list where a fabricated $0.20 B200 used to. No console errors at any level. 68/68 tests, typecheck clean, build clean.