### PR TITLE
fix(ci): correct the create-pull-request pin comment to v8.1.1

### DIFF
--- a/.github/workflows/sync-cli-docs.yaml
+++ b/.github/workflows/sync-cli-docs.yaml
@@ -76,7 +76,7 @@ jobs:
           done
 
       - name: Open sync PR
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           # Use the DOCS_SYNC_TOKEN PAT, not GITHUB_TOKEN: the org forbids Actions
           # from creating pull requests ("GitHub Actions is not permitted to create


### PR DESCRIPTION
Dependabot #438 bumped `peter-evans/create-pull-request` to the SHA of the **v8.1.1** release, but left the trailing comment reading `# v7`. The comment is the only human-readable check on a pinned SHA, so a stale one defeats the point of pinning.

SHA `5f6978faf089d4d20b00c7766989d076bb2fc7f1` = `refs/tags/v8.1.1` (verified via the GitHub tags API).

No behavior change — comment only. The v8 major only requires Actions Runner ≥2.327.1 on *self-hosted* runners for Node 24; this workflow is `ubuntu-latest`, so the bump itself is safe.