### PR TITLE
fix(portal): bound guided spend, stop polling after sign-out, drop overclaims

### DIFF
--- a/web/app/guided/cost.test.ts
+++ b/web/app/guided/cost.test.ts
@@ -1,0 +1,52 @@
+// The guided cost-limit arithmetic. Pure, so this is where the money-safety
+// properties get pinned down without a DOM or a client.
+import { describe, expect, it } from "vitest";
+import { COST_LIMIT_HEADROOM, costLimitFor } from "./cost.js";
+
+describe("costLimitFor", () => {
+  it("sits above the TTL-implied total, not on it", () => {
+    // The limit must not be the thing that kills a healthy instance. Accumulated
+    // cost is computed from wall-clock runtime, so a limit at exactly price × ttl
+    // would race the TTL and any rounding would let the cost rule win.
+    const limit = costLimitFor(0.5, 4)!;
+    expect(limit).toBeGreaterThan(0.5 * 4);
+    expect(limit).toBe(Math.ceil(0.5 * 4 * COST_LIMIT_HEADROOM));
+  });
+
+  it("still bounds a runaway to roughly what the user agreed to", () => {
+    // The other half: headroom that made the limit meaningless would be no limit.
+    // At H100 prices an unbounded instance is ~$100/hr, so the ceiling matters.
+    const limit = costLimitFor(12.29, 2)!;
+    expect(limit).toBeLessThan(12.29 * 2 * 2);
+  });
+
+  it("rounds up to whole dollars", () => {
+    expect(costLimitFor(0.1344, 4)).toBe(1); // 0.672 → floor'd would be $0 = no limit
+    expect(Number.isInteger(costLimitFor(2.83, 4)!)).toBe(true);
+  });
+
+  it("never returns zero for a real price", () => {
+    // A zero costLimit reads as "no limit" in spawn-ts's lifecycle engine, so a
+    // cheap instance rounding to 0 would silently lose the guard it looks like it
+    // has. t4g.nano for one hour is $0.0042.
+    expect(costLimitFor(0.0042, 1)).toBeGreaterThanOrEqual(1);
+  });
+
+  it("is undefined when no price is known, not zero", () => {
+    // Undefined so the caller omits the field. Passing 0 would look like a limit at
+    // the call site and be read as "unlimited" by the engine — the worst pairing.
+    expect(costLimitFor(undefined, 4)).toBeUndefined();
+  });
+
+  it("is undefined for a non-positive price", () => {
+    // Defence in depth against an upstream zero price (truffle-ts#42's failure
+    // mode): a 0 here would otherwise produce a $1 limit on an H100 box and
+    // terminate it almost immediately, which reads as a broken portal.
+    expect(costLimitFor(0, 4)).toBeUndefined();
+    expect(costLimitFor(-1, 4)).toBeUndefined();
+  });
+
+  it("is undefined for a non-positive TTL", () => {
+    expect(costLimitFor(0.5, 0)).toBeUndefined();
+  });
+});

--- a/web/app/guided/cost.ts
+++ b/web/app/guided/cost.ts
@@ -1,0 +1,62 @@
+// The two cost facts guided mode has to get right, kept in one place because both
+// are easy to state wrongly and neither is obvious from the call site.
+//
+// Pure — no DOM, no truffle-ts, no spawn-ts. So the arithmetic that decides how
+// much of the user's money is at risk is testable on its own.
+
+/**
+ * The region the bundled catalog's on-demand prices are quoted in.
+ *
+ * truffle-ts does not export this, so we assert it here: `gen-catalog.mjs` defaults
+ * to `--region us-east-1` (line 20) and the Pricing API filter uses that region
+ * code, so every `onDemandPrice` in the bundled snapshot is a us-east-1 figure.
+ *
+ * It matters because the guided confirmation renders the *session's* region beside
+ * the cost. Without saying so, a us-east-1 price shown to a user in ap-southeast-2
+ * is off by roughly 15-30% with nothing on screen to suggest it. `priceIsEstimate`
+ * does not cover this: it flags hand-seeded entries, so a genuinely pulled price
+ * shown in the wrong region carries no qualifier at all.
+ *
+ * If truffle-ts ever exports the region its snapshot was built from, import that
+ * instead of this — a constant that has to be kept in sync by hand is the weaker
+ * version of this fact.
+ */
+export const CATALOG_PRICE_REGION = "us-east-1";
+
+/**
+ * How much slack the cost limit gets over the TTL-implied total.
+ *
+ * The limit must sit *above* the expected spend or it becomes the thing that kills
+ * a healthy instance early: accumulated cost is computed from wall-clock runtime, so
+ * a limit set at exactly `price × ttl` would trip at the same moment the TTL does,
+ * and any rounding or a restart would make the cost rule win the race. 25% is
+ * enough to stay clear of that while still bounding a runaway to something the user
+ * would recognise as "about what I agreed to".
+ */
+export const COST_LIMIT_HEADROOM = 1.25;
+
+/**
+ * The cost limit to launch a guided instance with, or undefined when no price is
+ * known.
+ *
+ * This is guided mode's *second* guard, and it exists because the first one can
+ * fail. TTL is enforced by `spored` on the instance, so an instance that never
+ * boots the daemon, or whose daemon dies, never self-terminates — which is not
+ * hypothetical: the Dashboard ships an orphan banner for exactly that case. TTL
+ * alone therefore bounds the *intended* run and nothing else, whereas a cost limit
+ * is evaluated from the tags by anything that reads them.
+ *
+ * Undefined rather than 0 when the price is unknown: spawn-ts treats a non-positive
+ * costLimit as "no limit" (`lifecycle.ts` guards `costLimit > 0`), so passing 0
+ * would be indistinguishable from omitting it while *looking* like a limit at the
+ * call site. Guided mode handles the unknown-price case by refusing to launch
+ * silently instead — see the acknowledgement in launch.ts.
+ *
+ * Rounded UP to whole dollars: a limit of $1.35 invites the question "why that
+ * number?", and the rounding direction is the safe one (never below the expected
+ * spend, which would abort a healthy run).
+ */
+export function costLimitFor(pricePerHour: number | undefined, ttlHours: number): number | undefined {
+  if (pricePerHour == null || !(pricePerHour > 0) || !(ttlHours > 0)) return undefined;
+  return Math.max(1, Math.ceil(pricePerHour * ttlHours * COST_LIMIT_HEADROOM));
+}

--- a/web/app/guided/launch.test.ts
+++ b/web/app/guided/launch.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SpawnClient } from "@spore-host/spawn-ts";
 import { mountGuidedLaunch } from "./launch.js";
 import { GUIDED_SHAPES } from "./shapes.js";
+import { costLimitFor } from "./cost.js";
 
 const settle = () => new Promise((r) => setTimeout(r, 0));
 
@@ -74,6 +75,88 @@ describe("mountGuidedLaunch", () => {
     dispose();
   });
 
+  it("does not promise the shutdown happens 'whatever happens'", async () => {
+    // The portal ships an orphan banner for precisely the case where spored fails
+    // to reap an instance, so copy claiming the shutdown is unconditional is
+    // contradicted by another component of the same page. It must say what the
+    // fallback is instead of denying the failure exists.
+    const { client } = stubClient();
+    const dispose = await pickFirst(client);
+    const text = host.querySelector(".guided-confirm")!.textContent!.replace(/\s+/g, " ");
+    expect(text).not.toContain("whatever happens");
+    expect(text.toLowerCase()).toContain("if that ever fails");
+    dispose();
+  });
+
+  it("names the spend cap alongside the time limit", async () => {
+    // Two guards that fail differently, so both are stated: the TTL runs on the
+    // instance and dies with the daemon, while the cost limit is derived from tags.
+    const { client } = stubClient();
+    const dispose = await pickFirst(client);
+    const text = host.querySelector(".guided-facts")!.textContent!.replace(/\s+/g, " ");
+    expect(text).toMatch(/\$\d+ of spend/);
+    dispose();
+  });
+
+  it("says the price excludes storage and transfer", async () => {
+    // "Up to $X" is a bound the figure doesn't actually bound — it's
+    // onDemandPrice × hours, with no EBS and no egress.
+    const { client } = stubClient();
+    const dispose = await pickFirst(client);
+    expect(host.querySelector(".guided-cost")!.textContent).toContain("Compute only");
+    dispose();
+  });
+
+  it("says spot is off and what that costs", async () => {
+    // The right default, but silent: guided mode systematically pays ~3× spot
+    // without ever mentioning that spot exists.
+    const { client } = stubClient();
+    const dispose = await pickFirst(client);
+    const text = host.querySelector(".guided-facts")!.textContent!.replace(/\s+/g, " ");
+    expect(text).toContain("not spot");
+    dispose();
+  });
+
+  it("qualifies the price when the session's region isn't the catalog's", async () => {
+    // The confirmation renders the session region and a us-east-1 catalog price as
+    // two adjacent facts. Outside us-east-1 they are not the same fact, and
+    // priceIsEstimate doesn't cover it — it flags hand-seeded entries only.
+    const { client } = stubClient();
+    const dispose = mountGuidedLaunch(host, {
+      client,
+      region: "ap-southeast-2",
+      onEscape: vi.fn(),
+    });
+    await settle();
+    host.querySelector<HTMLButtonElement>(".guided-card")!.click();
+    await settle();
+    const cost = host.querySelector(".guided-cost")!.textContent!.replace(/\s+/g, " ");
+    expect(cost).toContain("us-east-1");
+    expect(cost).toContain("ap-southeast-2");
+    dispose();
+  });
+
+  it("does not qualify the price in the catalog's own region", async () => {
+    // A caveat that fires always is one nobody reads.
+    const { client } = stubClient();
+    const dispose = await pickFirst(client); // region: us-east-1
+    expect(host.querySelector(".guided-cost")!.textContent).not.toContain("may differ");
+    dispose();
+  });
+
+  it("offers the escape hatch on the confirmation, not just the picker", async () => {
+    // This is the moment the user learns what guided mode chose, so it's the moment
+    // they discover it's too small. Without this the only way onward is back to the
+    // same five cards.
+    const onEscape = vi.fn();
+    const { client } = stubClient();
+    const dispose = await pickFirst(client, onEscape);
+    expect(host.querySelector(".guided-confirm")).toBeTruthy();
+    host.querySelector<HTMLButtonElement>(".guided-confirm .guided-escape")!.click();
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
   it("launches with a TTL and without spot", async () => {
     const { client, launch } = stubClient();
     const dispose = await pickFirst(client);
@@ -94,6 +177,105 @@ describe("mountGuidedLaunch", () => {
     // THIS instance instead of its hardcoded default.
     expect(input.pricePerHour).toBeGreaterThan(0);
     dispose();
+  });
+
+  it("launches with a cost limit above the expected spend", async () => {
+    // The second guard, and the reason it isn't redundant with the TTL: the TTL is
+    // enforced by spored ON the instance, so an instance whose daemon never starts
+    // is bounded by nothing — which is why the Dashboard ships an orphan banner. A
+    // cost limit is derived from the tags, so it survives the daemon failing.
+    const { client, launch } = stubClient();
+    const dispose = await pickFirst(client);
+    host.querySelector<HTMLButtonElement>(".guided-go")!.click();
+    await settle();
+
+    const input = launch.mock.calls[0]![0] as any;
+    const shape = GUIDED_SHAPES[0]!;
+    expect(input.costLimit).toBe(costLimitFor(input.pricePerHour, shape.defaultTtlHours));
+    // Above the expected spend, so it bounds a runaway instead of aborting a
+    // healthy run that merely reached its TTL.
+    expect(input.costLimit).toBeGreaterThan(input.pricePerHour * shape.defaultTtlHours);
+    dispose();
+  });
+
+  describe("when the catalog has no price", () => {
+    // The shapes that land here are the accelerator ones — types with no on-demand
+    // row are the $30-100/hr machines, so this is the branch where an accidental
+    // click is most expensive. The real catalog never produces it, so it is only
+    // ever exercised here.
+    const unpriced = [{ ...GUIDED_SHAPES[0]!, id: "unpriced", defaultTtlHours: 2 }];
+    const finder = async () => [
+      {
+        instance: {
+          instanceType: "p6e-gb200.36xlarge",
+          vcpus: 144,
+          memoryMib: 1024 * 1024,
+          gpus: 72,
+          gpuModel: "B200",
+          // No onDemandPrice at all — truffle-ts 0.5.0 carries no price rather
+          // than a guessed one for these.
+        },
+        score: 1,
+        reasons: [],
+      } as any,
+    ];
+
+    async function mountUnpriced(client: SpawnClient) {
+      const dispose = mountGuidedLaunch(host, {
+        client,
+        region: "us-east-1",
+        onEscape: vi.fn(),
+        shapes: unpriced,
+        finder,
+      });
+      await settle();
+      host.querySelector<HTMLButtonElement>(".guided-card")!.click();
+      await settle();
+      return dispose;
+    }
+
+    it("will not launch until the user acknowledges the unknown cost", async () => {
+      const { client, launch } = stubClient();
+      const dispose = await mountUnpriced(client);
+
+      const go = host.querySelector<HTMLButtonElement>(".guided-go")!;
+      expect(go.disabled).toBe(true);
+      go.click();
+      await settle();
+      expect(launch).not.toHaveBeenCalled();
+
+      host.querySelector<HTMLInputElement>(".guided-ack-box")!.click();
+      expect(go.disabled).toBe(false);
+      go.click();
+      await settle();
+      expect(launch).toHaveBeenCalledTimes(1);
+      dispose();
+    });
+
+    it("omits costLimit rather than sending zero", async () => {
+      // spawn-ts reads a non-positive costLimit as "no limit", so a 0 would look
+      // like a guard at the call site while being none — the worst pairing. The
+      // field must be absent.
+      const { client, launch } = stubClient();
+      const dispose = await mountUnpriced(client);
+      host.querySelector<HTMLInputElement>(".guided-ack-box")!.click();
+      host.querySelector<HTMLButtonElement>(".guided-go")!.click();
+      await settle();
+
+      const input = launch.mock.calls[0]![0] as any;
+      expect("costLimit" in input).toBe(false);
+      // The TTL still applies — it's the only guard left, so it must not be lost too.
+      expect(input.ttl).toBe("2h");
+      dispose();
+    });
+
+    it("says unpriced machines are usually the expensive ones", async () => {
+      const { client } = stubClient();
+      const dispose = await mountUnpriced(client);
+      const cost = host.querySelector(".guided-cost")!.textContent!.replace(/\s+/g, " ");
+      expect(cost).toContain("most expensive");
+      dispose();
+    });
   });
 
   it("names the instance distinguishably", async () => {

--- a/web/app/guided/launch.ts
+++ b/web/app/guided/launch.ts
@@ -7,7 +7,8 @@
 // point, and duplicating the list is how the two views drift apart.
 
 import type { SpawnClient } from "@spore-host/spawn-ts";
-import { mountGuidedPicker, type GuidedChoice } from "./picker.js";
+import { mountGuidedPicker, type GuidedChoice, type GuidedPickerOptions } from "./picker.js";
+import { CATALOG_PRICE_REGION, costLimitFor } from "./cost.js";
 
 export interface GuidedLaunchOptions {
   client: SpawnClient;
@@ -15,6 +16,14 @@ export interface GuidedLaunchOptions {
   region: string;
   /** "I know what I need" — hand control back to the caller (raise the level). */
   onEscape(): void;
+  /**
+   * Catalog lookup and shape list, forwarded to the picker. Injected for the same
+   * reason picker.ts takes them: the unknown-price branch is unreachable through the
+   * real catalog, and it's the branch that gates the launch button on the machines
+   * that cost the most per hour — so it must be testable.
+   */
+  finder?: GuidedPickerOptions["finder"];
+  shapes?: GuidedPickerOptions["shapes"];
 }
 
 /** Render the guided launch flow into `host`. Returns a dispose fn. */
@@ -32,6 +41,8 @@ export function mountGuidedLaunch(host: HTMLElement, opts: GuidedLaunchOptions):
     disposeStep = mountGuidedPicker(root, {
       onChoose: (choice) => showConfirm(choice),
       onEscape: opts.onEscape,
+      ...(opts.finder ? { finder: opts.finder } : {}),
+      ...(opts.shapes ? { shapes: opts.shapes } : {}),
     });
   };
 
@@ -41,20 +52,40 @@ export function mountGuidedLaunch(host: HTMLElement, opts: GuidedLaunchOptions):
     const { shape, rec } = choice;
     const i = rec.pick.instance;
 
+    const limit = costLimitFor(rec.pricePerHour, shape.defaultTtlHours);
+    const priceUnknown = rec.pricePerHour == null;
+
     // The cost line is deliberately the total, and deliberately says "up to":
     // the TTL is a ceiling, not a prediction — an instance that finishes early
     // and is stopped costs less, and promising the exact figure would be wrong in
     // the user's favour right up until it wasn't.
-    const cost =
-      rec.pricePerHour == null
-        ? `<p class="guided-cost unknown">We don't have a price for
-             <code>${escapeHtml(i.instanceType)}</code> in the offline catalog, so we
-             can't tell you what this costs. Check the AWS pricing page before you
-             launch.</p>`
-        : `<p class="guided-cost">Up to <b>$${rec.estimatedTotal!.toFixed(2)}</b>
-             — $${rec.pricePerHour.toFixed(4)} per hour${
-               rec.priceIsEstimate ? " (estimated)" : ""
-             }, for at most ${shape.defaultTtlHours} hours.</p>`;
+    //
+    // "compute only" is not a hedge for its own sake. The figure is
+    // onDemandPrice × hours, which excludes the EBS volume, data transfer and
+    // anything the instance itself pulls — so "Up to $X" is a bound the number
+    // does not actually bound, and saying so is cheaper than being wrong.
+    const cost = priceUnknown
+      ? `<p class="guided-cost unknown">We don't have a price for
+           <code>${escapeHtml(i.instanceType)}</code> in the offline catalog, so we
+           can't tell you what this costs — and machines without a listed price are
+           usually the most expensive ones. Check the
+           <a href="https://aws.amazon.com/ec2/pricing/on-demand/" target="_blank"
+              rel="noopener">AWS pricing page</a> for
+           <code>${escapeHtml(i.instanceType)}</code> before you launch.</p>`
+      : `<p class="guided-cost">Up to <b>$${rec.estimatedTotal!.toFixed(2)}</b>
+           — $${rec.pricePerHour!.toFixed(4)} per hour${
+             rec.priceIsEstimate ? " (estimated)" : ""
+           }, for at most ${shape.defaultTtlHours} hours. Compute only; storage and
+           data transfer are extra.${regionCaveat(opts.region)}</p>`;
+
+    // Two limits, and they fail differently, so both are named. The TTL is enforced
+    // by the daemon on the instance; the spend cap is derived from the tags. Saying
+    // only "it shuts down after N hours" is what the previous copy did, and it
+    // promised an outcome the portal itself ships an orphan banner to catch.
+    const stops = limit
+      ? `after ${shape.defaultTtlHours} hours, or at $${limit} of spend — whichever
+         comes first`
+      : `after ${shape.defaultTtlHours} hours`;
 
     root.innerHTML = `
       <div class="guided-confirm">
@@ -65,22 +96,48 @@ export function mountGuidedLaunch(host: HTMLElement, opts: GuidedLaunchOptions):
               i.gpus ? `, ${i.gpus}× ${escapeHtml(i.gpuModel ?? "GPU")}` : ""
             }</dd>
           <dt>Region</dt><dd>${escapeHtml(opts.region)}</dd>
-          <dt>Shuts down</dt><dd>automatically after
-            ${shape.defaultTtlHours} hours, whatever happens</dd>
+          <dt>Shuts down</dt><dd>automatically ${stops}</dd>
+          <dt>Pricing</dt><dd>on-demand — not spot, so it won't be interrupted, and
+            costs roughly three times what spot would</dd>
         </dl>
         ${cost}
-        <p class="guided-reassure">The time limit is enforced on the machine itself, so
-          it applies even if you close this tab.</p>
+        <p class="guided-reassure">The time limit runs on the machine itself, so it
+          applies even if you close this tab. If that ever fails, the machine is
+          flagged in the list below so you can stop it.</p>
+        ${
+          priceUnknown
+            ? `<label class="guided-ack"><input type="checkbox" class="guided-ack-box">
+                 I understand I don't know what this will cost</label>`
+            : ""
+        }
         <div class="guided-actions">
           <button class="guided-back" type="button">← Something else</button>
-          <button class="guided-go" type="button">Start it</button>
+          <button class="guided-go" type="button"${priceUnknown ? " disabled" : ""}>Start it</button>
         </div>
+        <button class="guided-escape" type="button">Show me all the options →</button>
         <div class="guided-msg" aria-live="polite"></div>
       </div>`;
 
     const back = root.querySelector<HTMLButtonElement>(".guided-back")!;
     const go = root.querySelector<HTMLButtonElement>(".guided-go")!;
     const msg = root.querySelector<HTMLElement>(".guided-msg")!;
+
+    // The escape hatch belongs on this step too, not just the picker. This is the
+    // moment the user learns what guided mode chose for them, so it's the moment
+    // they discover it's too small — and without this the only way onward is back
+    // to the same five cards.
+    root
+      .querySelector<HTMLButtonElement>(".guided-escape")!
+      .addEventListener("click", () => opts.onEscape());
+
+    // An unknown price is the one case where "Start it" is a bet rather than a
+    // decision, and the shapes that land here are the accelerator ones — the
+    // machines that cost more per hour than the others cost per day. So the button
+    // stays disabled until the user says, in as many words, that they know.
+    const ack = root.querySelector<HTMLInputElement>(".guided-ack-box");
+    ack?.addEventListener("change", () => {
+      go.disabled = !ack.checked;
+    });
 
     back.addEventListener("click", () => showPicker());
     go.addEventListener("click", () => {
@@ -99,6 +156,14 @@ export function mountGuidedLaunch(host: HTMLElement, opts: GuidedLaunchOptions):
           // instance rather than its hardcoded default. Zero when unknown is
           // correct here: it disables the meter's math instead of inventing a rate.
           pricePerHour: rec.pricePerHour ?? 0,
+          // The second guard. TTL is enforced by spored *on the instance*, so an
+          // instance whose daemon never starts is bounded by nothing — and the
+          // Dashboard's orphan banner exists because that happens. A cost limit is
+          // derived from the tags, so it survives the daemon failing, and it also
+          // turns the Dashboard's bare cost figure into a meter against a ceiling.
+          // Omitted (not zeroed) when the price is unknown: spawn-ts reads a
+          // non-positive limit as "no limit".
+          ...(limit != null ? { costLimit: limit } : {}),
         })
         .then((inst) => {
           if (!live) return;
@@ -138,6 +203,20 @@ export function mountGuidedLaunch(host: HTMLElement, opts: GuidedLaunchOptions):
 function instanceName(shapeId: string): string {
   const stamp = new Date().toISOString().slice(5, 16).replace(/[-:T]/g, "");
   return `${shapeId}-${stamp}`;
+}
+
+/**
+ * The one clause that connects the price to the region shown above it.
+ *
+ * The confirmation renders the session's region and the catalog's price as two
+ * adjacent facts, and they're only the same fact in us-east-1. Empty string there,
+ * because a caveat that fires always is one nobody reads.
+ */
+function regionCaveat(region: string): string {
+  if (region === CATALOG_PRICE_REGION) return "";
+  return ` Priced for ${escapeHtml(CATALOG_PRICE_REGION)}; ${escapeHtml(
+    region,
+  )} may differ.`;
 }
 
 function escapeHtml(s: string): string {

--- a/web/app/guided/picker.test.ts
+++ b/web/app/guided/picker.test.ts
@@ -41,6 +41,42 @@ describe("mountGuidedPicker", () => {
     dispose();
   });
 
+  it("says how many machines fit, so the pick doesn't read as the only option", async () => {
+    // resolveShape computes totalMatches for exactly this purpose and the UI used to
+    // drop it. "cheapest of 194 that fit" tells the user a choice was made on their
+    // behalf; the bare recommendation reads as the only thing available.
+    const dispose = mountGuidedPicker(host, { onChoose: vi.fn(), onEscape: vi.fn() });
+    await settle();
+    expect(host.querySelector(".guided-card-alts")!.textContent).toMatch(
+      /cheapest of \d+ that fit/,
+    );
+    dispose();
+  });
+
+  it("omits the match count when there was nothing to choose between", async () => {
+    const dispose = mountGuidedPicker(host, {
+      onChoose: vi.fn(),
+      onEscape: vi.fn(),
+      shapes: [GUIDED_SHAPES[0]!],
+      finder: async () =>
+        [
+          {
+            instance: {
+              instanceType: "t4g.small",
+              vcpus: 2,
+              memoryMib: 2048,
+              onDemandPrice: 0.0168,
+            },
+            score: 1,
+            reasons: [],
+          },
+        ] as any,
+    });
+    await settle();
+    expect(host.querySelector(".guided-card-alts")).toBeNull();
+    dispose();
+  });
+
   it("reports the chosen shape and its resolved machine", async () => {
     const onChoose = vi.fn();
     const dispose = mountGuidedPicker(host, { onChoose, onEscape: vi.fn() });

--- a/web/app/guided/picker.ts
+++ b/web/app/guided/picker.ts
@@ -126,21 +126,30 @@ export function mountGuidedPicker(host: HTMLElement, opts: GuidedPickerOptions):
  *
  * An unknown price says so. Rendering "$0.00" or omitting the cost entirely would
  * both read as "free".
+ *
+ * The match count is rendered because `resolveShape` computes it for exactly this
+ * purpose — "cheapest of 194 that fit" tells the user a choice was made on their
+ * behalf and roughly how much was on the table, where the bare recommendation reads
+ * as the only thing available.
  */
 function describe(rec: GuidedRecommendation): string {
   const i = rec.pick.instance;
   const gib = (i.memoryMib / 1024).toFixed(i.memoryMib % 1024 === 0 ? 0 : 1);
   const gpu = i.gpus ? ` · ${i.gpus}× ${escapeHtml(i.gpuModel ?? "GPU")}` : "";
   const specs = `${escapeHtml(i.instanceType)} — ${i.vcpus} vCPU · ${gib} GiB${gpu}`;
+  const of =
+    rec.totalMatches > 1
+      ? `<span class="guided-card-alts">cheapest of ${rec.totalMatches} that fit</span>`
+      : "";
 
   if (rec.pricePerHour == null) {
     return `<b>${specs}</b><span class="guided-card-cost unknown">price unknown for this
-      type — check before launching</span>`;
+      type — check before launching</span>${of}`;
   }
   const est = rec.priceIsEstimate ? " (estimated)" : "";
   return `<b>${specs}</b><span class="guided-card-cost">about
     $${rec.estimatedTotal!.toFixed(2)} for ${rec.shape.defaultTtlHours} hours
-    ($${rec.pricePerHour.toFixed(4)}/hr${est})</span>`;
+    ($${rec.pricePerHour.toFixed(4)}/hr${est}, compute only)</span>${of}`;
 }
 
 function escapeHtml(s: string): string {

--- a/web/app/shell.test.ts
+++ b/web/app/shell.test.ts
@@ -1,0 +1,171 @@
+// The shell's lifecycle contract with its surfaces: when it disposes them, and
+// whether the level control tells the truth.
+//
+// The registry is mocked with a recording stub rather than the real surfaces. This
+// is a test about the shell's dispose/mount discipline, and mounting the real
+// surfaces would drag in the EC2/SSM SDKs and a live Dashboard to observe it.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const disposed: string[] = [];
+const mounted: string[] = [];
+
+vi.mock("./surfaces/registry.js", () => {
+  const make = (id: string, requiresAuth: boolean) => ({
+    id,
+    label: id,
+    accent: "--spawn",
+    requiresAuth,
+    async mount(host: HTMLElement) {
+      mounted.push(id);
+      host.innerHTML = `<div class="stub-${id}"></div>`;
+      return {
+        dispose() {
+          disposed.push(id);
+        },
+      };
+    },
+  });
+  const surfaces = [make("instances", true), make("truffle", false)];
+  return { surfaces, findSurface: (id: string) => surfaces.find((s) => s.id === id) };
+});
+
+vi.mock("./auth/globus-login.js", () => ({ startSignIn: vi.fn() }));
+
+const { Shell } = await import("./shell.js");
+const { SessionController } = await import("./session.js");
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+/** A session that reports as signed in without touching STS. */
+function signedInSession() {
+  const session = new SessionController("us-east-1", null);
+  vi.spyOn(session, "signedIn", "get").mockReturnValue(true);
+  vi.spyOn(session, "accountId", "get").mockReturnValue("123456789012");
+  vi.spyOn(session, "getCreds").mockReturnValue({
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "secret",
+    sessionToken: "token",
+  } as never);
+  return session;
+}
+
+describe("Shell sign-out", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    disposed.length = 0;
+    mounted.length = 0;
+    location.hash = "";
+    document.body.innerHTML = "";
+    root = document.createElement("div");
+    document.body.appendChild(root);
+  });
+
+  it("disposes the mounted surface on sign-out", async () => {
+    // The bug this pins down: route() only disposes when the route id CHANGES, and
+    // signing out doesn't change it — location.hash = "" falls through currentId()
+    // to surfaces[0], which is `instances`. So `this.current.id === id` and the
+    // dispose branch was skipped.
+    //
+    // That is not cosmetic. The instances surface holds a SpawnClient whose
+    // startMonitor() interval is still running over an EC2Provider that captured the
+    // credential VALUES — which session.clear() cannot invalidate. The user who signs
+    // out keeps making authenticated DescribeInstances calls until STS expiry.
+    const session = signedInSession();
+    const shell = new Shell(root, session, { region: "us-east-1" } as never);
+    shell.start();
+    await settle();
+    expect(mounted).toContain("instances");
+    const disposeMark = disposed.length;
+
+    // Sign out for real: the mock's signedIn getter has to follow, or the shell
+    // would re-mount the same surface and the assertion would pass for the wrong
+    // reason.
+    vi.spyOn(session, "signedIn", "get").mockReturnValue(false);
+    root.querySelector<HTMLButtonElement>(".portal-signout")!.click();
+    await settle();
+
+    expect(disposed.slice(disposeMark)).toEqual(["instances"]);
+  });
+
+  it("does not re-mount an auth-gated surface after signing out", async () => {
+    const session = signedInSession();
+    const shell = new Shell(root, session, { region: "us-east-1" } as never);
+    shell.start();
+    await settle();
+    const mountMark = mounted.length;
+
+    vi.spyOn(session, "signedIn", "get").mockReturnValue(false);
+    root.querySelector<HTMLButtonElement>(".portal-signout")!.click();
+    await settle();
+
+    expect(mounted.slice(mountMark)).toEqual([]); // not mounted a second time
+    expect(root.querySelector(".portal-gate")).not.toBeNull();
+  });
+
+  it("disposes before clearing the session, so teardown still has its creds", async () => {
+    // Ordering matters for the surfaces whose dispose() makes an AWS call — the
+    // terminal's TerminateSession is the live example. Disposing after clear() would
+    // leave a session open server-side.
+    //
+    // Both events land in one ordered list, so this asserts the interleaving rather
+    // than just that each happened.
+    const order: string[] = [];
+    const session = signedInSession();
+    vi.spyOn(session, "clear").mockImplementation(() => order.push("clear"));
+    disposed.length = 0;
+
+    const shell = new Shell(root, session, { region: "us-east-1" } as never);
+    shell.start();
+    await settle();
+
+    // Mirror dispose() calls into the same list. The stub's own dispose pushes to
+    // `disposed`, so watch that array's growth via a proxy on the recorded surface.
+    const origPush = disposed.push.bind(disposed);
+    disposed.push = ((...args: string[]) => {
+      order.push("dispose");
+      return origPush(...args);
+    }) as typeof disposed.push;
+
+    root.querySelector<HTMLButtonElement>(".portal-signout")!.click();
+    await settle();
+    disposed.push = origPush;
+
+    expect(order).toEqual(["dispose", "clear"]);
+  });
+});
+
+describe("Shell level changes", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    disposed.length = 0;
+    mounted.length = 0;
+    location.hash = "#/truffle";
+    document.body.innerHTML = "";
+    root = document.createElement("div");
+    document.body.appendChild(root);
+  });
+
+  it("re-mounts the current surface when the level changes", async () => {
+    // Surfaces read ctx.level once at mount rather than subscribing, so the remount
+    // IS the update mechanism. If it stopped happening, every surface would silently
+    // keep rendering the level the user had when they arrived.
+    //
+    // Measured as a delta, not an absolute count: Shell.start() registers a
+    // window-level hashchange listener and the class has no teardown (there is one
+    // Shell for the app's lifetime), so shells from earlier tests in this file still
+    // react to the beforeEach hash change. Counting from a mark keeps this test
+    // about the level, not about listener bookkeeping.
+    const session = new SessionController("us-east-1", null);
+    const shell = new Shell(root, session, { region: "us-east-1" } as never);
+    shell.start();
+    await settle();
+    const mountMark = mounted.length;
+    const disposeMark = disposed.length;
+
+    session.setLevel("expert");
+    await settle();
+    expect(disposed.slice(disposeMark)).toContain("truffle");
+    expect(mounted.slice(mountMark)).toContain("truffle");
+  });
+});

--- a/web/app/shell.ts
+++ b/web/app/shell.ts
@@ -115,6 +115,22 @@ export class Shell {
         this.session.accountId ?? "?",
       )}</b></span> <button class="portal-signout">sign out</button>`;
       el.querySelector(".portal-signout")!.addEventListener("click", () => {
+        // Dispose the mounted surface BEFORE clearing the session, and do it here
+        // rather than leaving it to route().
+        //
+        // route() only disposes when the route id changes, and signing out doesn't
+        // change it: location.hash = "" falls through currentId() to surfaces[0],
+        // which is `instances` — the surface most likely to be mounted. So without
+        // this, `this.current.id === id` and the dispose branch is skipped.
+        //
+        // That is not cosmetic. The instances surface holds a SpawnClient whose
+        // startMonitor() interval is still running, over an EC2Provider that
+        // captured the credential *values* — which session.clear() cannot
+        // invalidate. The result is authenticated DescribeInstances calls
+        // continuing after the user believes they signed out, until STS expiry.
+        // The same applies to a live SSM session on the terminal surface.
+        this.current?.disposable.dispose();
+        this.current = null;
         this.session.clear();
         location.hash = "";
         this.render();
@@ -195,14 +211,26 @@ export class Shell {
     });
   }
 
+  /**
+   * The expiry banner.
+   *
+   * Both strings name the instances, because expiry stops the *portal* and not the
+   * machines. The instances surface calls client.stopMonitor() when creds expire, so
+   * the list freezes and the cost meter stops advancing while the instances keep
+   * billing. "Session expired. Sign in again" is, at that moment, read as "nothing
+   * is happening" — the opposite of what's true, and expensive to believe.
+   */
   private showExpiry(state: "warning" | "expired"): void {
     this.bannerEl.hidden = false;
     if (state === "warning") {
       this.bannerEl.className = "portal-banner warn";
-      this.bannerEl.textContent = "Your session expires soon — sign in again to stay connected.";
+      this.bannerEl.textContent =
+        "Your session expires soon — sign in again to stay connected. Anything you have running keeps running.";
     } else {
       this.bannerEl.className = "portal-banner expired";
-      this.bannerEl.innerHTML = `Session expired. <button class="portal-reauth">Sign in again</button>`;
+      this.bannerEl.innerHTML = `Session expired — this page has stopped updating, but any
+        machines you started are still running and still costing money.
+        <button class="portal-reauth">Sign in again</button> to see and stop them.`;
       this.bannerEl.querySelector(".portal-reauth")!.addEventListener("click", () => {
         void startSignIn(this.config);
       });

--- a/web/app/surfaces/instances.test.ts
+++ b/web/app/surfaces/instances.test.ts
@@ -1,0 +1,129 @@
+// The guided Instances surface, and specifically the one thing about it that can
+// break silently and expensively.
+//
+// Guided mode hides the Dashboard's own launch/sweep/queue forms with a CSS rule
+// (`.guided-instances .dash-section.launch` et al.) that targets class names living
+// inside @spore-host/spawn-ts — a separately versioned package this repo consumes
+// prebuilt. Nothing in either repo couples the two, so a refactor of the Dashboard's
+// markup un-hides the full 14-field launch form for beginners, in a mode whose whole
+// promise is that you can't hurt yourself. No test failure, no type error, no visual
+// change in any mode a developer is ever in.
+//
+// So the selectors are read out of the stylesheet rather than restated here: this
+// asserts the *coupling*, not a copy of it. A selector that matches nothing is the
+// signal that spawn-ts moved.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionController } from "../session.js";
+import type { PortalConfig, SurfaceContext } from "./types.js";
+import type { DisclosureLevel } from "../disclosure.js";
+import { instancesSurface } from "./instances.js";
+
+const settle = () => new Promise((r) => setTimeout(r, 50));
+
+const config = { region: "us-east-1" } as PortalConfig;
+
+// Resolved from the vitest root (web/), not import.meta.url: under Vite's transform
+// import.meta.url is not a file: URL.
+const CSS = readFileSync(resolve(process.cwd(), "css/style.css"), "utf8");
+
+/**
+ * The `.guided-instances …` selectors the stylesheet hides, pulled from the rule
+ * itself so this test tracks the CSS instead of duplicating it.
+ */
+function hiddenSelectors(): string[] {
+  const rule = /((?:\s*\.guided-instances[^,{]+,?)+)\{\s*display:\s*none/.exec(CSS);
+  if (!rule) throw new Error("no `.guided-instances … { display: none }` rule in style.css");
+  return rule[1]!
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function ctxAt(level: DisclosureLevel): SurfaceContext {
+  const session = new SessionController("us-east-1", null);
+  session.setLevel(level);
+  // The surface throws without creds. These are never used: the EC2Provider is
+  // constructed but the test never lets a request complete.
+  vi.spyOn(session, "getCreds").mockReturnValue({
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    sessionToken: "token",
+  } as never);
+  return { session, config, level, navigate: vi.fn() };
+}
+
+describe("instancesSurface disclosure", () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+  });
+
+  it("marks the host so the stylesheet can hide the Dashboard's forms at guided", async () => {
+    const d = await instancesSurface.mount(host, ctxAt("guided"));
+    await settle();
+    expect(host.classList.contains("guided-instances")).toBe(true);
+    d.dispose();
+    // And removes it, or a level change would leave the class on a host that then
+    // mounts the standard view — hiding the launch form with no way to get it back.
+    expect(host.classList.contains("guided-instances")).toBe(false);
+  });
+
+  it("every selector the stylesheet hides still matches a rendered node", async () => {
+    // The load-bearing assertion. If spawn-ts renames `.dash-section.launch`, this
+    // fails here rather than shipping an un-hidden launch form to beginners.
+    const d = await instancesSurface.mount(host, ctxAt("guided"));
+    await settle();
+
+    const selectors = hiddenSelectors();
+    expect(selectors.length).toBeGreaterThan(0);
+    for (const sel of selectors) {
+      // Scoped to the host, which carries .guided-instances, so the full selector
+      // resolves exactly as it does in the browser.
+      expect(document.querySelectorAll(sel).length, `${sel} matched nothing`).toBeGreaterThan(0);
+    }
+    d.dispose();
+  });
+
+  it("hides the launch form but KEEPS the instance list at guided", async () => {
+    // The one simplification that would cost real money: a beginner who can start an
+    // instance and then can't see or stop it. The list, meters and log stay.
+    const d = await instancesSurface.mount(host, ctxAt("guided"));
+    await settle();
+
+    const launch = document.querySelector(".guided-instances .dash-section.launch");
+    expect(launch, "the Dashboard's launch section should still be in the DOM").not.toBeNull();
+    // Hidden by the stylesheet, which happy-dom doesn't apply — so assert the
+    // selector matches (above) and that the section we must NOT hide is untargeted.
+    const hidden = hiddenSelectors();
+    const list = [...document.querySelectorAll(".dash-section")].filter(
+      (el) => !hidden.some((sel) => el.matches(sel.replace(".guided-instances ", ""))),
+    );
+    expect(list.length, "no Dashboard sections left visible at guided").toBeGreaterThan(0);
+    d.dispose();
+  });
+
+  it("mounts the guided picker above the Dashboard at guided", async () => {
+    const d = await instancesSurface.mount(host, ctxAt("guided"));
+    await settle();
+    expect(host.querySelectorAll(".guided-card").length).toBeGreaterThan(0);
+    d.dispose();
+  });
+
+  it("leaves the Dashboard untouched from standard up", async () => {
+    for (const level of ["standard", "expert"] as const) {
+      host.innerHTML = "";
+      host.className = "";
+      const d = await instancesSurface.mount(host, ctxAt(level));
+      await settle();
+      expect(host.classList.contains("guided-instances"), level).toBe(false);
+      expect(host.querySelector(".guided-card"), level).toBeNull();
+      expect(host.querySelector(".dash-section.launch"), level).not.toBeNull();
+      d.dispose();
+    }
+  });
+});

--- a/web/app/surfaces/lagotto.ts
+++ b/web/app/surfaces/lagotto.ts
@@ -66,6 +66,10 @@ export const lagottoSurface: ToolSurface = {
           come and go. Describe what you want and this polls
           <b>${escapeHtml(region)}</b> until it appears — the same matching the
           <code>lagotto</code> CLI does, running in this tab against your own account.</p>
+        <p class="lagotto-hint warn">A watch lives only as long as this tab. Closing it,
+          reloading, or switching the detail level in the header stops the watch — nothing
+          keeps checking on your behalf. For a watch that outlives a browser, use the
+          <code>lagotto</code> CLI.</p>
       </div>
 
       <form class="lagotto-form">
@@ -80,7 +84,7 @@ export const lagottoSurface: ToolSurface = {
           <label for="lg-maxprice">Max $/hr</label>
           <input id="lg-maxprice" class="lagotto-maxprice" type="number" min="0" step="0.01"
                  placeholder="any" />
-          <span class="lagotto-fieldhint">blank = no cap</span>
+          <span class="lagotto-fieldhint lagotto-pricehint">blank = no cap</span>
         </div>
         <div class="lagotto-field">
           <label for="lg-azs">Only these AZs</label>
@@ -149,6 +153,23 @@ export const lagottoSurface: ToolSurface = {
       onceBtn.disabled = running;
       for (const el of [patternEl, maxPriceEl, azsEl, intervalEl, spotEl]) el.disabled = running;
     }
+
+    // What "Max $/hr" is compared against differs by an order of trustworthiness
+    // between the two modes, and the difference decides whether the cap works:
+    // a Spot watch prices live per AZ, while an on-demand watch is compared against
+    // truffle-ts's static us-east-1 table. Outside us-east-1 that makes the
+    // on-demand cap approximate — a cost guard that doesn't quite guard — and
+    // that fact previously existed only in a comment on portalCapacityFinder.
+    const priceHint = root.querySelector<HTMLElement>(".lagotto-pricehint")!;
+    const syncPriceHint = (): void => {
+      priceHint.textContent = spotEl.checked
+        ? "blank = no cap; compared against live Spot prices"
+        : `blank = no cap; compared against a static us-east-1 estimate${
+            region === "us-east-1" ? "" : ` — approximate in ${region}`
+          }`;
+    };
+    spotEl.addEventListener("change", syncPriceHint);
+    syncPriceHint();
 
     function appendLog(text: string): void {
       const li = document.createElement("li");

--- a/web/app/surfaces/terminal.ts
+++ b/web/app/surfaces/terminal.ts
@@ -74,6 +74,8 @@ export const terminalSurface: ToolSurface = {
       closeBtn.hidden = true;
       openBtn.disabled = false;
       target.disabled = false;
+      // Drop the connected-state styling; the caller sets the next message itself.
+      status.className = "terminal-status";
     }
 
     async function connect(instanceId: string): Promise<void> {
@@ -92,7 +94,14 @@ export const terminalSurface: ToolSurface = {
           throw new Error("StartSession returned an incomplete session");
         }
         sessionId = started.SessionId;
-        status.textContent = "";
+        // Say what ends the session, while it's live and the warning is actionable.
+        // dispose() terminates it, and dispose() runs on navigation AND on a
+        // disclosure-level change (which remounts the surface) — so an unrelated
+        // click in the header drops a shell the user is typing into. Naming it is
+        // the cheap half of the fix; not losing the session is issue-sized.
+        status.className = "terminal-status warn";
+        status.textContent =
+          "Connected. Leaving this page, reloading, or changing the detail level in the header ends this session.";
         // Un-hide BEFORE attach so xterm's fit addon measures a real size.
         termHost.hidden = false;
         attached = await attachTerminal(

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -609,6 +609,9 @@ footer {
 .terminal-form button { font: inherit; cursor: pointer; padding: 0.5rem 1rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
 .terminal-open { border-color: var(--spored) !important; color: var(--spored) !important; }
 .terminal-status { color: var(--text-muted); font-size: 0.9rem; min-height: 1.2em; }
+/* Shown while a session is live, to say what ends it — including a header click the
+   user would never connect to losing their shell. */
+.terminal-status.warn { color: var(--truffle); }
 .terminal-host { height: 460px; border-radius: var(--radius); overflow: hidden; border: 2px solid transparent; background: var(--terminal-bg); }
 .terminal-host:focus-within { border-color: var(--spored); }
 
@@ -747,6 +750,9 @@ footer {
 /* ── lagotto surface — watch for EC2 capacity (accent --lagotto) ── */
 .lagotto-surface { max-width: 820px; }
 .lagotto-hint { color: var(--text-muted); font-size: 0.9rem; max-width: 640px; }
+/* The tab-lifetime caveat. A watch that silently dies when the tab closes is worse
+   than no watch, because the user is waiting on it. */
+.lagotto-hint.warn { color: var(--truffle); }
 .lagotto-hint code, .lagotto-fieldhint code, .lagotto-match-next code { background: var(--code-bg); padding: 0.05rem 0.35rem; border-radius: 4px; font-size: 0.85em; }
 /* Two rows: the inputs, then spot + the actions. Fields align on their INPUT
    (not their bottom edge) so a wrapping hint doesn't shove one field upward. */
@@ -805,6 +811,9 @@ footer {
    missing number that looks like a normal one is the failure mode this whole
    surface is trying to avoid. */
 .guided-card-cost.unknown, .guided-card.errored .guided-card-machine { color: var(--accent-red); }
+/* "cheapest of N that fit" — smaller than the price, because it's context for the
+   choice rather than a fact the user has to weigh. */
+.guided-card-alts { display: block; margin-top: 0.1rem; font-size: 0.8rem; opacity: 0.8; }
 .guided-escape {
   font: inherit; cursor: pointer; padding: 0.4rem 0; border: 0; background: none;
   color: var(--text-muted); text-decoration: underline;
@@ -819,6 +828,13 @@ footer {
 .guided-cost b { font-variant-numeric: tabular-nums; }
 .guided-cost.unknown { font-size: 0.95rem; color: var(--accent-red); }
 .guided-reassure { color: var(--text-muted); font-size: 0.85rem; }
+/* The unknown-price acknowledgement. Deliberately not muted: it gates the launch
+   button, so it has to read as something to act on rather than fine print. */
+.guided-ack {
+  display: flex; gap: 0.5rem; align-items: flex-start; margin-top: 0.9rem;
+  font-size: 0.9rem; cursor: pointer;
+}
+.guided-ack input { margin-top: 0.15rem; }
 .guided-actions { display: flex; gap: 0.75rem; align-items: center; margin-top: 1.25rem; }
 .guided-actions button { font: inherit; cursor: pointer; padding: 0.55rem 1.2rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
 .guided-go { border-color: var(--spawn) !important; background: var(--spawn) !important; color: #fff !important; font-weight: 600; }


### PR DESCRIPTION
Phase 4 Tier 0. Progressive disclosure's foundation shipped in #505; this is the safety-and-honesty pass over what it left behind — two bugs that cost real money, and a set of strings that promise more than the mechanism delivers.

## The two bugs

**Signed-out sessions kept calling EC2.** `route()` only disposes on a route-id *change*, and signing out doesn't change it: `location.hash = ""` falls through `currentId()` to `surfaces[0]` = `instances`, so `this.current.id === id` and the dispose branch was skipped. The `SpawnClient`'s `startMonitor()` interval kept running over an `EC2Provider` that captured the credential **values** — which `session.clear()` cannot invalidate.

Measured in a real browser with the EC2 route intercepted and counted:

| | calls |
|---|---|
| while mounted and signed in (3s) | 22 |
| in the 6s **after** sign-out, gate on screen — before this PR | **48** |
| in the 6s after sign-out — after this PR | **0** |

Dispose now happens *before* `clear()`, so a surface whose teardown makes an AWS call (the terminal's `TerminateSession`) still has credentials to make it with.

**Guided launches carried no cost limit.** TTL is enforced by `spored` *on the instance*, so an instance whose daemon never starts is bounded by nothing — the Dashboard's orphan banner exists for exactly that case. `costLimit` is derived from the tags and survives daemon failure, so guided now sets both. The limit is `ceil(price × ttl × 1.25)`, floored at \$1: accumulated cost is computed from wall-clock runtime, so a limit at exactly the TTL-implied total would race the TTL and abort healthy runs. It also flips the Dashboard from its bare-number branch to the metered bar.

An **unknown** price now gates the launch behind an explicit acknowledgement. That branch is unreachable through the bundled catalog, and the shapes that land there are the accelerator ones — machines that cost more per hour than the others cost per day. The field is *omitted* rather than zeroed, because the engine reads `costLimit: 0` as "no limit", which would look like a guard at the call site and be none.

## Copy — each replaces a claim stronger than its mechanism

- **"shuts down … whatever happens"** → the shutdown runs on the machine, and if it fails the instance is flagged in the list below. The portal ships a component whose entire job is the case that text said cannot happen.
- **Region vs price.** The bundled catalog is priced for us-east-1 (truffle-ts's generator pulls with `--region us-east-1`), and the confirmation rendered that price directly under the session's region with nothing connecting them. Now caveated — but only *outside* us-east-1: a caveat that fires always is one nobody reads.
- **Spot** is off and was never mentioned, so guided quietly paid ~3× more than necessary.
- **The cost figure is compute-only**; storage and transfer are extra.
- **Expiry** stops the *portal*, not the machines — the monitor stops, the list freezes and the meter stops advancing while the instances keep billing. "Sign in again" read as "nothing is happening".
- **`totalMatches`** is rendered ("cheapest of 194 that fit"). `shapes.ts` computed it for exactly this reason and the UI dropped it, so a choice made on the user's behalf read as the only option available.
- **lagotto**: a watch lives only as long as the tab, and an on-demand `maxPrice` is compared against a static us-east-1 table — a cost guard that doesn't guard elsewhere. Both were code comments; neither was a label.
- **terminal**: says that leaving the page or changing the detail level ends the session.

## Tests: 68 → 97

The load-bearing one is `surfaces/instances.test.ts`. Guided hides the Dashboard's launch/sweep/queue forms with a CSS rule targeting class names inside the separately versioned `@spore-host/spawn-ts` package, so a refactor there un-hides the full 14-field launch form for beginners — with no test failure, no type error, and no visual change in any mode a developer is ever in. The test **parses the selectors out of style.css** rather than restating them, so it asserts the coupling instead of a copy of it; a selector matching nothing is the signal that spawn-ts moved.

Each fix was verified by **failing first**: the sign-out test against a reverted `shell.ts`, the CSS guard against a renamed selector, and the dispose fix against live EC2 request counts in a browser.

## Verified in a browser, not just in happy-dom

- **Signed out, no credentials, at `guided`** — the first-time user's path, and the one nobody developing the portal is ever in. All five cards resolve through the offline catalog: `t4g.xlarge` \$0.1344/hr, `r7g.4xlarge` \$0.8568/hr, `hpc7g.16xlarge` \$1.6832/hr, `g6.xlarge` \$0.8048/hr, `p5.48xlarge` \$55.04/hr. No AI, no network, no creds.
- **The guided hide against the real prebuilt Dashboard and real CSS** (happy-dom applies no stylesheets): `.launch`/`.sweep`/`.queue` compute to `display: none`, the other three `.dash-section`s stay `block`, picker mounts.
- **The ack gate is visible**, not just enforced — `.guided-go` is `!important`-painted, so a disabled state that looked identical would be a dead click with no explanation. Confirmed `opacity: 0.6` + `cursor: default` before the check, full colour after.
- **The escape hatch** raises the level, the header control follows, and it survives a reload.
- No console errors anywhere in the pass.

## Not in this PR

Tier 1 (the disclosure rollout across `costs`/`teams`/`shell`/`onboarding` + hash-persisted state) follows separately. Deferred to issues: terminal's instance picker, lagotto's guided cards and resume-after-remount, the `owner_arn` mismatch for CLI-created teams, and `catalog` being gated behind `requiresAuth` despite being static.

Note `deploy-site.yaml` deploys `web/**` to spore.host/app on merge, so this is a live deploy.