### PR TITLE
chore(deps): bump substrate to v0.85.0 in the Lambda test modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Changed
-- Bumped the `substrate` test dependency v0.65.0 → v0.81.0 in the
-  `accountlifecycle` and `spore-bot` Lambda modules, 16 minor versions of AWS
+- Bumped the `substrate` test dependency v0.65.0 → v0.85.0 in the
+  `accountlifecycle` and `spore-bot` Lambda modules, 20 minor versions of AWS
   emulation fidelity. Test-only; no runtime or deployed behaviour change. Both
   modules still imported substrate at its **root** package path, which moved to
   `/emulator` at v0.70.0, so the pin could not advance without that one-line

--- a/lambda/accountlifecycle/go.mod
+++ b/lambda/accountlifecycle/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.37
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
-	github.com/scttfrdmn/substrate v0.81.0
+	github.com/scttfrdmn/substrate v0.85.0
 )
 
 require (

--- a/lambda/accountlifecycle/go.sum
+++ b/lambda/accountlifecycle/go.sum
@@ -87,8 +87,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
-github.com/scttfrdmn/substrate v0.81.0 h1:NxX1dgvAx1PodsUQxYBC2TCwTVsNUXoebibxFCZrh30=
-github.com/scttfrdmn/substrate v0.81.0/go.mod h1:q0Q4+aLxZdA8peP/zcRLx2oiVQ/78FbO8qxv+ToABlA=
+github.com/scttfrdmn/substrate v0.85.0 h1:PLoj+u+nbQ0Kh28qs5Qw1Vt1TXaFmkyev9XsfmqwE3E=
+github.com/scttfrdmn/substrate v0.85.0/go.mod h1:q0Q4+aLxZdA8peP/zcRLx2oiVQ/78FbO8qxv+ToABlA=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/lambda/spore-bot/go.mod
+++ b/lambda/spore-bot/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.88.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/google/uuid v1.6.0
-	github.com/scttfrdmn/substrate v0.81.0
+	github.com/scttfrdmn/substrate v0.85.0
 )
 
 require (

--- a/lambda/spore-bot/go.sum
+++ b/lambda/spore-bot/go.sum
@@ -95,8 +95,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
-github.com/scttfrdmn/substrate v0.81.0 h1:NxX1dgvAx1PodsUQxYBC2TCwTVsNUXoebibxFCZrh30=
-github.com/scttfrdmn/substrate v0.81.0/go.mod h1:q0Q4+aLxZdA8peP/zcRLx2oiVQ/78FbO8qxv+ToABlA=
+github.com/scttfrdmn/substrate v0.85.0 h1:PLoj+u+nbQ0Kh28qs5Qw1Vt1TXaFmkyev9XsfmqwE3E=
+github.com/scttfrdmn/substrate v0.85.0/go.mod h1:q0Q4+aLxZdA8peP/zcRLx2oiVQ/78FbO8qxv+ToABlA=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=


### PR DESCRIPTION
Test-only pin bump **v0.81.0 → v0.85.0** in `lambda/accountlifecycle` and `lambda/spore-bot`. No runtime or deployed behaviour change.

Verified locally against a real v0.85.0 server before bumping — both registry round-trip suites pass.

The notable fix in this span is **substrate#457**, which we filed: `HeadObject` did not resolve a synthesized task-completion record, so `HEAD` returned 404 for a key `GET` served with a 200 and a full body. Both verbs now agree, including under the clock gate.

Two v0.85.0 behavior changes were checked against this repo and neither applies: nothing here writes `aws:`-prefixed tag keys (substrate#452), and nothing calls `RunInstances` with both an `ImageId` and a launch template (substrate#453).

`web/app/` changes present in the working tree are unrelated in-progress work and are deliberately excluded from this branch.