### PR TITLE
feat(portal): roll progressive disclosure across the remaining surfaces

### DIFF
--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -1,11 +1,12 @@
 ---
-description: "The spore.host portal has one control that decides how much of the interface you see — Guided, Standard, or Expert. What each level shows, and why Guided works with no AI and no credentials."
+description: "The spore.host portal has one control that decides how much of the interface you see — Guided, Standard, or Expert. What each level shows on each page, and why Guided works with no AI and no credentials."
 ---
 
 # Portal detail levels
 
 The [portal](https://spore.host/app) has one control in its header, labelled
-**Detail**, with three settings. It decides how much of the interface you see.
+**Mode**, with three settings side by side. It decides how much of the interface
+you see.
 
 | Level | What you get |
 |---|---|
@@ -15,6 +16,23 @@ The [portal](https://spore.host/app) has one control in its header, labelled
 
 The setting is **remembered** and applies **across the whole portal**, not
 per-page. Changing it re-renders whatever you're looking at.
+
+It's three visible buttons rather than a dropdown, because the levels are an
+**ordered** scale and a collapsed control showing one of them hides that. The
+current level's one-line description sits beside the buttons where you can read it
+before choosing — it used to be a tooltip on each dropdown option, which Safari
+never rendered at all.
+
+Changing the mode **rebuilds the page you're on**, so anything the page was holding
+would be lost. It isn't: your truffle query, the cost window and table view, and
+the team you had open all live in the address bar (`#/truffle?q=nvidia+h100`) and
+come back at the new level. That also makes them bookmarkable and shareable.
+
+Raising the level from inside a page — the **Show me all the options →** buttons —
+puts one dismissible line at the top of the window saying what changed and that
+**Mode** in the header is where to change it back. One click otherwise silently
+rewrites a persistent, portal-wide setting, and finding the way back would need
+exactly the knowledge those buttons exist to not require.
 
 ## Guided mode
 
@@ -28,28 +46,47 @@ machine:
 The cost leads with the **total for the whole run**, not the hourly rate. "$0.1344
 per hour" is a number a first-time user cannot act on; "about $0.54" is.
 
-Picking one gets a single confirmation screen — machine, region, *"Shuts down
-automatically after 4 hours, whatever happens"*, the cost — and one **Start it**
-button. `← Something else` goes back without launching.
+Picking one gets a single confirmation screen — machine, region, when it shuts
+itself down, the cost — and one **Start it** button. `← Something else` goes back
+without launching.
 
-Every guided launch gets a **time limit** — 4 hours for CPU shapes, 2 for GPU ones
-— and none of them use spot. Both are deliberate:
+Every guided launch gets **two** limits, and they're both named on that screen
+because they fail differently:
 
-- **The time limit is not optional.** An instance nobody remembered to stop is the
-  most expensive mistake this interface makes available. The limit is enforced by
-  `spored` *on the machine*, so it holds even if you close the tab — which is
-  exactly what the confirmation screen says, because a user who closes the tab
-  must not be left guessing whether their instance now runs forever or was killed.
-- **Spot is off.** A spot instance can be reclaimed mid-run. That's a good trade
-  once you understand it and a baffling one before you do. See
-  [Spot instances](/guides/spot-instances) for when to take it.
+- **A time limit** — 4 hours for CPU shapes, 2 for GPU ones. Enforced by `spored`
+  *on the machine*, so it holds even if you close the tab. It does **not** hold if
+  the daemon never starts, which is why the instance list flags machines that
+  outlived their limit so you can stop them. The confirmation screen says this
+  rather than promising the shutdown is unconditional — the portal ships a banner
+  for exactly the case such a promise would deny.
+- **A spend cap**, set above the expected cost of the run. Derived from the
+  instance's tags rather than from anything running on it, so it survives the
+  daemon failing. It also turns the cost figure in the instance list into a meter
+  against a ceiling instead of a bare number.
+
+**Spot is off**, and the confirmation now says so along with what that costs. A
+spot instance can be reclaimed mid-run: a good trade once you understand it and a
+baffling one before you do, but paying roughly three times spot's price shouldn't be
+silent either. See [Spot instances](/guides/spot-instances) for when to take it.
+
+The cost figure is **compute only** — no EBS volume, no data transfer — and says
+so. It's priced from the catalog's `us-east-1` figures, so outside that region the
+confirmation adds that your region may differ.
+
+If a machine has **no price** in the catalog, **Start it** stays disabled until you
+tick a box saying you know you're launching something you can't be quoted for. The
+shapes that land there are the accelerator ones: types with no on-demand row are
+generally the $30–100/hr machines, so it's the one place where an accidental click
+is most expensive.
 
 Guided mode hides the launch form but **never** the instance list. Being able to
 start an instance without being able to see or stop it is the one simplification
 that would cost real money.
 
 **I know what I need →** at the bottom of the list moves you to Standard. Guided is
-a starting point, not a cage.
+a starting point, not a cage. Picking a shape on the **Find instances** page — which
+needs no sign-in and so can't launch anything — carries that choice to the
+Instances page rather than making you choose again.
 
 ### Guided mode needs nothing but the portal
 
@@ -106,6 +143,30 @@ that can act on knowing which it is. A field the catalog genuinely doesn't carry
 states something false about the hardware to the user most likely to act on it.
 
 Standard hides all of this because it's noise when you're comparing two boxes.
+
+## What changes on each page
+
+Not every page has three versions, and that's deliberate — a page with no controls,
+no writes and no jargon has nothing to hide and nothing to withhold. Where a page
+isn't listed, it looks the same at every level.
+
+| Page | Guided | Standard | Expert |
+|---|---|---|---|
+| **Instances** | The curated picker instead of the launch form. The instance list is always shown. | Full launch form | + |
+| **Find instances** | The curated picker instead of the query box | Query box | + per-result hardware detail and price provenance |
+| **Cost history** | Same chart and numbers, plainer labels, and a link to Instances to go stop something | Same chart, shorter labels | + compute/storage/network breakdown, window total, peak hour, a 1-year window, and where the series came from |
+| **Teams** | **Read-only.** Your teams and their members, with no forms. | Create teams, add and remove members, delete a team | + team ids, full ARNs, created dates, and who invited whom |
+| **Connect account** | Technical detail collapsed | Collapsed | Expanded — what the IAM role can do, before the button rather than after |
+
+Two rules held throughout:
+
+- **Nothing disappears from the sidebar.** Hiding a page at Guided would mean a user
+  told "check Teams" can neither find it nor tell it exists. Guided's promise is
+  "you can't hurt yourself here", not "fewer features" — so Teams goes read-only
+  rather than absent, with a **Manage teams →** button to move up a level.
+- **Cost history hides nothing at any level**, including its **Table** button. That
+  button is the chart's non-visual equivalent, not a density control, and the people
+  who need it are the least likely to have raised the mode.
 
 ## Notes
 

--- a/web/app/guided/launch.test.ts
+++ b/web/app/guided/launch.test.ts
@@ -353,6 +353,85 @@ describe("mountGuidedLaunch", () => {
     dispose();
   });
 
+  describe("when a shape is carried in from another surface", () => {
+    // The truffle surface's picker is auth-free and cannot launch, so it navigates to
+    // `#/instances?shape=<id>`. Without honouring that the user who chose "A big GPU
+    // for training" met an identical picker asking the same question again — the
+    // choice they'd just made, discarded.
+    it("opens the confirmation for that shape without a second click", async () => {
+      const { client } = stubClient();
+      const shape = GUIDED_SHAPES[3]!; // a GPU shape, not the default first card
+      const dispose = mountGuidedLaunch(host, {
+        client,
+        region: "us-east-1",
+        onEscape: vi.fn(),
+        initialShapeId: shape.id,
+      });
+      await settle();
+      const confirm = host.querySelector<HTMLElement>(".guided-confirm");
+      expect(confirm).toBeTruthy();
+      // The right shape, not merely some shape: carrying the wrong card over would
+      // be worse than carrying none.
+      expect(confirm!.querySelector("h2")!.textContent).toBe(shape.label);
+      dispose();
+    });
+
+    it("falls back to the picker for an unknown id", async () => {
+      // This value comes from the URL, so a stale bookmark or a hand-typed hash is
+      // expected input, not a fault. It must not error and must not blank the panel.
+      const { client } = stubClient();
+      const dispose = mountGuidedLaunch(host, {
+        client,
+        region: "us-east-1",
+        onEscape: vi.fn(),
+        initialShapeId: "no-such-shape",
+      });
+      await settle();
+      expect(host.querySelectorAll(".guided-card")).toHaveLength(GUIDED_SHAPES.length);
+      expect(host.querySelector(".guided-confirm")).toBeNull();
+      dispose();
+    });
+
+    it("leaves the user on the picker when the catalog lookup fails", async () => {
+      // A jump that can't resolve must land somewhere usable. Showing the picker
+      // meanwhile (rather than after) is what makes that true even for a slow catalog.
+      const { client } = stubClient();
+      const shape = GUIDED_SHAPES[0]!;
+      const dispose = mountGuidedLaunch(host, {
+        client,
+        region: "us-east-1",
+        onEscape: vi.fn(),
+        initialShapeId: shape.id,
+        finder: async () => {
+          throw new Error("catalog unreadable");
+        },
+      });
+      await settle();
+      expect(host.querySelector(".guided-confirm")).toBeNull();
+      expect(host.querySelector(".guided-picker")).toBeTruthy();
+      dispose();
+    });
+
+    it("opens no confirmation when the shape resolves to nothing", async () => {
+      // resolveShape returns undefined for a no-match, which is a fact about the
+      // catalog — distinct from a failure, and distinct from a machine we can price.
+      // Confirming a launch for an unresolved shape would be confirming nothing.
+      const { client } = stubClient();
+      const shape = GUIDED_SHAPES[0]!;
+      const dispose = mountGuidedLaunch(host, {
+        client,
+        region: "us-east-1",
+        onEscape: vi.fn(),
+        initialShapeId: shape.id,
+        finder: async () => [],
+      });
+      await settle();
+      expect(host.querySelector(".guided-confirm")).toBeNull();
+      expect(host.querySelector(".guided-card.unresolved")).toBeTruthy();
+      dispose();
+    });
+  });
+
   it("passes the escape hatch through", async () => {
     const onEscape = vi.fn();
     const { client } = stubClient();

--- a/web/app/guided/launch.ts
+++ b/web/app/guided/launch.ts
@@ -8,6 +8,7 @@
 
 import type { SpawnClient } from "@spore-host/spawn-ts";
 import { mountGuidedPicker, type GuidedChoice, type GuidedPickerOptions } from "./picker.js";
+import { GUIDED_SHAPES, resolveShape } from "./shapes.js";
 import { CATALOG_PRICE_REGION, costLimitFor } from "./cost.js";
 
 export interface GuidedLaunchOptions {
@@ -24,6 +25,16 @@ export interface GuidedLaunchOptions {
    */
   finder?: GuidedPickerOptions["finder"];
   shapes?: GuidedPickerOptions["shapes"];
+  /**
+   * Skip the picker and open the confirmation for this shape id.
+   *
+   * The truffle surface's guided picker is auth-free and cannot launch, so it hands
+   * over to this surface — and without carrying the choice, the user who picked
+   * "A big GPU for training" arrived at an identical picker asking the same question
+   * again. Unknown ids fall back to the picker rather than erroring: this comes from
+   * the URL, so a stale bookmark is expected input, not a fault.
+   */
+  initialShapeId?: string;
 }
 
 /** Render the guided launch flow into `host`. Returns a dispose fn. */
@@ -184,7 +195,33 @@ export function mountGuidedLaunch(host: HTMLElement, opts: GuidedLaunchOptions):
     });
   };
 
-  showPicker();
+  // Jump straight to the confirmation when the caller carried a shape over. Resolved
+  // here rather than in the picker so the picker stays a pure list-and-choose: this
+  // is the same resolveShape() the cards use, on one shape.
+  const jumpTo = (shapeId: string): void => {
+    const shape = (opts.shapes ?? GUIDED_SHAPES).find((s) => s.id === shapeId);
+    if (!shape) {
+      showPicker();
+      return;
+    }
+    // Show the picker meanwhile, so a slow catalog read isn't a blank panel — and so
+    // a resolve failure leaves the user somewhere useful instead of nowhere.
+    showPicker();
+    void resolveShape(shape, opts.finder)
+      .then((rec) => {
+        if (!live) return;
+        // resolveShape returns undefined for no-match. Don't open a confirmation for
+        // a machine we couldn't find: the picker renders no-match and failure as the
+        // distinct states they are (#63's invariant), so leave the user there.
+        if (rec) showConfirm({ shape, rec });
+      })
+      .catch(() => {
+        /* the picker is already mounted and shows its own error state */
+      });
+  };
+
+  if (opts.initialShapeId) jumpTo(opts.initialShapeId);
+  else showPicker();
 
   return () => {
     live = false;

--- a/web/app/hashstate.test.ts
+++ b/web/app/hashstate.test.ts
@@ -1,0 +1,90 @@
+// The state-in-URL helper. Small enough to read at a glance, but three of its
+// properties are load-bearing and none of them is obvious from the signature:
+// writes must not fire `hashchange` (or a surface recording its own state would
+// re-route itself out from under the user), an empty value must remove the key
+// rather than write `?q=`, and the route path must survive the query being
+// rewritten.
+import { beforeEach, describe, expect, it } from "vitest";
+import { readHashParam, readHashParams, writeHashParams } from "./hashstate.js";
+
+describe("readHashParams", () => {
+  it("reads params from a hash route", () => {
+    const p = readHashParams("#/truffle?q=nvidia+h100&days=90");
+    expect(p.get("q")).toBe("nvidia h100");
+    expect(p.get("days")).toBe("90");
+  });
+
+  it("returns empty for a route with no query", () => {
+    expect([...readHashParams("#/truffle")]).toEqual([]);
+    expect([...readHashParams("")]).toEqual([]);
+  });
+
+  it("returns null for an absent key", () => {
+    expect(readHashParam("q", "#/truffle?days=7")).toBeNull();
+  });
+});
+
+describe("writeHashParams", () => {
+  beforeEach(() => {
+    location.hash = "#/truffle";
+  });
+
+  it("round-trips a value through the URL", () => {
+    writeHashParams({ q: "nvidia h100" });
+    expect(readHashParam("q")).toBe("nvidia h100");
+  });
+
+  it("keeps the route path", () => {
+    // The path is what the router reads. Rewriting the query must not move the user
+    // to a different surface — which is precisely what a naive `location.hash = "?q="`
+    // would do.
+    writeHashParams({ q: "gpu" });
+    expect(location.hash.split("?")[0]).toBe("#/truffle");
+  });
+
+  it("merges rather than replacing the existing query", () => {
+    // costs writes `days` and `table` from two independent handlers, so a write of
+    // one that dropped the other would silently reset the view on every click.
+    writeHashParams({ days: "90" });
+    writeHashParams({ table: "1" });
+    expect(readHashParam("days")).toBe("90");
+    expect(readHashParam("table")).toBe("1");
+  });
+
+  it("removes a key for null or empty rather than writing an empty value", () => {
+    // A cleared search box should leave a clean, shareable URL — `#/truffle?q=` is
+    // both ugly and a falsy-but-present value for anything reading it back.
+    writeHashParams({ q: "gpu", days: "90" });
+    writeHashParams({ q: "" });
+    expect(readHashParam("q")).toBeNull();
+    writeHashParams({ days: null });
+    expect(location.hash).toBe("#/truffle");
+  });
+
+  it("replaces the history entry instead of pushing one", async () => {
+    // A keystroke-by-keystroke search is not navigation, and filling the back button
+    // with it would make Back useless on the one surface where the user most wants it.
+    //
+    // This is also the observable half of the *other* reason for replaceState: the
+    // shell routes on `hashchange`, and replaceState doesn't fire it, so a surface
+    // recording its own state can't trip a re-route that disposes it mid-keystroke.
+    // That half can't be asserted here — happy-dom fires `hashchange` on
+    // replaceState, which browsers do not (the spec's URL-and-history-update steps
+    // skip it). Verified in Chromium instead; do not "fix" this by writing through
+    // location.hash to make a shim happy.
+    location.hash = "#/truffle";
+    await new Promise((r) => setTimeout(r, 0));
+    const before = history.length;
+    writeHashParams({ q: "gpu" });
+    writeHashParams({ q: "gpu h100" });
+    expect(history.length).toBe(before);
+  });
+
+  it("writes a query onto a bare route", () => {
+    location.hash = "";
+    writeHashParams({ q: "gpu" });
+    // "#/" rather than "" — a query hung off an empty hash would read as the
+    // document's own query string on the next parse.
+    expect(location.hash).toBe("#/?q=gpu");
+  });
+});

--- a/web/app/hashstate.ts
+++ b/web/app/hashstate.ts
@@ -1,0 +1,55 @@
+// Per-surface state in the URL, so a re-mount doesn't lose it.
+//
+// A disclosure-level change re-mounts the current surface (that IS the update
+// mechanism — surfaces read ctx.level once at mount), and the shell clears
+// `.portal-main` to do it. So everything a surface held in a local is gone. The
+// worst case is also the common one: type a truffle query, get rows, want the
+// expert detail on them, raise the level → empty box, query gone. The level change
+// is most often triggered at exactly that moment, on exactly that data.
+//
+// The URL is the store rather than sessionStorage or a shell-held bag, for three
+// reasons: `currentId()` already tolerates a trailing `?query` (it was taught to
+// for the Slack OAuth callback), so no shell change is needed; the state becomes
+// bookmarkable and shareable for free; and there is one source of truth rather
+// than a cache that can disagree with the address bar.
+//
+// Writes use history.replaceState, which does NOT fire `hashchange` — so a surface
+// recording its own state can't trip the router into re-routing underneath itself.
+// (Assigning location.hash would.)
+
+/** The query params on the current hash route, e.g. `#/truffle?q=gpu` → `q=gpu`. */
+export function readHashParams(hash: string = location.hash): URLSearchParams {
+  const q = hash.indexOf("?");
+  return new URLSearchParams(q === -1 ? "" : hash.slice(q + 1));
+}
+
+/** One param from the current hash route, or null. */
+export function readHashParam(key: string, hash: string = location.hash): string | null {
+  return readHashParams(hash).get(key);
+}
+
+/**
+ * Merge `patch` into the current hash route's query and replace the history entry.
+ * A null/empty value removes the key, so a cleared search box leaves a clean URL
+ * rather than `?q=`.
+ *
+ * replaceState rather than pushState: a keystroke-by-keystroke search is not
+ * navigation, and filling the back button with it would make Back useless on the
+ * one surface where the user most wants it.
+ */
+export function writeHashParams(patch: Record<string, string | null | undefined>): void {
+  const hash = location.hash;
+  const q = hash.indexOf("?");
+  const path = (q === -1 ? hash : hash.slice(0, q)) || "#/";
+  const params = readHashParams(hash);
+  for (const [k, v] of Object.entries(patch)) {
+    if (v == null || v === "") params.delete(k);
+    else params.set(k, v);
+  }
+  const qs = params.toString();
+  // `location.pathname + location.search` keeps the SPA's own path intact — the
+  // portal is served from /app/, and a bare "#…" argument to replaceState is
+  // resolved against the current URL anyway, but being explicit survives a future
+  // move to a different base path.
+  history.replaceState(history.state, "", `${location.pathname}${location.search}${path}${qs ? `?${qs}` : ""}`);
+}

--- a/web/app/shell.test.ts
+++ b/web/app/shell.test.ts
@@ -33,7 +33,23 @@ vi.mock("./auth/globus-login.js", () => ({ startSignIn: vi.fn() }));
 
 const { Shell } = await import("./shell.js");
 const { SessionController } = await import("./session.js");
+type SessionController = InstanceType<typeof SessionController>;
+const { LEVEL_INFO, LEVELS } = await import("./disclosure.js");
 const settle = () => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * Fire an expiry transition through the session's real listener set.
+ *
+ * The alternative — arming the timer with a near-past expiration — would make these
+ * tests depend on setTimeout ordering to assert something about banner precedence.
+ * `emit` is private, so this reaches the private set directly rather than mocking
+ * `onExpiry`, which would decouple the test from the wiring it's meant to cover.
+ */
+function fireExpiry(session: SessionController, state: "warning" | "expired"): void {
+  const listeners = (session as unknown as { expiryListeners: Set<(s: string) => void> })
+    .expiryListeners;
+  for (const fn of listeners) fn(state);
+}
 
 /** A session that reports as signed in without touching STS. */
 function signedInSession() {
@@ -167,5 +183,170 @@ describe("Shell level changes", () => {
     await settle();
     expect(disposed.slice(disposeMark)).toContain("truffle");
     expect(mounted.slice(mountMark)).toContain("truffle");
+  });
+});
+
+describe("Shell level control", () => {
+  let root: HTMLElement;
+  let session: SessionController;
+
+  const opts = () => [...root.querySelectorAll<HTMLButtonElement>(".portal-level-opt")];
+  const optFor = (level: string) =>
+    root.querySelector<HTMLButtonElement>(`.portal-level-opt[data-level="${level}"]`)!;
+
+  beforeEach(async () => {
+    disposed.length = 0;
+    mounted.length = 0;
+    location.hash = "#/truffle";
+    document.body.innerHTML = "";
+    root = document.createElement("div");
+    document.body.appendChild(root);
+    session = new SessionController("us-east-1", null);
+    new Shell(root, session, { region: "us-east-1" } as never).start();
+    await settle();
+  });
+
+  it("renders one option per level, in order", () => {
+    // The levels are ORDERED — that ordering is the entire semantics atLeast()
+    // depends on — and three side-by-side options show it where a collapsed
+    // <select> showing one did not.
+    expect(opts().map((o) => o.dataset.level)).toEqual([...LEVELS]);
+  });
+
+  it("shows the current level's blurb as visible text", async () => {
+    // These blurbs were attached as `title` on each <option>, and native
+    // `<option title>` is not reliably rendered anywhere: Safari never shows it and
+    // mobile pickers show labels only. So the copy explaining what each level is FOR
+    // was written, shipped, and seen by almost nobody.
+    expect(root.querySelector(".portal-level-blurb")!.textContent).toBe(
+      LEVEL_INFO[session.level].blurb,
+    );
+    optFor("expert").click();
+    await settle();
+    expect(root.querySelector(".portal-level-blurb")!.textContent).toBe(LEVEL_INFO.expert.blurb);
+  });
+
+  it("sets the level on click and marks exactly one option checked", async () => {
+    optFor("expert").click();
+    await settle();
+    expect(session.level).toBe("expert");
+    const checked = opts().filter((o) => o.getAttribute("aria-checked") === "true");
+    expect(checked.map((o) => o.dataset.level)).toEqual(["expert"]);
+  });
+
+  it("keeps one tab stop for the whole group, on the selected option", async () => {
+    // Roving tabindex: a radiogroup is one stop, not three, and the stop must follow
+    // the selection or Tab would land on an option the user didn't choose.
+    optFor("standard").click();
+    await settle();
+    expect(opts().filter((o) => o.tabIndex === 0).map((o) => o.dataset.level)).toEqual([
+      "standard",
+    ]);
+  });
+
+  it("moves through the group with arrow keys", async () => {
+    // Not optional for role="radiogroup" — a screen-reader user is told this is a
+    // radio group and will try to arrow through it, so without this the control
+    // announces an interaction model it doesn't implement.
+    optFor("guided").focus();
+    const group = root.querySelector<HTMLElement>(".portal-level-group")!;
+    group.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    await settle();
+    expect(session.level).toBe("standard");
+  });
+
+  it("wraps at the ends of the group", async () => {
+    optFor("guided").focus();
+    root
+      .querySelector<HTMLElement>(".portal-level-group")!
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    await settle();
+    expect(session.level).toBe("expert");
+  });
+
+  it("announces the change in a live region", async () => {
+    // Changing the level silently rebuilds .portal-main. Sighted users see that; a
+    // screen-reader user gets an unannounced document mutation, having activated a
+    // control whose entire effect is that mutation.
+    optFor("expert").click();
+    await settle();
+    const live = root.querySelector<HTMLElement>(".portal-live")!;
+    expect(live.getAttribute("aria-live")).toBe("polite");
+    expect(live.textContent).toContain(LEVEL_INFO.expert.label);
+  });
+
+  it("says where to undo a raised level, dismissibly", async () => {
+    // A surface can raise the level itself (the guided picker's "Show me all the
+    // options"), and that one click writes localStorage and changes every surface
+    // forever. The return trip means finding the header control — precisely the
+    // knowledge the escape hatch existed to spare them.
+    optFor("expert").click();
+    await settle();
+    const banner = root.querySelector<HTMLElement>(".portal-banner")!;
+    expect(banner.hidden).toBe(false);
+    expect(banner.textContent).toContain("Mode");
+    banner.querySelector<HTMLButtonElement>(".portal-banner-x")!.click();
+    expect(banner.hidden).toBe(true);
+  });
+
+  it("shows no note when returning to the default level", async () => {
+    // "Showing guided controls" would be explaining the absence of a change.
+    optFor("expert").click();
+    await settle();
+    optFor("guided").click();
+    await settle();
+    expect(root.querySelector<HTMLElement>(".portal-banner")!.hidden).toBe(true);
+  });
+
+  it("never replaces an expiry banner with a level note", async () => {
+    // The expiry banner is telling the user their machines are still running and
+    // still costing money. Trading that for "Showing more options" — explaining a
+    // control they just clicked and can already see — would swap the most expensive
+    // message in the portal for the least.
+    //
+    // Driven through the shell's own onExpiry subscription rather than by poking the
+    // banner, so this fails if that wiring changes too.
+    const banner = root.querySelector<HTMLElement>(".portal-banner")!;
+    fireExpiry(session, "expired");
+    expect(banner.textContent).toContain("costing money");
+
+    optFor("expert").click();
+    await settle();
+    expect(banner.hidden).toBe(false);
+    expect(banner.textContent).toContain("costing money");
+  });
+});
+
+describe("Shell nav order", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    location.hash = "#/truffle";
+    document.body.innerHTML = "";
+    root = document.createElement("div");
+    document.body.appendChild(root);
+  });
+
+  const ids = () =>
+    [...root.querySelectorAll<HTMLAnchorElement>(".portal-tool")].map((a) =>
+      a.getAttribute("href")!.replace("#/", ""),
+    );
+
+  it("puts the auth-free surfaces first when signed out", async () => {
+    // The default route is auth-gated, so a first-time visitor's landing is a sign-in
+    // gate — while the surface explaining how to GET an account to sign in with sat
+    // last in a nine-item list. The mocked registry here has no `connect`, so what
+    // this pins is the auth-free-first half of the rule.
+    const session = new SessionController("us-east-1", null);
+    new Shell(root, session, { region: "us-east-1" } as never).start();
+    await settle();
+    expect(ids()).toEqual(["truffle", "instances"]);
+  });
+
+  it("leaves the registry order alone when signed in", async () => {
+    // The list must not reshuffle unrecognisably at the moment of sign-in.
+    new Shell(root, signedInSession(), { region: "us-east-1" } as never).start();
+    await settle();
+    expect(ids()).toEqual(["instances", "truffle"]);
   });
 });

--- a/web/app/shell.ts
+++ b/web/app/shell.ts
@@ -5,13 +5,15 @@ import { surfaces, findSurface } from "./surfaces/registry.js";
 import type { PortalConfig, SurfaceContext, Disposable } from "./surfaces/types.js";
 import type { SessionController } from "./session.js";
 import { startSignIn } from "./auth/globus-login.js";
-import { isLevel, LEVEL_INFO, LEVELS } from "./disclosure.js";
+import { DEFAULT_LEVEL, isLevel, LEVEL_INFO, LEVELS, type DisclosureLevel } from "./disclosure.js";
 
 export class Shell {
   private navEl!: HTMLElement;
   private mainEl!: HTMLElement;
   private bannerEl!: HTMLElement;
   private current: { id: string; disposable: Disposable } | null = null;
+  // Once expiry has fired, the banner belongs to it — see showLevelNote().
+  private expiryShown = false;
 
   constructor(
     private root: HTMLElement,
@@ -32,8 +34,16 @@ export class Shell {
     // level itself (guided mode's "I know what I need"), and without this the
     // header would still read "Guided" while the user was looking at the standard
     // view — the control lying about the one piece of state it exists to show.
-    this.session.onLevelChange(() => {
+    this.session.onLevelChange((level) => {
       this.renderLevel();
+      this.announceLevel(level);
+      // A surface can raise the level itself — the guided picker's "Show me all the
+      // options" is the whole point of the escape hatch. But that one click writes
+      // localStorage and changes every surface, forever, and the return trip means
+      // finding the header control: precisely the knowledge the escape hatch existed
+      // to spare them. So say what just happened and where to undo it.
+      if (level !== DEFAULT_LEVEL) this.showLevelNote(level);
+      else this.hideBanner();
       void this.route({ remount: true });
     });
     void this.route();
@@ -53,6 +63,9 @@ export class Shell {
         <div class="portal-account"></div>
       </header>
       <div class="portal-banner" hidden></div>
+      <!-- Announces level changes, which silently rebuild .portal-main. Outside
+           .portal-main so a re-mount doesn't destroy the element mid-announcement. -->
+      <div class="portal-live" role="status" aria-live="polite"></div>
       <div class="portal-body">
         <nav class="portal-nav" aria-label="Tools"></nav>
         <main class="portal-main" id="surface-host"></main>
@@ -69,37 +82,113 @@ export class Shell {
    * The one portal-wide disclosure control, in the header beside the account block.
    *
    * A single visible control is the whole state — no per-surface toggles, which
-   * would leave the user unable to say what mode they were in. The blurb is
-   * rendered as the option's title so the choice explains itself; "Guided" alone
-   * doesn't tell a first-timer what they'd get.
+   * would leave the user unable to say what mode they were in.
+   *
+   * A radiogroup of three buttons, not a `<select>`. Three reasons, each a defect
+   * in the `<select>` this replaced:
+   *
+   * 1. The LEVEL_INFO blurbs were attached as `title` on each `<option>`, and
+   *    native `<option title>` is not reliably rendered anywhere — Safari never
+   *    shows it, and mobile pickers show labels only. So the copy explaining what
+   *    each level is FOR was written, shipped, and seen by almost nobody. It is now
+   *    visible text under the control.
+   * 2. A collapsed control hides the scale. These levels are ORDERED — that
+   *    ordering is the entire semantics `atLeast()` depends on — and three
+   *    side-by-side options show it where a dropdown showing one does not.
+   * 3. "Detail" named the wrong axis: the control changes *capability* (spot, TTL,
+   *    AZ, placement), not verbosity. It's "Mode" now.
+   *
+   * The label is a real `<span id>` referenced by aria-labelledby rather than a
+   * `<label for>`, because a radiogroup is not a labelable form control.
    */
   private renderLevel(): void {
     const el = this.root.querySelector<HTMLElement>(".portal-level")!;
     const current = this.session.level;
-    const opts = LEVELS.map(
+    const buttons = LEVELS.map(
       (l) =>
-        `<option value="${l}"${l === current ? " selected" : ""} title="${escapeHtml(
-          LEVEL_INFO[l].blurb,
-        )}">${escapeHtml(LEVEL_INFO[l].label)}</option>`,
+        `<button type="button" class="portal-level-opt${l === current ? " active" : ""}"
+                 role="radio" aria-checked="${l === current}" data-level="${l}"
+                 tabindex="${l === current ? "0" : "-1"}">${escapeHtml(LEVEL_INFO[l].label)}</button>`,
     ).join("");
     el.innerHTML = `
-      <label class="portal-level-label" for="portal-level-select">Detail</label>
-      <select class="portal-level-select" id="portal-level-select"
-              title="${escapeHtml(LEVEL_INFO[current].blurb)}">${opts}</select>`;
-    const select = el.querySelector<HTMLSelectElement>(".portal-level-select")!;
-    select.addEventListener("change", () => {
-      // Guard rather than cast: a stale bookmarked value or a hand-edited DOM
-      // must not put an unknown string into the level, where every atLeast()
-      // comparison would silently read as below-guided.
-      if (!isLevel(select.value)) return;
-      this.session.setLevel(select.value);
-      select.title = LEVEL_INFO[select.value].blurb;
+      <span class="portal-level-label" id="portal-level-label">Mode</span>
+      <div class="portal-level-group" role="radiogroup" aria-labelledby="portal-level-label"
+           >${buttons}</div>
+      <span class="portal-level-blurb">${escapeHtml(LEVEL_INFO[current].blurb)}</span>`;
+
+    const group = el.querySelector<HTMLElement>(".portal-level-group")!;
+    const opts = [...group.querySelectorAll<HTMLButtonElement>(".portal-level-opt")];
+
+    const pick = (btn: HTMLButtonElement): void => {
+      const v = btn.dataset.level;
+      // Guard rather than cast: a hand-edited DOM must not put an unknown string
+      // into the level, where every atLeast() comparison would silently read as
+      // below-guided — i.e. the most restrictive mode, for no visible reason.
+      if (!isLevel(v)) return;
+      this.session.setLevel(v);
+    };
+
+    group.addEventListener("click", (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".portal-level-opt");
+      if (btn) pick(btn);
     });
+
+    // Arrow-key navigation is not optional for role="radiogroup" — a screen-reader
+    // user is told this is a radio group and will try to arrow through it. Roving
+    // tabindex (one stop for the whole group) matches that expectation too.
+    group.addEventListener("keydown", (e) => {
+      const idx = opts.findIndex((o) => o === document.activeElement);
+      if (idx === -1) return;
+      const delta =
+        e.key === "ArrowRight" || e.key === "ArrowDown"
+          ? 1
+          : e.key === "ArrowLeft" || e.key === "ArrowUp"
+            ? -1
+            : 0;
+      if (!delta) return;
+      e.preventDefault();
+      const next = opts[(idx + delta + opts.length) % opts.length]!;
+      next.focus();
+      pick(next);
+    });
+  }
+
+  /**
+   * Announce a level change to assistive tech.
+   *
+   * Changing the level silently rebuilds `.portal-main`. Sighted users see that;
+   * a screen-reader user gets an unannounced document mutation, having activated a
+   * control whose effect is exactly that mutation. `aria-checked` on the button
+   * says which option is selected but not that the page behind it changed.
+   */
+  private announceLevel(level: DisclosureLevel): void {
+    const live = this.root.querySelector<HTMLElement>(".portal-live");
+    if (!live) return;
+    live.textContent = `${LEVEL_INFO[level].label} mode — ${LEVEL_INFO[level].blurb}`;
+  }
+
+  /**
+   * The sidebar. Nothing is ever hidden by level — see the note in disclosure.ts on
+   * why: hiding a nav entry means the user can neither find the feature nor learn it
+   * exists, and guided's promise is "you can't hurt yourself", not "fewer features".
+   *
+   * The one reorder is by auth, not by level. The default route is `instances`,
+   * which is auth-gated, so a first-time visitor's landing is a sign-in gate — and
+   * "Connect account", the surface explaining how to GET an account to sign in with,
+   * sat last in a nine-item list. For a signed-out visitor the auth-free surfaces
+   * come first, "Connect account" at the top, with the relative order otherwise
+   * preserved so the list doesn't reshuffle unrecognisably on sign-in.
+   */
+  private navSurfaces(): typeof surfaces {
+    if (this.session.signedIn) return surfaces;
+    const rank = (s: (typeof surfaces)[number]): number =>
+      s.id === "connect" ? 0 : s.requiresAuth ? 2 : 1;
+    return [...surfaces].sort((a, b) => rank(a) - rank(b));
   }
 
   private renderNav(): void {
     const active = this.currentId();
-    this.navEl.innerHTML = surfaces
+    this.navEl.innerHTML = this.navSurfaces()
       .map(
         (s) =>
           `<a class="portal-tool${s.id === active ? " active" : ""}" href="#/${s.id}"
@@ -221,6 +310,7 @@ export class Shell {
    * is happening" — the opposite of what's true, and expensive to believe.
    */
   private showExpiry(state: "warning" | "expired"): void {
+    this.expiryShown = true;
     this.bannerEl.hidden = false;
     if (state === "warning") {
       this.bannerEl.className = "portal-banner warn";
@@ -235,6 +325,37 @@ export class Shell {
         void startSignIn(this.config);
       });
     }
+  }
+
+  /**
+   * A dismissible note that the mode changed, in the EXISTING banner element.
+   *
+   * Reuses `.portal-banner` rather than adding a second notification slot: two
+   * stacked banners is how a header starts eating the viewport, and there is never a
+   * reason to show both of these at once.
+   *
+   * Never overwrites an expiry banner. That one is telling the user their machines
+   * are still running and still costing money; replacing it with "Showing more
+   * options" to explain a control they just clicked and can already see would trade
+   * the most expensive message in the portal for the least.
+   */
+  private showLevelNote(level: DisclosureLevel): void {
+    if (this.expiryShown) return;
+    this.bannerEl.hidden = false;
+    this.bannerEl.className = "portal-banner info";
+    this.bannerEl.innerHTML = `Showing ${escapeHtml(
+      LEVEL_INFO[level].label.toLowerCase(),
+    )} controls. Change this any time with <b>Mode</b> in the header.
+      <button class="portal-banner-x" aria-label="Dismiss">×</button>`;
+    this.bannerEl.querySelector(".portal-banner-x")!.addEventListener("click", () => {
+      this.hideBanner();
+    });
+  }
+
+  private hideBanner(): void {
+    if (this.expiryShown) return;
+    this.bannerEl.hidden = true;
+    this.bannerEl.innerHTML = "";
   }
 }
 

--- a/web/app/surfaces/costs.test.ts
+++ b/web/app/surfaces/costs.test.ts
@@ -1,0 +1,284 @@
+// Per-level rendering of the cost-history surface.
+//
+// Disclosure here is ADDITIVE ONLY — this is the one surface that answers "what am I
+// spending?", so nothing is hidden from anyone. That makes the negative assertions
+// the important ones: the table toggle is an accessibility affordance for the chart,
+// not a density control, and a future "simplify guided" change that removed it would
+// take the chart's only non-visual path with it.
+//
+// `fetch` is stubbed. The real endpoint needs a federated session, and what's under
+// test is the rendering of a known series, not the transport.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionController } from "../session.js";
+import type { PortalConfig, SurfaceContext } from "./types.js";
+import type { DisclosureLevel } from "../disclosure.js";
+import { costsSurface } from "./costs.js";
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+const config = { region: "us-east-1", apiBase: "https://api.example" } as PortalConfig;
+
+/**
+ * Five daily samples with a mid-window spike.
+ *
+ * The spike is deliberate: it's what makes the expert-only "Peak hourly" tile
+ * distinguishable from "Current hourly cost", which reads the last point. A flat
+ * series would let a broken peak calculation pass.
+ */
+const HISTORY = [
+  { timestamp: "2026-07-01T00:00:00Z", hourly_cost: 0.5, monthly_estimate: 365, instance_count: 1, breakdown: { compute: 0.4, storage: 0.08, network: 0.02 } },
+  { timestamp: "2026-07-02T00:00:00Z", hourly_cost: 0.75, monthly_estimate: 547.5, instance_count: 2, breakdown: { compute: 0.6, storage: 0.1, network: 0.05 } },
+  { timestamp: "2026-07-03T00:00:00Z", hourly_cost: 4.25, monthly_estimate: 3102.5, instance_count: 6, breakdown: { compute: 4.0, storage: 0.2, network: 0.05 } },
+  { timestamp: "2026-07-04T00:00:00Z", hourly_cost: 0.9, monthly_estimate: 657, instance_count: 2, breakdown: { compute: 0.7, storage: 0.15, network: 0.05 } },
+  { timestamp: "2026-07-05T00:00:00Z", hourly_cost: 1.25, monthly_estimate: 912.5, instance_count: 3, breakdown: { compute: 1.0, storage: 0.2, network: 0.05 } },
+];
+
+/** Records every requested `days` so the preset wiring can be asserted. */
+let requestedDays: number[] = [];
+
+function stubFetch(history: unknown = HISTORY): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      requestedDays.push(Number(new URL(url).searchParams.get("days")));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, history }),
+      } as never;
+    }),
+  );
+}
+
+function ctxAt(level: DisclosureLevel, navigate = vi.fn()): SurfaceContext {
+  const session = new SessionController("us-east-1", null);
+  session.setLevel(level);
+  vi.spyOn(session, "getCreds").mockReturnValue({
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "secret",
+    sessionToken: "token",
+  } as never);
+  return { session, config, level, navigate };
+}
+
+describe("costsSurface disclosure", () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    requestedDays = [];
+    stubFetch();
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    location.hash = "#/costs";
+  });
+
+  it("keeps the table toggle at every level", async () => {
+    // Not a density control. It is the chart's non-visual equivalent, and the users
+    // most likely to need it are the least likely to have raised the mode.
+    for (const level of ["guided", "standard", "expert"] as const) {
+      host.innerHTML = "";
+      const d = await costsSurface.mount(host, ctxAt(level));
+      await settle();
+      expect(host.querySelector(".costs-tabletoggle"), level).not.toBeNull();
+      d.dispose();
+    }
+  });
+
+  it("shows the same series at every level", async () => {
+    // Additive only: nobody is shown less spend than anyone else.
+    for (const level of ["guided", "standard", "expert"] as const) {
+      host.innerHTML = "";
+      const d = await costsSurface.mount(host, ctxAt(level));
+      await settle();
+      expect(host.querySelector(".costs-chart"), level).not.toBeNull();
+      d.dispose();
+    }
+  });
+
+  it("does not call the projection a 'monthly estimate' at guided", async () => {
+    // `monthly_estimate` is hourly × 730 — a projection of this instant, not a sum of
+    // anything that happened. "Monthly estimate" is read as a bill owed, and it's
+    // wrong in both directions: a machine shut down in an hour will never cost that,
+    // and one launched tomorrow isn't in it. This is the portal's most expensive
+    // misreading, so guided states the condition.
+    const d = await costsSurface.mount(host, ctxAt("guided"));
+    await settle();
+    const labels = [...host.querySelectorAll(".costs-tile-label")].map((e) => e.textContent);
+    expect(labels).not.toContain("Monthly estimate");
+    expect(labels.join(" ")).toContain("If it keeps running");
+    d.dispose();
+  });
+
+  it("offers a route to Instances at guided only", async () => {
+    // A cost figure with no adjacent way to ACT on it is where a guided user gets
+    // stuck: they can see they're spending money and not what to do about it. From
+    // standard up the sidebar is enough.
+    const navigate = vi.fn();
+    const d = await costsSurface.mount(host, ctxAt("guided", navigate));
+    await settle();
+    host.querySelector<HTMLButtonElement>(".costs-goinstances")!.click();
+    expect(navigate).toHaveBeenCalledWith("instances");
+    d.dispose();
+
+    host.innerHTML = "";
+    const d2 = await costsSurface.mount(host, ctxAt("standard"));
+    await settle();
+    expect(host.querySelector(".costs-goinstances")).toBeNull();
+    d2.dispose();
+  });
+
+  it("adds the window-total and peak tiles only at expert", async () => {
+    // The existing tiles all read history[length-1], so "is this growing / did
+    // something spike" is unanswerable from them — and that's the question a 90-day
+    // window is opened to ask.
+    for (const [level, expected] of [
+      ["standard", false],
+      ["expert", true],
+    ] as const) {
+      host.innerHTML = "";
+      const d = await costsSurface.mount(host, ctxAt(level));
+      await settle();
+      const labels = [...host.querySelectorAll(".costs-tile-label")].map((e) => e.textContent).join(" ");
+      expect(labels.includes("Peak hourly"), level).toBe(expected);
+      expect(labels.includes("Window total"), level).toBe(expected);
+      d.dispose();
+    }
+  });
+
+  it("reports the peak from the whole window, not the last point", async () => {
+    // The spike is mid-series, so a peak computed off history[length-1] would read
+    // $1.25 and look plausible.
+    const d = await costsSurface.mount(host, ctxAt("expert"));
+    await settle();
+    const peakTile = [...host.querySelectorAll(".costs-tile")].find((t) =>
+      t.textContent!.includes("Peak hourly"),
+    )!;
+    // The figure and the date it came from are separate elements. Concatenating them
+    // into the 1.5rem value wraps as "$4.25 · Jul" / "3", which reads as a broken
+    // number — and "which sample" is unusable without knowing which one it was.
+    expect(peakTile.querySelector(".costs-tile-value")!.textContent).toContain("4.25");
+    // A date, not pinned to one: `fmtDate` renders the UTC timestamp in the runner's
+    // local zone, so the spike's "Jul 3" is "Jul 2" west of Greenwich.
+    expect(peakTile.querySelector(".costs-tile-note")!.textContent).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/);
+    d.dispose();
+  });
+
+  it("offers a 1-year preset only at expert", async () => {
+    // Four buttons of noise is a cost paid by every user for a question only some are
+    // asking.
+    for (const [level, expected] of [
+      ["guided", false],
+      ["standard", false],
+      ["expert", true],
+    ] as const) {
+      host.innerHTML = "";
+      const d = await costsSurface.mount(host, ctxAt(level));
+      await settle();
+      const days = [...host.querySelectorAll<HTMLElement>(".costs-range")].map((b) => b.dataset.days);
+      expect(days.includes("365"), level).toBe(expected);
+      d.dispose();
+    }
+  });
+
+  it("breaks the cost down by component in the table only at expert", async () => {
+    // The API has always returned compute/storage/network per point and the UI always
+    // dropped it. It's the difference between "spend is up" and "spend is up because
+    // of storage, which shutting an instance down will not fix". The table carries it
+    // as well as the tooltip, or it would be mouse-only.
+    for (const [level, expected] of [
+      ["standard", false],
+      ["expert", true],
+    ] as const) {
+      host.innerHTML = "";
+      // Reset the hash between iterations: the toggle persists there, so the second
+      // mount would open already-showing-the-table and the click would turn it off.
+      location.hash = "#/costs";
+      const d = await costsSurface.mount(host, ctxAt(level));
+      await settle();
+      host.querySelector<HTMLButtonElement>(".costs-tabletoggle")!.click();
+      const heads = [...host.querySelectorAll(".costs-table th")].map((t) => t.textContent);
+      expect(heads.includes("Storage"), level).toBe(expected);
+      d.dispose();
+    }
+  });
+
+  it("shows an absent breakdown as unknown, not as zero", async () => {
+    // Zero storage cost is a claim about the account, and a missing field is not
+    // evidence for it.
+    requestedDays = [];
+    stubFetch([{ timestamp: "2026-07-01T00:00:00Z", hourly_cost: 0.5, monthly_estimate: 365, instance_count: 1 }]);
+    const d = await costsSurface.mount(host, ctxAt("expert"));
+    await settle();
+    host.querySelector<HTMLButtonElement>(".costs-tabletoggle")!.click();
+    const cells = [...host.querySelectorAll(".costs-table tbody td")].map((t) => t.textContent);
+    expect(cells).toContain("—");
+    expect(cells).not.toContain("$0.0000");
+    d.dispose();
+  });
+
+  it("states the endpoint and sample density only at expert", async () => {
+    // The chart looks like a continuous line but is N discrete samples the API chose
+    // the spacing of, so a spike between them is invisible. Expert is the level that
+    // can go ask the endpoint directly; below it this is noise.
+    for (const [level, expected] of [
+      ["standard", false],
+      ["expert", true],
+    ] as const) {
+      host.innerHTML = "";
+      const d = await costsSurface.mount(host, ctxAt(level));
+      await settle();
+      expect(host.querySelector(".costs-provenance") !== null, level).toBe(expected);
+      d.dispose();
+    }
+  });
+
+  describe("state survives a re-mount", () => {
+    it("restores the chosen window", async () => {
+      // A level change re-mounts this surface. Silently resetting a 90-day window to
+      // 30 would make the mode control feel like it lost the user's place — which it
+      // did.
+      const first = await costsSurface.mount(host, ctxAt("standard"));
+      await settle();
+      host.querySelector<HTMLButtonElement>('.costs-range[data-days="90"]')!.click();
+      await settle();
+      first.dispose();
+
+      host.innerHTML = "";
+      requestedDays = [];
+      const second = await costsSurface.mount(host, ctxAt("expert"));
+      await settle();
+      expect(requestedDays[0]).toBe(90);
+      expect(
+        host.querySelector<HTMLElement>('.costs-range[data-days="90"]')!.getAttribute("aria-pressed"),
+      ).toBe("true");
+      second.dispose();
+    });
+
+    it("restores the table view", async () => {
+      const first = await costsSurface.mount(host, ctxAt("standard"));
+      await settle();
+      host.querySelector<HTMLButtonElement>(".costs-tabletoggle")!.click();
+      expect(host.querySelector(".costs-table")).not.toBeNull();
+      first.dispose();
+
+      host.innerHTML = "";
+      const second = await costsSurface.mount(host, ctxAt("standard"));
+      await settle();
+      expect(host.querySelector(".costs-table")).not.toBeNull();
+      expect(host.querySelector(".costs-chart")).toBeNull();
+      second.dispose();
+    });
+
+    it("ignores a window the current level doesn't offer", async () => {
+      // `?days=365` is reachable from a bookmark made at expert, or by hand. At
+      // standard there is no 365 button, so honouring it would show a year of data
+      // above a control set that all reads unpressed — a view the user cannot undo.
+      location.hash = "#/costs?days=365";
+      const d = await costsSurface.mount(host, ctxAt("standard"));
+      await settle();
+      expect(requestedDays[0]).toBe(30);
+      d.dispose();
+    });
+  });
+});

--- a/web/app/surfaces/costs.ts
+++ b/web/app/surfaces/costs.ts
@@ -10,8 +10,15 @@
 // tooltip snapping to the nearest day. KPI row of stat tiles for the current
 // values. Days-range presets in one row above. Table view for a11y. Text wears
 // ink tokens, never the series hue.
+//
+// Disclosure: ADDITIVE ONLY. This is the one surface that answers "what am I
+// spending?", so nothing is hidden from anyone — guided relabels, expert adds. The
+// `.costs-tabletoggle` in particular stays at every level: it's an accessibility
+// affordance for the chart, not a density control.
 import type { AwsCreds } from "@spore-host/spawn-ts/auth";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+import { atLeast, type DisclosureLevel } from "../disclosure.js";
+import { readHashParam, writeHashParams } from "../hashstate.js";
 
 interface CostComponents {
   compute: number;
@@ -34,7 +41,13 @@ interface CostHistoryResponse {
   error?: string;
 }
 
+// Expert gets a year. A 365-day window is the one that answers "is this growing?"
+// rather than "what did last month look like", and it's the level that can act on
+// the answer. Kept out of the shorter list because four buttons of noise is a cost
+// paid by every user for a question only some are asking.
 const DAY_PRESETS = [7, 30, 90] as const;
+const EXPERT_DAY_PRESETS = [7, 30, 90, 365] as const;
+const DEFAULT_DAYS = 30;
 
 function credentialsHeader(creds: AwsCreds): string {
   return btoa(
@@ -56,31 +69,60 @@ export const costsSurface: ToolSurface = {
     const creds = ctx.session.getCreds();
     if (!creds) throw new Error("costs surface mounted without a session");
 
+    const level = ctx.level;
+    const expert = atLeast(level, "expert");
+    const presets = expert ? EXPERT_DAY_PRESETS : DAY_PRESETS;
+
+    // Restored from the hash so a mode change (which re-mounts this surface) doesn't
+    // silently reset the window the user chose and the view they were reading.
+    const urlDays = Number(readHashParam("days"));
+    let days = presets.includes(urlDays as never) ? urlDays : DEFAULT_DAYS;
+    let showTable = readHashParam("table") === "1";
+
     const root = document.createElement("div");
     root.className = "costs-surface";
     root.innerHTML = `
       <div class="costs-head">
         <h2>Cost history</h2>
-        <p class="costs-hint">Estimated hourly spend across your account, from the
-          shared dashboard-api over your federated session.</p>
+        <p class="costs-hint">${
+          atLeast(level, "standard")
+            ? `Estimated hourly spend across your account, from the
+               shared dashboard-api over your federated session.`
+            : `What your account is spending on machines. Estimated from what's
+               running — not a bill from AWS.`
+        }</p>
       </div>
       <div class="costs-controls" role="group" aria-label="Time range">
-        ${DAY_PRESETS.map(
-          (d) =>
-            `<button type="button" class="costs-range" data-days="${d}" aria-pressed="${d === 30}">${d}d</button>`,
-        ).join("")}
-        <button type="button" class="costs-tabletoggle" aria-pressed="false">Table</button>
+        ${presets
+          .map(
+            (d) =>
+              `<button type="button" class="costs-range" data-days="${d}" aria-pressed="${d === days}">${
+                d === 365 ? "1y" : `${d}d`
+              }</button>`,
+          )
+          .join("")}
+        <button type="button" class="costs-tabletoggle" aria-pressed="${showTable}">Table</button>
       </div>
       <div class="costs-kpis" aria-live="polite"></div>
-      <div class="costs-body" aria-live="polite"><div class="costs-status">loading…</div></div>`;
+      <div class="costs-body" aria-live="polite"><div class="costs-status">loading…</div></div>
+      ${
+        atLeast(level, "standard")
+          ? ""
+          : // A cost figure with no adjacent way to ACT on it is where a guided user
+            // gets stuck: they can see they're spending money and not what to do
+            // about it. The instance list is where you stop things.
+            `<p class="costs-act">To stop something that's running, go to
+             <button type="button" class="costs-goinstances">Instances</button>.</p>`
+      }`;
     host.appendChild(root);
 
     const controls = root.querySelector<HTMLElement>(".costs-controls")!;
     const kpis = root.querySelector<HTMLElement>(".costs-kpis")!;
     const body = root.querySelector<HTMLElement>(".costs-body")!;
 
-    let days = 30;
-    let showTable = false;
+    const goInstances = root.querySelector<HTMLButtonElement>(".costs-goinstances");
+    const onGo = () => ctx.navigate("instances");
+    goInstances?.addEventListener("click", onGo);
     let last: CostPoint[] = [];
     let controller: AbortController | null = null;
     let seq = 0;
@@ -124,13 +166,14 @@ export const costsSurface: ToolSurface = {
     }
 
     function render(): void {
-      renderKpis(kpis, last);
+      renderKpis(kpis, last, level);
       if (!last.length) {
         body.innerHTML = `<div class="costs-status">No cost history yet for this account.</div>`;
         return;
       }
       body.innerHTML = "";
-      body.appendChild(showTable ? buildTable(last) : buildChart(last));
+      body.appendChild(showTable ? buildTable(last, expert) : buildChart(last, expert));
+      if (expert) body.appendChild(buildProvenance(last, days, ctx.config.apiBase));
     }
 
     const onControlsClick = (e: Event) => {
@@ -143,11 +186,13 @@ export const costsSurface: ToolSurface = {
           for (const b of controls.querySelectorAll<HTMLButtonElement>(".costs-range")) {
             b.setAttribute("aria-pressed", String(Number(b.dataset.days) === days));
           }
+          writeHashParams({ days: d === DEFAULT_DAYS ? null : String(d) });
           void load();
         }
       } else if (btn.classList.contains("costs-tabletoggle")) {
         showTable = !showTable;
         btn.setAttribute("aria-pressed", String(showTable));
+        writeHashParams({ table: showTable ? "1" : null });
         render();
       }
     };
@@ -165,6 +210,7 @@ export const costsSurface: ToolSurface = {
       dispose() {
         offExpiry();
         controls.removeEventListener("click", onControlsClick);
+        goInstances?.removeEventListener("click", onGo);
         controller?.abort();
         root.remove();
       },
@@ -173,30 +219,71 @@ export const costsSurface: ToolSurface = {
 };
 
 // ── KPI row ──────────────────────────────────────────────────────────────────
-function renderKpis(host: HTMLElement, history: CostPoint[]): void {
+/**
+ * The stat tiles.
+ *
+ * `monthly_estimate` is `hourly × 730` — a projection of the current instant, not a
+ * sum of anything that happened. "Monthly estimate" is read as a bill owed, which is
+ * the portal's most expensive misreading: it's wrong in both directions (a machine
+ * shut down an hour from now will never cost that, and one launched tomorrow isn't
+ * in it). Guided phrases it as the conditional it is. Standard and expert keep the
+ * shorter label — they have the chart beside it to read the number against.
+ */
+function renderKpis(host: HTMLElement, history: CostPoint[], level: DisclosureLevel): void {
   if (!history.length) {
     host.innerHTML = "";
     return;
   }
   const latest = history[history.length - 1]!;
-  const tiles = [
-    { label: "Current hourly cost", value: fmtUsd(latest.hourly_cost) },
-    { label: "Monthly estimate", value: fmtUsd(latest.monthly_estimate) },
-    { label: "Instances", value: String(latest.instance_count) },
-  ];
+  const tiles: { label: string; value: string; note?: string }[] = atLeast(level, "standard")
+    ? [
+        { label: "Current hourly cost", value: fmtUsd(latest.hourly_cost) },
+        { label: "Monthly estimate", value: fmtUsd(latest.monthly_estimate) },
+        { label: "Instances", value: String(latest.instance_count) },
+      ]
+    : [
+        { label: "Running right now", value: `${fmtUsd(latest.hourly_cost)}/hr` },
+        { label: "If it keeps running", value: `${fmtUsd(latest.monthly_estimate)} a month` },
+        { label: "Machines running", value: String(latest.instance_count) },
+      ];
+
+  // Expert gets the two figures the single latest row cannot answer: what the window
+  // actually cost, and what the worst hour in it was. The existing tiles all read
+  // history[length-1], so "is this growing / did something spike" is unanswerable
+  // from them — and that's the question a 90-day or 1-year window is opened to ask.
+  if (atLeast(level, "expert")) {
+    const hours = history.map((p) => p.hourly_cost);
+    const peak = Math.max(...hours);
+    const peakAt = history[hours.indexOf(peak)]!;
+    // Each point is one sample, not one hour, so summing hourly_cost would be
+    // summing rates. Mean rate × elapsed hours is the honest window total, and
+    // labelled as approximate because the sampling interval is the API's choice.
+    const spanMs = new Date(history[history.length - 1]!.timestamp).getTime() - new Date(history[0]!.timestamp).getTime();
+    const spanHours = spanMs > 0 ? spanMs / 3_600_000 : 0;
+    const mean = hours.reduce((a, b) => a + b, 0) / hours.length;
+    tiles.push(
+      { label: "Window total (approx)", value: spanHours > 0 ? `~${fmtUsd(mean * spanHours)}` : "—" },
+      // The date is a `note`, not appended to the value: at 1.5rem in a 140px tile
+      // `$4.25 · Jul 12` wraps to "$4.25 · Jul" / "12", which reads as a broken
+      // number. It's metadata about the peak, not part of the figure.
+      { label: "Peak hourly", value: fmtUsd(peak), note: fmtDate(peakAt.timestamp) },
+    );
+  }
+
   host.innerHTML = tiles
     .map(
       (t) => `
       <div class="costs-tile">
         <div class="costs-tile-label">${escapeHtml(t.label)}</div>
         <div class="costs-tile-value">${escapeHtml(t.value)}</div>
+        ${t.note ? `<div class="costs-tile-note">${escapeHtml(t.note)}</div>` : ""}
       </div>`,
     )
     .join("");
 }
 
 // ── Area + line chart (SVG) ────────────────────────────────────────────────────
-function buildChart(history: CostPoint[]): SVGSVGElement {
+function buildChart(history: CostPoint[], expert = false): SVGSVGElement {
   const W = 720;
   const H = 300;
   const M = { top: 16, right: 20, bottom: 28, left: 56 };
@@ -337,6 +424,18 @@ function buildChart(history: CostPoint[]): SVGSVGElement {
     meta.textContent = `${fmtDate(p.timestamp)} · ${p.instance_count} instance${p.instance_count === 1 ? "" : "s"}`;
     tip.appendChild(val);
     tip.appendChild(meta);
+    // The API has always returned compute/storage/network per point and the UI has
+    // always dropped it. It's the difference between "spend is up" and "spend is up
+    // because of storage, which shutting an instance down will not fix" — so it goes
+    // where the number it explains already is.
+    if (expert && p.breakdown) {
+      const b = document.createElement("div");
+      b.className = "costs-tip-breakdown";
+      b.textContent = `compute ${fmtUsd(p.breakdown.compute)} · storage ${fmtUsd(
+        p.breakdown.storage,
+      )} · network ${fmtUsd(p.breakdown.network)}`;
+      tip.appendChild(b);
+    }
     // Position in wrap pixel space (viewBox → wrap ratio).
     const ratio = wrap.clientWidth / W || 1;
     tip.style.display = "";
@@ -359,16 +458,28 @@ function buildChart(history: CostPoint[]): SVGSVGElement {
 }
 
 // ── Table view (a11y / non-visual) ─────────────────────────────────────────────
-function buildTable(history: CostPoint[]): HTMLElement {
+function buildTable(history: CostPoint[], expert = false): HTMLElement {
   const table = document.createElement("table");
   table.className = "costs-table";
   const thead = document.createElement("thead");
-  thead.innerHTML = `<tr><th>Date</th><th>Hourly</th><th>Monthly est.</th><th>Instances</th></tr>`;
+  // The table is the a11y path to the chart, so it carries whatever the chart's
+  // tooltip carries — otherwise the breakdown would be mouse-only.
+  const extra = expert ? `<th>Compute</th><th>Storage</th><th>Network</th>` : "";
+  thead.innerHTML = `<tr><th>Date</th><th>Hourly</th><th>Monthly est.</th><th>Instances</th>${extra}</tr>`;
   table.appendChild(thead);
   const tbody = document.createElement("tbody");
   for (const p of history) {
     const tr = document.createElement("tr");
     const cells = [fmtDate(p.timestamp), fmtUsd(p.hourly_cost), fmtUsd(p.monthly_estimate), String(p.instance_count)];
+    if (expert) {
+      // An absent breakdown is "—", not $0.00: zero storage cost is a claim about
+      // the account, and a missing field isn't evidence for it.
+      cells.push(
+        p.breakdown ? fmtUsd(p.breakdown.compute) : "—",
+        p.breakdown ? fmtUsd(p.breakdown.storage) : "—",
+        p.breakdown ? fmtUsd(p.breakdown.network) : "—",
+      );
+    }
     for (const c of cells) {
       const td = document.createElement("td");
       td.textContent = c; // untrusted data → textContent
@@ -378,6 +489,26 @@ function buildTable(history: CostPoint[]): HTMLElement {
   }
   table.appendChild(tbody);
   return table;
+}
+
+/**
+ * Where the series came from and how densely it's sampled.
+ *
+ * Expert-only because it's only actionable if you know what to do with it: the chart
+ * looks like a continuous line but is N discrete samples the API chose the spacing
+ * of, so a spike between samples is invisible. Someone reading this can go ask the
+ * endpoint directly; at standard it would be noise.
+ */
+function buildProvenance(history: CostPoint[], days: number, apiBase: string): HTMLElement {
+  const p = document.createElement("p");
+  p.className = "costs-provenance";
+  const spanMs =
+    new Date(history[history.length - 1]!.timestamp).getTime() -
+    new Date(history[0]!.timestamp).getTime();
+  const everyH = history.length > 1 && spanMs > 0 ? spanMs / 3_600_000 / (history.length - 1) : 0;
+  const cadence = everyH > 0 ? `, ~1 sample every ${everyH < 1 ? `${Math.round(everyH * 60)} min` : `${everyH.toFixed(1)} h`}` : "";
+  p.textContent = `${history.length} sample${history.length === 1 ? "" : "s"} over ${days} days${cadence} — GET ${apiBase}/api/cost-history?days=${days}`;
+  return p;
 }
 
 // ── helpers ────────────────────────────────────────────────────────────────────

--- a/web/app/surfaces/instances.ts
+++ b/web/app/surfaces/instances.ts
@@ -11,6 +11,7 @@ import "@spore-host/spawn-ts/ui/style.css";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
 import { atLeast } from "../disclosure.js";
 import { mountGuidedLaunch } from "../guided/launch.js";
+import { readHashParam } from "../hashstate.js";
 
 export const instancesSurface: ToolSurface = {
   id: "instances",
@@ -54,10 +55,14 @@ export const instancesSurface: ToolSurface = {
       host.classList.add("guided-instances");
       const panel = document.createElement("div");
       host.appendChild(panel);
+      // `#/instances?shape=big-gpu` — the truffle surface's picker hands the choice
+      // over rather than making the user repeat it here.
+      const shapeId = readHashParam("shape");
       disposeGuided = mountGuidedLaunch(panel, {
         client,
         region: ctx.session.region,
         onEscape: () => ctx.session.setLevel("standard"),
+        ...(shapeId ? { initialShapeId: shapeId } : {}),
       });
     }
     host.appendChild(dashboard.el);

--- a/web/app/surfaces/onboarding.ts
+++ b/web/app/surfaces/onboarding.ts
@@ -5,7 +5,13 @@
 // deployment/cloudformation/portal-onboarding-role.yaml. The template's
 // phone-home custom resource auto-registers the new role with the portal on stack
 // create, so there's nothing to copy-paste back.
+//
+// Disclosure: this surface is already written in guided register — four numbered
+// steps, one CTA, and the technical detail (what the role can do, the CLI
+// equivalent, the ExternalId) behind a `<details>`. So the only level-dependent
+// thing is whether that `<details>` starts open.
 import type { Disposable, PortalConfig, SurfaceContext, ToolSurface } from "./types.js";
+import { atLeast } from "../disclosure.js";
 
 export const onboardingSurface: ToolSurface = {
   id: "connect",
@@ -62,7 +68,11 @@ export const onboardingSurface: ToolSurface = {
 
         <a class="onboard-launch" target="_blank" rel="noopener">Launch the CloudFormation stack ↗</a>
 
-        <details class="onboard-details">
+        <!-- Open at expert: an expert reading "grant spore.host permission to launch
+             EC2 in your own account" wants the IAM scope before the CTA, not after
+             clicking to find it. Below expert it stays collapsed — the whole design
+             of this surface is that you can complete it without reading this. -->
+        <details class="onboard-details"${atLeast(ctx.level, "expert") ? " open" : ""}>
           <summary>What this creates / prefer the CLI?</summary>
           <p>The stack creates an IAM role (<code>spore-portal-onboard</code>) that
             trusts the portal under a one-time ExternalId, scoped to EC2 launch +

--- a/web/app/surfaces/teams.test.ts
+++ b/web/app/surfaces/teams.test.ts
@@ -1,0 +1,282 @@
+// Per-level rendering of the teams surface.
+//
+// Guided here is READ-ONLY, not absent, and both halves of that are asserted. The
+// forms all demand an IAM ARN a guided user cannot produce and three of the actions
+// are irreversible — but membership is information about your own account, and a user
+// told "check Teams" who can neither find it nor tell it exists is worse off than one
+// shown a list with no buttons.
+//
+// `fetch` is stubbed: the real endpoints need a federated session, and every write
+// path is owner-gated server-side (403), which is not what these assert. `canWrite`
+// is about not showing a beginner a form they can't fill in — never about security.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionController } from "../session.js";
+import type { PortalConfig, SurfaceContext } from "./types.js";
+import type { DisclosureLevel } from "../disclosure.js";
+import { teamsSurface } from "./teams.js";
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+const config = { region: "us-east-1", apiBase: "https://api.example" } as PortalConfig;
+
+const ACCOUNT = "123456789012";
+
+const TEAM = {
+  team_id: "t-0001",
+  team_name: "Nagel Lab",
+  // A bare account id, not an ARN: that's what dashboard-api writes for a
+  // portal-created team (portalAccountFromARN), which is why the owner check compares
+  // against session.accountId. See spore-host#514 for the CLI-created case.
+  owner_arn: ACCOUNT,
+  description: "shared instance visibility",
+  created_at: "2026-06-01T00:00:00Z",
+  member_count: 2,
+  role: "owner",
+};
+
+const MEMBERS = [
+  {
+    team_id: "t-0001",
+    member_arn: `arn:aws:iam::${ACCOUNT}:user/owner`,
+    role: "owner",
+    joined_at: "2026-06-01T00:00:00Z",
+    invited_by: "self",
+  },
+  {
+    team_id: "t-0001",
+    member_arn: `arn:aws:iam::${ACCOUNT}:user/alice`,
+    role: "member",
+    joined_at: "2026-06-02T00:00:00Z",
+    invited_by: `arn:aws:iam::${ACCOUNT}:user/owner`,
+  },
+];
+
+function stubFetch(): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      const path = url.replace(config.apiBase, "");
+      const body = path === "/teams" ? { teams: [TEAM] } : { team: TEAM, members: MEMBERS };
+      return { ok: true, status: 200, json: async () => body } as never;
+    }),
+  );
+}
+
+function ctxAt(level: DisclosureLevel): SurfaceContext {
+  const session = new SessionController("us-east-1", null);
+  session.setLevel(level);
+  vi.spyOn(session, "accountId", "get").mockReturnValue(ACCOUNT);
+  vi.spyOn(session, "getCreds").mockReturnValue({
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "secret",
+    sessionToken: "token",
+  } as never);
+  return { session, config, level, navigate: vi.fn() };
+}
+
+/**
+ * Mount at the list and click into the one team's detail view.
+ *
+ * Clears `?team=` first: the surface records the open team there and restores it at
+ * mount, so a second call in the same test would find no list card to click. That
+ * persistence has its own tests below.
+ */
+async function openDetail(host: HTMLElement, ctx: SurfaceContext) {
+  location.hash = "#/teams";
+  const d = await teamsSurface.mount(host, ctx);
+  await settle();
+  host.querySelector<HTMLButtonElement>(".teams-card")!.click();
+  await settle();
+  return d;
+}
+
+describe("teamsSurface disclosure", () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    stubFetch();
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    // The surface records the open team in the hash, so a leftover `?team=` would put
+    // the next mount straight into a detail view.
+    location.hash = "#/teams";
+  });
+
+  it("still lists your teams at guided", async () => {
+    // Read-only, not absent. Hiding this would mean the user can neither find the
+    // feature nor learn it exists.
+    const d = await teamsSurface.mount(host, ctxAt("guided"));
+    await settle();
+    expect(host.querySelectorAll(".teams-card")).toHaveLength(1);
+    expect(host.textContent).toContain("Nagel Lab");
+    d.dispose();
+  });
+
+  it("shows no create form at guided", async () => {
+    const d = await teamsSurface.mount(host, ctxAt("guided"));
+    await settle();
+    expect(host.querySelector(".teams-create")).toBeNull();
+    d.dispose();
+  });
+
+  it("shows the create form from standard up", async () => {
+    for (const level of ["standard", "expert"] as const) {
+      host.innerHTML = "";
+      const d = await teamsSurface.mount(host, ctxAt(level));
+      await settle();
+      expect(host.querySelector(".teams-create"), level).not.toBeNull();
+      d.dispose();
+    }
+  });
+
+  it("still shows the membership list at guided, with no write controls", async () => {
+    // Every write here needs an IAM ARN a guided user cannot produce, and Remove and
+    // Delete are irreversible.
+    const d = await openDetail(host, ctxAt("guided"));
+    expect(host.querySelectorAll(".teams-members tbody tr")).toHaveLength(2);
+    expect(host.querySelector(".teams-remove")).toBeNull();
+    expect(host.querySelector(".teams-addmember")).toBeNull();
+    expect(host.querySelector(".teams-danger")).toBeNull();
+    // And no vestigial action column. Leaving the header and the empty cells in place
+    // renders as a fourth column that failed to load, which is a worse read than three
+    // columns that are all there is.
+    expect(host.querySelectorAll(".teams-members thead th")).toHaveLength(3);
+    expect(host.querySelector(".teams-memb-action")).toBeNull();
+    d.dispose();
+  });
+
+  it("shows the owner's write controls from standard up", async () => {
+    // The mirror of the above: if standard rendered identically to guided, read-only
+    // guided would be indistinguishable from a broken surface.
+    const d = await openDetail(host, ctxAt("standard"));
+    expect(host.querySelector(".teams-addmember")).not.toBeNull();
+    expect(host.querySelector(".teams-danger")).not.toBeNull();
+    // The owner row is not removable; the member row is.
+    expect(host.querySelectorAll(".teams-remove")).toHaveLength(1);
+    d.dispose();
+  });
+
+  it("shows a non-owner no write controls even at expert", async () => {
+    // Raising the mode cannot grant authority. The API owner-gates every write with a
+    // 403 regardless, so this is about not offering a button that can only fail — and
+    // the action column goes with it, since Remove was the only thing in it.
+    const ctx = ctxAt("expert");
+    vi.spyOn(ctx.session, "accountId", "get").mockReturnValue("999999999999");
+    const d = await openDetail(host, ctx);
+    expect(host.querySelector(".teams-addmember")).toBeNull();
+    expect(host.querySelector(".teams-danger")).toBeNull();
+    expect(host.querySelector(".teams-memb-action")).toBeNull();
+    // Expert's read-only additions are still there — they're information, not authority.
+    expect(host.querySelector(".teams-meta")).not.toBeNull();
+    d.dispose();
+  });
+
+  it("offers a route out of read-only at guided", async () => {
+    // Guided must not be a dead end: the user who arrives because a colleague said
+    // "add me to your team" needs a route to the form, and "go find Mode in the
+    // header" is not one — that's the knowledge guided exists to not require.
+    const ctx = ctxAt("guided");
+    const d = await teamsSurface.mount(host, ctx);
+    await settle();
+    host.querySelector<HTMLButtonElement>(".guided-escape")!.click();
+    expect(ctx.session.level).toBe("standard");
+    d.dispose();
+  });
+
+  it("has no escape button once writes are available", async () => {
+    const d = await teamsSurface.mount(host, ctxAt("standard"));
+    await settle();
+    expect(host.querySelector(".guided-escape")).toBeNull();
+    d.dispose();
+  });
+
+  it("shortens member ARNs below expert but keeps the full one recoverable", async () => {
+    // `arn:aws:iam::123456789012:user/alice` is 45 characters of which one word
+    // identifies the person, and it wraps the table on a laptop. Truncating without
+    // the title would make the identity unrecoverable without changing mode.
+    const d = await openDetail(host, ctxAt("standard"));
+    const cell = host.querySelector<HTMLElement>(".teams-members tbody td")!;
+    expect(cell.textContent).toBe("user/owner");
+    expect(cell.title).toBe(`arn:aws:iam::${ACCOUNT}:user/owner`);
+    d.dispose();
+  });
+
+  it("shows full ARNs at expert", async () => {
+    const d = await openDetail(host, ctxAt("expert"));
+    const cell = host.querySelector<HTMLElement>(".teams-members tbody td")!;
+    expect(cell.textContent).toBe(`arn:aws:iam::${ACCOUNT}:user/owner`);
+    d.dispose();
+  });
+
+  it("adds who invited whom only at expert", async () => {
+    // `invited_by` is on every Member the API returns and was never rendered. In a
+    // shared-visibility team, "who added this person" is the audit question.
+    for (const [level, expected] of [
+      ["standard", false],
+      ["expert", true],
+    ] as const) {
+      host.innerHTML = "";
+      const d = await openDetail(host, ctxAt(level));
+      const heads = [...host.querySelectorAll(".teams-members th")].map((t) => t.textContent);
+      expect(heads.includes("Invited by"), level).toBe(expected);
+      d.dispose();
+    }
+  });
+
+  it("adds the team's identifiers and timestamps only at expert", async () => {
+    for (const [level, expected] of [
+      ["standard", false],
+      ["expert", true],
+    ] as const) {
+      host.innerHTML = "";
+      const d = await openDetail(host, ctxAt(level));
+      expect(host.querySelector(".teams-meta") !== null, level).toBe(expected);
+      d.dispose();
+    }
+    // And the id is on the list card too, where it's what an API call needs.
+    host.innerHTML = "";
+    location.hash = "#/teams";
+    const d = await teamsSurface.mount(host, ctxAt("expert"));
+    await settle();
+    expect(host.querySelector(".teams-id")!.textContent).toBe("t-0001");
+    d.dispose();
+  });
+
+  describe("the open team survives a re-mount", () => {
+    it("returns to the detail view the user was reading", async () => {
+      // A level change re-mounts this surface. Dumping the user back at the list is
+      // the loss they'd notice, because raising the mode is most often triggered
+      // while looking at one specific team.
+      const first = await openDetail(host, ctxAt("standard"));
+      expect(host.querySelector(".teams-members")).not.toBeNull();
+      first.dispose();
+
+      host.innerHTML = "";
+      const second = await teamsSurface.mount(host, ctxAt("expert"));
+      await settle();
+      expect(host.querySelector(".teams-members")).not.toBeNull();
+      expect(host.querySelector(".teams-card")).toBeNull(); // not the list
+      second.dispose();
+    });
+
+    it("clears the recorded team when the user goes back to the list", async () => {
+      const d = await openDetail(host, ctxAt("standard"));
+      host.querySelector<HTMLButtonElement>(".teams-back")!.click();
+      await settle();
+      expect(location.hash).toBe("#/teams");
+      d.dispose();
+    });
+  });
+
+  it("cleans up at every level", async () => {
+    for (const level of ["guided", "standard", "expert"] as const) {
+      host.innerHTML = "";
+      location.hash = "#/teams";
+      const d = await teamsSurface.mount(host, ctxAt(level));
+      await settle();
+      d.dispose();
+      expect(host.querySelector(".teams-surface"), level).toBeNull();
+    }
+  });
+});

--- a/web/app/surfaces/teams.ts
+++ b/web/app/surfaces/teams.ts
@@ -6,8 +6,17 @@
 //
 // Identity note: with account-scoped auth (spawn#445), the caller's team key is
 // their verified AWS account id; teammates are added by their IAM user/role ARN.
+//
+// Disclosure: guided is READ-ONLY, not absent. Every write here needs an IAM ARN a
+// guided user cannot produce (see MEMBER_ARN_RE), and three of the actions are
+// irreversible. But membership is information about your own account, and hiding the
+// surface from the sidebar would mean a user told "check Teams" can neither find it
+// nor tell it exists. So the lists stay and the forms go, with an escape to
+// standard for the user who does need to manage one.
 import type { AwsCreds } from "@spore-host/spawn-ts/auth";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+import { atLeast } from "../disclosure.js";
+import { readHashParam, writeHashParams } from "../hashstate.js";
 
 interface Team {
   team_id: string;
@@ -57,6 +66,11 @@ export const teamsSurface: ToolSurface = {
 
     const controller = new AbortController();
     let disposed = false;
+    // `canWrite` gates the forms, not the data. The API enforces owner-only on every
+    // write regardless (403), so this is about not showing a beginner a form they
+    // can't fill in — never about security.
+    const canWrite = atLeast(ctx.level, "standard");
+    const expert = atLeast(ctx.level, "expert");
 
     // Thin fetch wrapper: attaches auth, JSON content-type on writes, and the
     // abort signal; returns parsed body + status.
@@ -96,11 +110,14 @@ export const teamsSurface: ToolSurface = {
     async function showList(): Promise<void> {
       if (disposed) return;
       root.replaceChildren();
+      writeHashParams({ team: null });
       root.append(
         el("div", "teams-head", [
           el("h2", "", ["Teams"]),
           el("p", "teams-hint", [
-            "Teams share visibility of spawn-managed instances. You own the teams you create; owners manage membership.",
+            canWrite
+              ? "Teams share visibility of spawn-managed instances. You own the teams you create; owners manage membership."
+              : "Teams share visibility of spawn-managed instances. These are the teams you're in.",
           ]),
         ]),
       );
@@ -120,10 +137,17 @@ export const teamsSurface: ToolSurface = {
       const teams: Team[] = res.data?.teams ?? [];
 
       // Create-team form (collapsible).
-      root.append(buildCreateForm(showList, api, errText));
+      if (canWrite) root.append(buildCreateForm(showList, api, errText));
 
       if (teams.length === 0) {
-        root.append(el("div", "teams-status", ["You're not in any teams yet — create one above."]));
+        root.append(
+          el("div", "teams-status", [
+            canWrite
+              ? "You're not in any teams yet — create one above."
+              : "You're not in any teams yet.",
+          ]),
+        );
+        if (!canWrite) root.append(buildEscape(ctx));
         return;
       }
 
@@ -141,15 +165,20 @@ export const teamsSurface: ToolSurface = {
           ]),
         );
         if (t.description) card.append(spanText("teams-desc", t.description));
+        if (expert) card.append(spanText("teams-id", t.team_id));
         card.addEventListener("click", () => void showDetail(t.team_id));
         list.append(card);
       }
       root.append(list);
+      if (!canWrite) root.append(buildEscape(ctx));
     }
 
     // ── Detail view ────────────────────────────────────────────────────────
     async function showDetail(teamID: string): Promise<void> {
       if (disposed) return;
+      // Recorded so a mode change — which re-mounts this surface — returns to the
+      // team the user was reading rather than dumping them back at the list.
+      writeHashParams({ team: teamID });
       root.replaceChildren();
       const back = el("button", "teams-back", ["← All teams"]);
       (back as HTMLButtonElement).type = "button";
@@ -170,6 +199,13 @@ export const teamsSurface: ToolSurface = {
 
       const team: Team = res.data.team;
       const members: Member[] = res.data.members ?? [];
+      // `owner_arn` holds a bare 12-digit account id for portal-created teams
+      // (dashboard-api's portalAccountFromARN) but a real IAM ARN for CLI-created
+      // ones (cliIamArn) — so this comparison is correct for the former and never
+      // matches the latter, and a CLI-created team shows its own owner no owner
+      // controls. Tracked in spore-host#514; the fix belongs on the API side, not
+      // here — the browser should not be parsing ARN shapes to guess which code path
+      // wrote the record.
       const iAmOwner = team.owner_arn === ctx.session.accountId;
 
       root.append(
@@ -179,37 +215,69 @@ export const teamsSurface: ToolSurface = {
         ]),
       );
 
+      // Expert: the identifiers and timestamps a support conversation or an API call
+      // needs. Deliberately below the name, not beside it — a team_id is not what
+      // anyone came here to read.
+      if (expert) {
+        const dl = el("dl", "teams-meta", []);
+        const rows: Array<[string, string]> = [
+          ["team id", team.team_id],
+          ["owner", team.owner_arn],
+          ["created", fmtDate(team.created_at)],
+        ];
+        for (const [k, v] of rows) dl.append(el("dt", "", [k]), el("dd", "", [v]));
+        root.append(dl);
+      }
+
       // Members table.
       const table = el("table", "teams-members", []);
       const thead = el("thead", "", []);
       const htr = el("tr", "", []);
-      for (const h of ["Member", "Role", "Joined", ""]) htr.append(el("th", "", [h]));
+      // `invited_by` is on every Member the API returns and was never rendered. In a
+      // shared-visibility team, "who added this person" is the audit question, and
+      // expert is the level that would act on the answer.
+      // The trailing blank column holds Remove, so it's only there when Remove can be.
+      // At guided it rendered as a fourth column of empty cells with the row rules
+      // running past "Joined" — which reads as a column that failed to load.
+      const canRemove = canWrite && iAmOwner;
+      const heads = [
+        "Member",
+        "Role",
+        "Joined",
+        ...(expert ? ["Invited by"] : []),
+        ...(canRemove ? [""] : []),
+      ];
+      for (const h of heads) htr.append(el("th", "", [h]));
       thead.append(htr);
       table.append(thead);
       const tbody = el("tbody", "", []);
       for (const m of members) {
         const tr = el("tr", "", []);
-        tr.append(
-          tdText(m.member_arn),
-          tdText(m.role),
-          tdText(fmtDate(m.joined_at)),
-        );
-        const actionTd = el("td", "teams-memb-action", []);
-        // Owner can remove non-owner members.
-        if (iAmOwner && m.role !== "owner") {
-          const rm = el("button", "teams-remove", ["Remove"]);
-          (rm as HTMLButtonElement).type = "button";
-          rm.addEventListener("click", () => void removeMember(teamID, m.member_arn));
-          actionTd.append(rm);
+        // Below expert, show the ARN's trailing user/role name with the full ARN in
+        // the title: `arn:aws:iam::123456789012:user/alice` is 45 characters of which
+        // one word identifies the person, and it wraps the table on a laptop.
+        const who = expert ? tdText(m.member_arn) : tdTitled(shortArn(m.member_arn), m.member_arn);
+        tr.append(who, tdText(m.role), tdText(fmtDate(m.joined_at)));
+        if (expert) tr.append(tdText(m.invited_by || "—"));
+        if (canRemove) {
+          const actionTd = el("td", "teams-memb-action", []);
+          // The owner's own row is not removable — the cell stays, to keep the column
+          // aligned, but empty.
+          if (m.role !== "owner") {
+            const rm = el("button", "teams-remove", ["Remove"]);
+            (rm as HTMLButtonElement).type = "button";
+            rm.addEventListener("click", () => void removeMember(teamID, m.member_arn));
+            actionTd.append(rm);
+          }
+          tr.append(actionTd);
         }
-        tr.append(actionTd);
         tbody.append(tr);
       }
       table.append(tbody);
       root.append(table);
 
       // Owner controls: add member + delete team.
-      if (iAmOwner) {
+      if (canWrite && iAmOwner) {
         root.append(buildAddMemberForm(teamID, () => void showDetail(teamID), api, errText));
         const danger = el("div", "teams-danger", []);
         const del = el("button", "teams-delete", ["Delete team"]);
@@ -218,6 +286,7 @@ export const teamsSurface: ToolSurface = {
         danger.append(del);
         root.append(danger);
       }
+      if (!canWrite) root.append(buildEscape(ctx));
     }
 
     async function removeMember(teamID: string, memberARN: string): Promise<void> {
@@ -244,7 +313,11 @@ export const teamsSurface: ToolSurface = {
       void showList();
     }
 
-    void showList();
+    // Restore the open team from the hash, so a mode change lands back where the
+    // user was rather than at the list.
+    const openTeam = readHashParam("team");
+    if (openTeam) void showDetail(openTeam);
+    else void showList();
 
     return {
       dispose() {
@@ -255,6 +328,29 @@ export const teamsSurface: ToolSurface = {
     };
   },
 };
+
+/**
+ * The way out of read-only, matching the picker's `.guided-escape` pattern.
+ *
+ * Guided mode must not be a dead end: the user who arrives here because a colleague
+ * said "add me to your team" needs a route to the form, and "go find Mode in the
+ * header" is not one — that's exactly the knowledge guided mode exists to not
+ * require. Raising the level is the same gesture truffle's picker uses.
+ */
+function buildEscape(ctx: SurfaceContext): HTMLElement {
+  const btn = el("button", "guided-escape", ["Manage teams →"]);
+  (btn as HTMLButtonElement).type = "button";
+  btn.addEventListener("click", () => ctx.session.setLevel("standard"));
+  return btn;
+}
+
+/** `arn:aws:iam::123456789012:user/alice` → `user/alice`. Unrecognised input is
+ *  returned whole rather than truncated to something that looks like an identity
+ *  but isn't. */
+function shortArn(arn: string): string {
+  const i = arn.lastIndexOf(":");
+  return i === -1 ? arn : arn.slice(i + 1) || arn;
+}
 
 // ── form builders ──────────────────────────────────────────────────────────
 type ApiFn = (p: string, i?: { method?: string; body?: unknown }) => Promise<{ ok: boolean; status: number; data: any }>;
@@ -353,6 +449,14 @@ function spanText(className: string, text: string): HTMLElement {
 
 function tdText(text: string): HTMLElement {
   return el("td", "", [text]);
+}
+
+/** A cell showing `text` with `title` on hover — for a shortened identity whose full
+ *  form must still be recoverable without changing mode. */
+function tdTitled(text: string, title: string): HTMLElement {
+  const td = el("td", "", [text]);
+  td.title = title;
+  return td;
 }
 
 function inputEl(type: string, placeholder: string, required: boolean): HTMLInputElement {

--- a/web/app/surfaces/truffle.test.ts
+++ b/web/app/surfaces/truffle.test.ts
@@ -6,9 +6,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionController } from "../session.js";
 import type { PortalConfig, SurfaceContext } from "./types.js";
 import type { DisclosureLevel } from "../disclosure.js";
+import { GUIDED_SHAPES } from "../guided/shapes.js";
+import { readHashParam } from "../hashstate.js";
 import { truffleSurface } from "./truffle.js";
 
 const settle = () => new Promise((r) => setTimeout(r, 0));
+
+/** Type into the query box and submit, as a user would. */
+function search(host: HTMLElement, q: string): void {
+  host.querySelector<HTMLInputElement>(".truffle-q")!.value = q;
+  host
+    .querySelector<HTMLFormElement>(".truffle-form")!
+    .dispatchEvent(new Event("submit", { cancelable: true }));
+}
 
 const config = { region: "us-east-1" } as PortalConfig;
 
@@ -25,6 +35,9 @@ describe("truffleSurface disclosure", () => {
     document.body.innerHTML = "";
     host = document.createElement("div");
     document.body.appendChild(host);
+    // The surface persists its query in the hash and restores it at mount, so a
+    // leftover `?q=` from an earlier test would silently pre-fill the next one.
+    location.hash = "#/truffle";
   });
 
   it("shows the curated picker and NO query box at guided", async () => {
@@ -61,14 +74,20 @@ describe("truffleSurface disclosure", () => {
     d.dispose();
   });
 
-  it("navigates to instances when a guided shape is chosen", async () => {
+  it("carries the chosen shape to the instances surface", async () => {
     // This surface is auth-free by design, so there's no session to launch into —
     // the instances surface mounts the same picker with a live client behind it.
+    //
+    // The shape id has to ride along. Navigating bare is what shipped, and it dropped
+    // the GuidedChoice on the floor: the user who picked "A big GPU for training"
+    // arrived at an identical picker asking the same question again. Asserting the
+    // exact id rather than just the presence of `shape=` is deliberate — carrying the
+    // *wrong* card over would be worse than carrying none.
     const navigate = vi.fn();
     const d = await truffleSurface.mount(host, ctxAt("guided", navigate));
     await settle();
     host.querySelector<HTMLButtonElement>(".guided-card")!.click();
-    expect(navigate).toHaveBeenCalledWith("instances");
+    expect(navigate).toHaveBeenCalledWith(`instances?shape=${GUIDED_SHAPES[0]!.id}`);
     d.dispose();
   });
 
@@ -154,6 +173,62 @@ describe("truffleSurface disclosure", () => {
       expect(row.textContent, `${row.textContent} has no GPU`).toMatch(/gpu/i);
     }
     d.dispose();
+  });
+
+  // A level change re-mounts the surface, and the shell clears .portal-main to do it
+  // — so anything the surface held in a local is gone. This is the state loss that
+  // mattered most and it's the *common* path: type a query, get rows, want the expert
+  // detail on them, raise the mode. The level change is most often triggered at
+  // exactly that moment, on exactly those results.
+  describe("query survives a re-mount", () => {
+    beforeEach(() => {
+      location.hash = "#/truffle";
+    });
+
+    it("records the query in the hash on search", async () => {
+      const d = await truffleSurface.mount(host, ctxAt("standard"));
+      await settle();
+      search(host, "nvidia h100");
+      await settle();
+      expect(readHashParam("q")).toBe("nvidia h100");
+      d.dispose();
+    });
+
+    it("restores and re-runs the query at the new level", async () => {
+      // The whole point: the same query, re-executed, now rendering expert detail.
+      // Restoring the text into the box without re-running it would be worse than
+      // nothing — a filled search box above someone else's results.
+      const first = await truffleSurface.mount(host, ctxAt("standard"));
+      await settle();
+      search(host, "nvidia h100");
+      await settle();
+      expect(host.querySelectorAll(".truffle-row").length).toBeGreaterThan(0);
+      expect(host.querySelector(".truffle-detail")).toBeNull();
+
+      // What the shell does on a level change.
+      first.dispose();
+      host.innerHTML = "";
+      const second = await truffleSurface.mount(host, ctxAt("expert"));
+      await settle();
+
+      expect(host.querySelector<HTMLInputElement>(".truffle-q")!.value).toBe("nvidia h100");
+      expect(host.querySelectorAll(".truffle-row").length).toBeGreaterThan(0);
+      expect(host.querySelector(".truffle-detail")).not.toBeNull();
+      second.dispose();
+    });
+
+    it("clears the hash when the query is emptied", async () => {
+      // Otherwise a stale query would be resurrected on the next mount, after the
+      // user had deliberately cleared it.
+      const d = await truffleSurface.mount(host, ctxAt("standard"));
+      await settle();
+      search(host, "nvidia h100");
+      await settle();
+      search(host, "");
+      await settle();
+      expect(readHashParam("q")).toBeNull();
+      d.dispose();
+    });
   });
 
   it("cleans up at every level", async () => {

--- a/web/app/surfaces/truffle.ts
+++ b/web/app/surfaces/truffle.ts
@@ -11,6 +11,7 @@ import { find, CATALOG_AS_OF, type FindResult } from "@spore-host/truffle-ts";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
 import { atLeast, type DisclosureLevel } from "../disclosure.js";
 import { mountGuidedPicker } from "../guided/picker.js";
+import { readHashParam, writeHashParams } from "../hashstate.js";
 
 export const truffleSurface: ToolSurface = {
   id: "truffle",
@@ -70,9 +71,22 @@ export const truffleSurface: ToolSurface = {
 
     const onSubmit = (e: Event) => {
       e.preventDefault();
+      writeHashParams({ q: input.value.trim() || null });
       void run(input.value);
     };
     form.addEventListener("submit", onSubmit);
+
+    // Restore a query from the hash and re-run it.
+    //
+    // This is the state loss that mattered most, and it's the *common* path: type a
+    // query, get rows, want the expert detail on them, raise the mode → the shell
+    // re-mounts this surface with an empty box and the query gone. The mode change is
+    // most often triggered at exactly that moment, on exactly those results.
+    const initialQ = readHashParam("q");
+    if (initialQ) {
+      input.value = initialQ;
+      void run(initialQ);
+    }
 
     return {
       dispose() {
@@ -96,7 +110,11 @@ function mountGuided(host: HTMLElement, ctx: SurfaceContext): Disposable {
   host.appendChild(root);
 
   const dispose = mountGuidedPicker(root, {
-    onChoose: () => ctx.navigate("instances"),
+    // Carry the chosen shape across. Navigating bare discarded the GuidedChoice, so
+    // "A big GPU for training" landed the user on a fresh picker demanding the same
+    // choice they had just made (or, unsigned-in, on a sign-in gate that forgets it).
+    // The shape id in the hash survives both.
+    onChoose: (choice) => ctx.navigate(`instances?shape=${encodeURIComponent(choice.shape.id)}`),
     // The escape hatch raises the level rather than navigating: the user is saying
     // "show me more", and the query box is one level up on this very surface.
     onEscape: () => ctx.session.setLevel("standard"),

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -550,8 +550,33 @@ footer {
 /* The disclosure control. margin-left:auto pulls it out of the header's
    space-between centre and parks it beside the account block — the two things
    that say "who you are" and "how much you're shown" belong together. */
-.portal-level { display: flex; align-items: center; gap: 0.4rem; margin-left: auto; margin-right: 1.25rem; font-size: 0.85rem; color: var(--text-muted); }
-.portal-level-select { font: inherit; padding: 0.25rem 0.4rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+.portal-level { display: flex; align-items: center; gap: 0.5rem; margin-left: auto; margin-right: 1.25rem; font-size: 0.85rem; color: var(--text-muted); }
+/* A segmented control, so the three levels read as the ordered scale they are —
+   `atLeast()`'s whole semantics is that ordering, and a dropdown showing one option
+   at a time hides it. */
+.portal-level-group { display: flex; border: 1px solid var(--border-strong); border-radius: var(--radius); overflow: hidden; }
+.portal-level-opt {
+  font: inherit; font-size: 0.85rem; cursor: pointer; padding: 0.25rem 0.6rem;
+  border: 0; border-left: 1px solid var(--border-strong);
+  background: var(--bg); color: var(--text-muted);
+}
+.portal-level-opt:first-child { border-left: 0; }
+.portal-level-opt:hover { background: var(--bg-subtle); color: var(--text); }
+.portal-level-opt.active { background: var(--spawn); color: #fff; font-weight: 600; }
+/* Roving tabindex means one focus stop for the group, so the ring has to be obvious
+   — it's the only indication of which option the arrow keys will move from. */
+.portal-level-opt:focus-visible { outline: 2px solid var(--spawn); outline-offset: -2px; }
+/* The blurb the old <option title> could never show. Hidden on narrow screens rather
+   than wrapping the header onto two lines; the labels still carry the ordering. */
+.portal-level-blurb { max-width: 22rem; font-size: 0.78rem; line-height: 1.2; }
+@media (max-width: 1100px) { .portal-level-blurb { display: none; } }
+@media (max-width: 720px) { .portal-level-label { display: none; } }
+/* Visually hidden, still announced. The level change rebuilds .portal-main with no
+   audible signal otherwise. */
+.portal-live {
+  position: absolute; width: 1px; height: 1px; overflow: hidden;
+  clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;
+}
 .portal-account { display: flex; align-items: center; gap: 0.75rem; font-size: 0.9rem; color: var(--text-muted); }
 .portal-account .acct b { color: var(--text); }
 .portal-account button, .portal-gate button, .portal-banner button {
@@ -581,6 +606,10 @@ footer {
 .portal-banner.warn { background: var(--truffle-bg); color: var(--truffle); }
 .portal-banner.expired { background: #fef2f2; color: var(--accent-red); }
 [data-theme="dark"] .portal-banner.expired { background: #2a1010; }
+/* The mode-change note. Informational, so it must not borrow the expiry banner's
+   alarm colours — and it never replaces one (see Shell.showLevelNote). */
+.portal-banner.info { background: var(--bg-subtle); color: var(--text-muted); display: flex; align-items: center; gap: 0.75rem; }
+.portal-banner-x { margin-left: auto; line-height: 1; padding: 0.1rem 0.45rem !important; }
 
 /* ── truffle surface — offline instance-type catalog search ── */
 .truffle-surface { max-width: 820px; }
@@ -670,6 +699,9 @@ footer {
 .costs-tile { flex: 1 1 140px; border: 1px solid var(--border); border-radius: var(--radius); padding: 0.7rem 0.9rem; background: var(--bg-card); }
 .costs-tile-label { color: var(--text-muted); font-size: 0.8rem; }
 .costs-tile-value { color: var(--text); font-size: 1.5rem; font-weight: 600; margin-top: 0.2rem; }
+/* When a figure needs a qualifier (which sample the peak came from), it goes here
+   rather than into the value, which is too large to wrap without looking broken. */
+.costs-tile-note { color: var(--text-muted); font-size: 0.78rem; margin-top: 0.1rem; }
 .costs-status { color: var(--text-muted); }
 .costs-status.error { color: var(--accent-red); }
 .costs-body { transition: opacity 0.15s ease; }
@@ -688,6 +720,12 @@ footer {
 }
 .costs-tip-val { color: var(--text); font-weight: 600; font-variant-numeric: tabular-nums; }
 .costs-tip-meta { color: var(--text-muted); font-size: 0.75rem; margin-top: 0.1rem; }
+.costs-tip-breakdown { color: var(--text-muted); font-size: 0.72rem; margin-top: 0.25rem; padding-top: 0.25rem; border-top: 1px solid var(--border); font-variant-numeric: tabular-nums; }
+.costs-provenance { color: var(--text-muted); font-size: 0.75rem; margin-top: 0.75rem; word-break: break-all; }
+/* Guided's "what do I do about it" line. Styled as prose with an inline button
+   rather than a CTA block: it's a pointer, not the surface's purpose. */
+.costs-act { color: var(--text-muted); font-size: 0.9rem; margin-top: 1.25rem; }
+.costs-act button { font: inherit; cursor: pointer; background: none; border: none; padding: 0; color: var(--spawn); text-decoration: underline; }
 .costs-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
 .costs-table th, .costs-table td { text-align: left; padding: 0.35rem 0.6rem; border-bottom: 1px solid var(--border); }
 .costs-table th { color: var(--text-muted); font-weight: 600; }
@@ -710,6 +748,12 @@ footer {
 .teams-role { margin-left: auto; font-size: 0.75rem; color: var(--lagotto); text-transform: uppercase; letter-spacing: 0.03em; }
 .teams-card-meta { color: var(--text-muted); font-size: 0.85rem; margin-top: 0.2rem; }
 .teams-desc { display: block; color: var(--text-muted); font-size: 0.85rem; margin-top: 0.3rem; }
+/* Expert-only identifiers. Monospace because they're things you copy into an API
+   call or a support thread, not things you read. */
+.teams-id { display: block; margin-top: 0.3rem; font-family: ui-monospace, monospace; font-size: 0.75rem; color: var(--text-muted); }
+.teams-meta { display: grid; grid-template-columns: auto 1fr; gap: 0.2rem 0.75rem; margin: 0.75rem 0 0; font-size: 0.8rem; }
+.teams-meta dt { color: var(--text-muted); }
+.teams-meta dd { margin: 0; color: var(--text); font-family: ui-monospace, monospace; word-break: break-all; }
 .teams-members { width: 100%; border-collapse: collapse; font-size: 0.85rem; margin: 1rem 0; }
 .teams-members th, .teams-members td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--border); }
 .teams-members th { color: var(--text-muted); font-weight: 600; }


### PR DESCRIPTION
Tier 1 of the progressive-disclosure plan. [Tier 0](https://github.com/spore-host/spore-host/pull/511) bounded guided spend, stopped the post-sign-out polling and dropped the overclaims; this is the rollout itself, plus the header control and the state-loss fix that made a mode change costly to use.

Closes #512.

## Four surfaces get variants; three deliberately don't

`catalog.ts` and `slack.ts` are already at the right density for everyone — a name, a slug and a `<details>` of OAuth scopes have nothing to hide and nothing withheld — and `onboarding.ts` needed one line (`details.open` at expert). Forcing three variants on the rest would buy a branch, a test and a maintenance surface for nothing. `terminal.ts`'s instance picker and `lagotto.ts`'s guided cards are deferred to filed issues.

**No sidebar entry is hidden at guided.** Hiding a nav entry means the user can't find the feature *and* can't tell it exists. Guided's promise is "you can't hurt yourself here", not "fewer features".

### `costs.ts` — additive only

The one surface answering "what am I spending?", so nothing is hidden from anyone.

- **Guided** relabels `monthly_estimate`. It's `hourly × 730` — a projection of this instant, not a sum of anything that happened — and "Monthly estimate" is read as a bill owed, wrong in both directions: a machine shut down in an hour will never cost that, and one launched tomorrow isn't in it. Now "If it keeps running: \$Y a month". Plus a route to Instances: a cost figure with no adjacent way to *act* is where a guided user gets stuck.
- **Expert** renders the `compute`/`storage`/`network` breakdown the API has always returned and the UI always dropped — the difference between "spend is up" and "spend is up because of storage, which shutting an instance down will not fix" — in the tooltip *and* the table, or it would be mouse-only. Adds window-total and peak-hourly tiles: every existing tile reads `history[length-1]`, so "did something spike" was unanswerable from the very window opened to ask it. Adds a 1-year preset and states the endpoint and sample cadence.
- **`.costs-tabletoggle` stays at every level.** It's the chart's non-visual equivalent, not a density control, and the people who need it are the least likely to have raised the mode.

### `teams.ts` — read-only at guided, not absent

Every write needs an IAM ARN a guided user cannot produce (`MEMBER_ARN_RE`) and three of the actions are irreversible. But membership is information about your own account, so the lists stay, the forms go, and a **Manage teams →** escape moves up a level. The action column now appears only when Remove can — at guided it rendered as a fourth column of empty cells, which reads as a column that failed to load.

Expert adds team ids, full ARNs, created dates, and the never-rendered `invited_by`: "who added this person" is the audit question in a shared-visibility team. Below expert the ARN shows its trailing `user/name` with the full value in `title` — 45 characters of which one word identifies the person, and it wraps the table on a laptop.

A comment at the owner check records that `owner_arn` is a bare account id for portal-created teams but a real ARN for CLI-created ones (#514) — traced, not guessed, and not something to paper over in the browser.

### `shell.ts` — the header control had three defects

The `LEVEL_INFO` blurbs were attached as `title` on each `<option>`, and **native `<option title>` is not reliably rendered** — Safari never shows it, mobile pickers show labels only. Well-written copy nearly nobody saw, under a comment claiming it worked. It's now a `role="radiogroup"` of three buttons with `aria-checked`, roving tabindex, arrow-key navigation, the blurb as **visible** text, and a polite live-region announcement — a level change silently rebuilds `.portal-main` today.

Relabelled **"Detail" → "Mode"**: the control changes *capability* (spot, TTL, AZ, placement), not verbosity, and a collapsed 3-way `<select>` is the wrong shape for an **ordered** scale, which is the entire semantics `atLeast` depends on.

Raising the level from inside a surface now leaves one dismissible line in the existing `.portal-banner` saying where to change it back. One click otherwise rewrites a persistent, portal-wide setting, and finding the way back needs exactly the knowledge those escape buttons exist to not require.

For a **signed-out** visitor, "Connect account" comes first. It sat last in a nine-item nav while the default route was `instances` — auth-gated — so a first-time visitor's landing was a sign-in gate with the page explaining how to get an account to sign into at the bottom.

### State loss on remount

`route({remount: true})` clears the main element, so everything a surface held was gone — and the worst case was also the *common* path: type a truffle query, get rows, want the expert detail, raise the mode → empty box, query gone. The level change is most often triggered at exactly that moment.

New `hashstate.ts` records the truffle query, the cost window and table view, and the open team in the hash via `replaceState`, reusing the `?query` tolerance `currentId()` already had for the Slack callback. Bookmarkable and shareable, no shell change, no new abstraction. Costs **ignores a window the current level doesn't offer** — `?days=365` is reachable from a bookmark made at expert, and honouring it at standard would render a year of data above a control set that all reads unpressed, a view the user cannot undo.

Choosing a shape on the truffle picker now carries it to `#/instances?shape=…` and opens the confirmation directly. It used to discard the `GuidedChoice`, landing the user on a fresh picker demanding the same choice again.

## Verification

- `npm run typecheck`, `npm test` (**153 tests**, was 68), `npm run build` — all clean.
- **Every new test proven load-bearing** by reverting the behaviour it covers and confirming the expected tests — and only those — fail. Pinning `const expert = false` + `canWrite = true` failed 7; making `writeHashParams` a no-op failed 8; dropping the announcement and the carried shape failed 3; killing the keydown handler failed 3.
- **Driven in Chromium** against the real dev server, 19 + 22 scripted checks. The two render bugs fixed here were only visible there: the peak tile wrapping as \`\$4.25 · Jul\` / \`12\` (the date is now a `note` below the figure, not appended to a 1.5rem value), and the vestigial teams action column. Confirmed the plan's named checks — signed out at guided with no credentials the curated picker still resolves real types and real prices (`t4g.xlarge … \$0.54 for 4 hours … cheapest of 194 that fit`), and a truffle query survives raising to expert with **0** surface re-mounts and `history.length` unchanged.
- `hashstate.test.ts` records why the no-re-route property is asserted in the browser rather than the suite: **happy-dom fires `hashchange` on `replaceState`, which browsers do not** (the spec's URL-and-history-update steps skip it). Probed to confirm. The comment says not to "fix" it by writing through `location.hash` to satisfy a shim.
- `docs/guides/portal-detail-levels.md` updated: the Mode control, the two launch limits and how they fail differently, state in the address bar, and a per-page disclosure table.

⚠️ `deploy-site.yaml` deploys `web/**` to **spore.host/app** on merge, so merging this is a live deploy.