### PR TITLE
fix(portal): two surfaces still told the user to use a control named "Detail"

### DIFF
--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -177,3 +177,8 @@ Two rules held throughout:
 - The level is stored in `localStorage` under `spore.disclosure`. It's a
   preference, not a credential — your AWS credentials never leave the tab's memory
   (see [Security, credentials & data flow](/architecture)).
+- Two pages warn you that changing **Mode** ends something live — a capacity watch,
+  or a connected terminal. Both take the name from one constant, because when the
+  control was renamed from "Detail" those two warnings were left pointing at a
+  control that no longer existed. Being told a running session dies when you touch
+  something you can't find is worse than not being warned.

--- a/web/app/disclosure.test.ts
+++ b/web/app/disclosure.test.ts
@@ -1,8 +1,10 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   atLeast,
   DEFAULT_LEVEL,
   isLevel,
+  LEVEL_CONTROL_NAME,
   LEVEL_INFO,
   LEVELS,
   loadLevel,
@@ -125,5 +127,36 @@ describe("LEVEL_INFO", () => {
     // union without an entry here is a type error, not a blank tooltip.
     const check: Record<DisclosureLevel, unknown> = LEVEL_INFO;
     expect(check).toBeTruthy();
+  });
+});
+
+describe("LEVEL_CONTROL_NAME", () => {
+  // A source scan, not a DOM assertion, because the failure this guards against is
+  // cross-file: the control was called "Detail", lagotto and terminal each told the
+  // user so in a warning about losing a running watch or SSM session, and renaming it
+  // to "Mode" left both pointing at a control that no longer existed. Every per-file
+  // test still passed. Nothing but a scan catches that.
+  const SRC = ["shell.ts", "surfaces/lagotto.ts", "surfaces/terminal.ts"];
+  const read = (f: string) => readFileSync(new URL(f, import.meta.url), "utf8");
+
+  it("is what every reference to the control interpolates", () => {
+    for (const f of SRC) {
+      const src = read(f);
+      // Skip comments: they explain the rename, so they legitimately say "Detail".
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+      expect(code, `${f} interpolates the constant`).toContain("LEVEL_CONTROL_NAME");
+      // No hard-coded name in a user-visible string. `<b>Mode</b>` and "changing Mode"
+      // are exactly what drifted.
+      expect(code, `${f} has no hard-coded control name`).not.toMatch(
+        /<b>\s*(Mode|Detail)\s*<\/b>|(changing|switching|change this any time with)\s+(the\s+)?(Mode|Detail|detail level)/i,
+      );
+    }
+  });
+
+  it("names a control the user can find", () => {
+    // The name has to match the header label, or the instruction is unfollowable.
+    expect(read("shell.ts")).toContain('class="portal-level-label"');
+    expect(LEVEL_CONTROL_NAME.trim()).toBe(LEVEL_CONTROL_NAME);
+    expect(LEVEL_CONTROL_NAME.length).toBeGreaterThan(0);
   });
 });

--- a/web/app/disclosure.ts
+++ b/web/app/disclosure.ts
@@ -17,6 +17,16 @@ export type DisclosureLevel = "guided" | "standard" | "expert";
 /** Ordered least- to most-revealing. Index is the comparison key. */
 export const LEVELS: readonly DisclosureLevel[] = ["guided", "standard", "expert"] as const;
 
+/**
+ * What the header control is called, wherever anything refers the user to it.
+ *
+ * One constant because the name has already drifted once: the control was labelled
+ * "Detail", two surfaces told the user so in a warning, and renaming it to "Mode" left
+ * lagotto and terminal pointing at a control that no longer existed. Someone told a
+ * running SSM session ends when they touch X needs X to be findable.
+ */
+export const LEVEL_CONTROL_NAME = "Mode";
+
 /** Human labels + one line of what each level is FOR, shown in the picker. */
 export const LEVEL_INFO: Record<DisclosureLevel, { label: string; blurb: string }> = {
   guided: {

--- a/web/app/shell.ts
+++ b/web/app/shell.ts
@@ -5,7 +5,14 @@ import { surfaces, findSurface } from "./surfaces/registry.js";
 import type { PortalConfig, SurfaceContext, Disposable } from "./surfaces/types.js";
 import type { SessionController } from "./session.js";
 import { startSignIn } from "./auth/globus-login.js";
-import { DEFAULT_LEVEL, isLevel, LEVEL_INFO, LEVELS, type DisclosureLevel } from "./disclosure.js";
+import {
+  DEFAULT_LEVEL,
+  isLevel,
+  LEVEL_CONTROL_NAME,
+  LEVEL_INFO,
+  LEVELS,
+  type DisclosureLevel,
+} from "./disclosure.js";
 
 export class Shell {
   private navEl!: HTMLElement;
@@ -111,7 +118,7 @@ export class Shell {
                  tabindex="${l === current ? "0" : "-1"}">${escapeHtml(LEVEL_INFO[l].label)}</button>`,
     ).join("");
     el.innerHTML = `
-      <span class="portal-level-label" id="portal-level-label">Mode</span>
+      <span class="portal-level-label" id="portal-level-label">${escapeHtml(LEVEL_CONTROL_NAME)}</span>
       <div class="portal-level-group" role="radiogroup" aria-labelledby="portal-level-label"
            >${buttons}</div>
       <span class="portal-level-blurb">${escapeHtml(LEVEL_INFO[current].blurb)}</span>`;
@@ -345,7 +352,7 @@ export class Shell {
     this.bannerEl.className = "portal-banner info";
     this.bannerEl.innerHTML = `Showing ${escapeHtml(
       LEVEL_INFO[level].label.toLowerCase(),
-    )} controls. Change this any time with <b>Mode</b> in the header.
+    )} controls. Change this any time with <b>${escapeHtml(LEVEL_CONTROL_NAME)}</b> in the header.
       <button class="portal-banner-x" aria-label="Dismiss">×</button>`;
     this.bannerEl.querySelector(".portal-banner-x")!.addEventListener("click", () => {
       this.hideBanner();

--- a/web/app/surfaces/lagotto.ts
+++ b/web/app/surfaces/lagotto.ts
@@ -29,6 +29,7 @@ import { CapacityWatcher, type CapacityFinder, type FinderInstanceType, type Fin
 import type { MatchResult, Watch } from "@spore-host/lagotto-ts";
 import { onDemandPrice } from "@spore-host/truffle-ts";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+import { LEVEL_CONTROL_NAME } from "../disclosure.js";
 
 /** Poll cadence offered in the UI. A browser tab is a short-lived watcher. */
 const INTERVALS = [
@@ -67,7 +68,7 @@ export const lagottoSurface: ToolSurface = {
           <b>${escapeHtml(region)}</b> until it appears — the same matching the
           <code>lagotto</code> CLI does, running in this tab against your own account.</p>
         <p class="lagotto-hint warn">A watch lives only as long as this tab. Closing it,
-          reloading, or switching the detail level in the header stops the watch — nothing
+          reloading, or changing <b>${escapeHtml(LEVEL_CONTROL_NAME)}</b> in the header stops the watch — nothing
           keeps checking on your behalf. For a watch that outlives a browser, use the
           <code>lagotto</code> CLI.</p>
       </div>

--- a/web/app/surfaces/terminal.ts
+++ b/web/app/surfaces/terminal.ts
@@ -7,6 +7,7 @@
 import { SSMClient, StartSessionCommand, TerminateSessionCommand } from "@aws-sdk/client-ssm";
 import { attachTerminal, type AttachedTerminal } from "@spore-host/spawn-ts/terminal";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+import { LEVEL_CONTROL_NAME } from "../disclosure.js";
 
 export const terminalSurface: ToolSurface = {
   id: "terminal",
@@ -100,8 +101,8 @@ export const terminalSurface: ToolSurface = {
         // click in the header drops a shell the user is typing into. Naming it is
         // the cheap half of the fix; not losing the session is issue-sized.
         status.className = "terminal-status warn";
-        status.textContent =
-          "Connected. Leaving this page, reloading, or changing the detail level in the header ends this session.";
+        // `textContent`, so the name is interpolated raw rather than escaped.
+        status.textContent = `Connected. Leaving this page, reloading, or changing ${LEVEL_CONTROL_NAME} in the header ends this session.`;
         // Un-hide BEFORE attach so xterm's fit addon measures a real size.
         termHost.hidden = false;
         attached = await attachTerminal(


### PR DESCRIPTION
Follow-up to #517, found by grepping the source for stale vocabulary after the merge.

Tier 1 renamed the header control **Detail → Mode**. It missed the two places that name the control in a *warning about losing live work*:

| Surface | The string that shipped |
|---|---|
| `lagotto.ts` | "…reloading, or switching **the detail level** in the header stops the watch" |
| `terminal.ts`, while a shell is open | "Connected. Leaving this page, reloading, or changing **the detail level** in the header ends this session." |

Being told a running SSM session dies when you touch something you then cannot find in the UI is worse than not being warned at all — and these are the two surfaces where **the warning is the whole mitigation**. Neither survives the re-mount a level change causes; that's #513 and #512, both still open.

Neither surface reads `ctx.level`, which is exactly why the rename passed them by: every per-file test still passed, because no test knew that the header label and these warnings had to agree.

## The fix, and why the guard is a source scan

The name is now one exported constant — `LEVEL_CONTROL_NAME` in `disclosure.ts` — interpolated at all five sites (the header label, the escape banner, and the two warnings).

The regression guard in `disclosure.test.ts` reads the three source files and asserts each interpolates the constant and contains no hard-coded control name in a user-visible string. A DOM assertion cannot catch this: the failure is **cross-file agreement**, so nothing local to a file sees it. Comments are stripped before the scan, since they legitimately discuss the old name while explaining the rename.

Verified by restoring both original strings and confirming the scan fails on **each file independently**, not just the first.

`docs/guides/portal-detail-levels.md` gains a note recording why the name is a constant, so the next rename doesn't repeat this.

155 tests (was 153), typecheck and build clean.

⚠️ `deploy-site.yaml` deploys `web/**` to spore.host/app on merge, so merging this is a live deploy.