### PR TITLE
fix(ci-runners): survive a reboot — Broken VM, dead prune, stale .runner (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Fixed
+- **CI runner fleet: a host reboot no longer leaves the fleet dead** (#518). On
+  2026-08-01 the whole self-hosted fleet stayed offline for ~5.5h and every
+  `Test` / `E2E Tier 0` job across spawn, truffle, lagotto and miniwdl-spawn sat
+  queued. Three independent defects in `infra/ci-runners/`, each fixed:
+  - `boot-recreate.sh` **could not recover a `Broken` colima VM.** A vz VM whose
+    prior shutdown failed comes back with its driver running but no host agent, and
+    `colima start` — the script's only recovery — exits 1 on inspection without
+    attempting a boot. The script waited its full 3 min, tried the one thing that
+    cannot work, and gave up. It now escalates to `colima stop --force` (which
+    moves `Broken` → `Stopped`) and retries, releasing a stale lima disk lock on
+    the way.
+  - **The offline-runner prune was dead code.** It was gated on
+    `command -v gh`, and `gh` is not installed on orion — so it had silently
+    no-opped on every boot while looking like a working safety net in review.
+    Rewritten on `curl` + `jq` (both present) using the `ACCESS_TOKEN` already in
+    `.env`, so it needs no new credential; it now also refuses to delete a
+    registration that is `busy`, and reports failures instead of swallowing them.
+  - **`--replace` did not prevent the crash-loop it was added for.** All 6
+    containers still crash-looped on `Cannot configure the runner because it is
+    already configured` with `--replace` live in the image, because that flag
+    resolves the *server-side* name conflict while the check that fires is
+    *local* — `config.sh` refuses whenever `/home/runner/.runner` exists, and an
+    unclean stop skips the cleanup trap that would remove it. `entrypoint.sh` now
+    clears the stale local registration before configuring, so a plain restart is
+    survivable rather than depending on the recreate path.
+  Docs corrected accordingly: the README previously stated `--replace` fixed the
+  reboot crash-loop, which was not true. Fleet-offline alerting is tracked
+  separately in #520 — the outage was silent because queued jobs never fail.
+
 ### Changed
 - Bumped the `substrate` test dependency v0.65.0 → v0.85.0 in the
   `accountlifecycle` and `spore-bot` Lambda modules, 20 minor versions of AWS

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -177,3 +177,8 @@ Two rules held throughout:
 - The level is stored in `localStorage` under `spore.disclosure`. It's a
   preference, not a credential — your AWS credentials never leave the tab's memory
   (see [Security, credentials & data flow](/architecture)).
+- Two pages warn you that changing **Mode** ends something live — a capacity watch,
+  or a connected terminal. Both take the name from one constant, because when the
+  control was renamed from "Detail" those two warnings were left pointing at a
+  control that no longer existed. Being told a running session dies when you touch
+  something you can't find is worse than not being warned.

--- a/infra/ci-runners/README.md
+++ b/infra/ci-runners/README.md
@@ -35,33 +35,91 @@ recreating it. Two failure modes resulted:
 2. **Reboot crash-loop.** After a host reboot, the reused containers' baked
    `.runner` config made `config.sh` refuse ("already configured") and
    `restart: always` looped them forever → all runners offline.
+3. **`Broken` colima VM after reboot** (added 2026-08-01, spore-host#518). See
+   below — this one kept the whole fleet down ~5.5h.
 
 ## The durable fix (in this dir)
 
 - **`entrypoint.sh` self-heals:** clears `_work/_temp` + `_work/_actions` and caps
   the go-build cache (wipes if >4GB) at the start of every cycle, so a reused
-  container can't grow unbounded; `--replace` re-registers cleanly so a baked
-  `.runner` no longer crash-loops.
-- **`boot-recreate.sh` + launchd:** at boot, wait for colima then `down
-  --remove-orphans && up -d` (recreate, not restart-in-place) and prune offline
-  ghost registrations.
+  container can't grow unbounded; and it **removes a stale local `.runner`**
+  before `config.sh` runs, so an unclean stop no longer crash-loops.
+- **`boot-recreate.sh` + launchd:** at boot, wait for colima (escalating to
+  `stop --force` if the VM is `Broken`) then `down --remove-orphans && up -d`
+  (recreate, not restart-in-place) and prune offline ghost registrations.
+
+## What `--replace` does NOT fix (spore-host#518)
+
+`--replace` was originally added believing it stopped the reboot crash-loop. **It
+doesn't.** On 2026-08-01 all 6 runners crash-looped on exactly
+`Cannot configure the runner because it is already configured` *with `--replace`
+present in the running image*.
+
+`--replace` resolves the **server-side** name conflict. The check that fires is
+**local**: `config.sh` refuses whenever `/home/runner/.runner` exists. On a clean
+exit the `trap cleanup EXIT` removes the registration and that file; on an unclean
+stop (host reboot, VM killed) the trap never runs, the file survives, and
+`restart: always` restarts the container into an unbreakable loop. So
+`entrypoint.sh` now explicitly removes the local registration first (`config.sh
+remove` when a token can be minted, plus `rm -f .runner .credentials*`
+unconditionally, since the local files are what block `config.sh`).
+
+## The `Broken` colima VM (spore-host#518)
+
+Distinct from the disk-full mode — **check the host disk first; if it has room,
+this is your failure.** A vz VM whose prior shutdown died (`fatal: vz:
+CanRequestStop is not supported`) comes back as lima state `Broken`, not
+`Stopped`: the driver process is running but its host agent isn't.
+
+`colima start` **cannot** recover that — it exits 1 during inspection
+(`errors inspecting instance: [vz driver is running but host agent is not]`)
+without attempting a boot. `boot-recreate.sh` used to stop there and exit 1, so
+the fleet stayed down until someone noticed. It now escalates automatically:
+
+```sh
+colima stop --force   # Broken → Stopped (also reaps the orphaned vz driver)
+colima start          # now succeeds
+```
+
+Diagnose with `colima list` (→ `Broken`) or
+`LIMA_HOME=$HOME/.colima/_lima limactl list`.
 
 ## Operations
 
-**Recover now (jobs stuck / disk full / offline ghosts):**
+**Recover now (jobs stuck / disk full / offline ghosts / after a reboot):**
 ```sh
 ssh orion.local
 export PATH=/opt/homebrew/bin:$PATH
-cd ~/spore-runner-deploy && docker compose down --remove-orphans && docker compose up -d
+bash ~/spore-runner-deploy/boot-recreate.sh   # idempotent; handles a Broken VM too
 # verify: 6 containers Up, each log shows "Listening for Jobs"
-docker compose logs --tail=40 runner | grep -c "Listening for Jobs"   # → 6
+cd ~/spore-runner-deploy && docker compose logs --tail=40 runner | grep -c "Listening for Jobs"   # → 6
 ```
+Prefer the script over a bare `docker compose up -d`: that **restarts** the stale
+pre-reboot containers, which crash-loop. Recreating is what clears them.
 
 **Rebuild the image after changing `Dockerfile`/`entrypoint.sh`:**
 ```sh
-# copy this dir's Dockerfile + entrypoint.sh to ~/spore-runner, then:
-cd ~/spore-runner && docker build -t spore-runner:latest .
-cd ~/spore-runner-deploy && docker compose down --remove-orphans && docker compose up -d
+# from a clone of this repo, with the fleet IDLE (a recreate kills running jobs):
+scp infra/ci-runners/{Dockerfile,entrypoint.sh} orion.local:~/spore-runner/
+ssh orion.local 'export PATH=/opt/homebrew/bin:$PATH
+  cd ~/spore-runner && docker build -t spore-runner:latest .
+  bash ~/spore-runner-deploy/boot-recreate.sh'
+```
+A change to `entrypoint.sh` is **baked into the image** — copying it to the host is
+not enough, and neither is a recreate. Rebuild, or the fleet keeps running the old
+entrypoint. Confirm what's actually live:
+```sh
+docker run --rm --entrypoint /bin/bash spore-runner:latest -c 'md5sum /home/runner/entrypoint.sh'
+md5 -q infra/ci-runners/entrypoint.sh   # must match
+```
+
+**Check for host drift** (this dir is the source of truth; the host copies are
+deployed by hand, so they diverge silently):
+```sh
+for f in entrypoint.sh Dockerfile; do
+  ssh orion.local "md5 -q ~/spore-runner/$f" ; md5 -q "infra/ci-runners/$f"
+done
+ssh orion.local 'md5 -q ~/spore-runner-deploy/boot-recreate.sh'; md5 -q infra/ci-runners/boot-recreate.sh
 ```
 
 **Install the boot unit (one-time):**
@@ -77,6 +135,12 @@ gh api orgs/spore-host/actions/runners --jq '.total_count, (.runners[]|"\(.name)
 ```
 
 ## Notes
+- **`gh` is not installed on orion.** Anything in these scripts gated on
+  `command -v gh` silently no-ops there — that's how the ghost-prune went
+  unnoticed as dead code for weeks (#518). Use `curl` + `jq` (both at
+  `/usr/bin/`) with the `ACCESS_TOKEN` from `.env`, which is already the token
+  `entrypoint.sh` mints registration tokens with. Run `gh`-based health checks
+  from a dev host instead.
 - Repo-scope queries (`gh api repos/spore-host/spawn/actions/runners`) show **0** —
   these are **org** runners; always query the org scope.
 - Disk lives on the colima VM volume `/dev/vdb1`; check with

--- a/infra/ci-runners/boot-recreate.sh
+++ b/infra/ci-runners/boot-recreate.sh
@@ -21,9 +21,34 @@ for i in $(seq 1 36); do
   echo "waiting for colima/docker ($i)…"
   sleep 5
 done
+
+# 1b. Still no docker: escalate. `colima start` alone is NOT enough — a VM left
+# `Broken` by an unclean shutdown (seen 2026-08-01: the vz driver process survives
+# but its host agent doesn't, so lima reports "vz driver is running but host agent
+# is not") makes `colima start` exit 1 on inspection without ever trying to boot:
+#
+#   level=fatal msg="errors inspecting instance: [vz driver is running but host agent is not]"
+#
+# The fleet then stayed down ~5.5h because this script exited here (#518).
+# `colima stop --force` reaps the orphaned driver and moves Broken → Stopped, after
+# which a normal start works. Escalate on ANY failed start, not on a parsed status
+# string: the goal is never to exit while an untried recovery remains.
 if ! docker info >/dev/null 2>&1; then
   echo "colima/docker not up — trying 'colima start'"
-  colima start || { echo "FATAL: colima not available"; exit 1; }
+  if ! colima start; then
+    echo "'colima start' failed — VM is likely Broken; forcing stop then restarting"
+    colima list 2>&1 || true
+    colima stop --force || true
+    sleep 3
+    # A failed shutdown can also leave the lima disk locked; releasing it is
+    # harmless when it's already unlocked ("Ignoring unlocked disk").
+    LIMA_HOME="$HOME/.colima/_lima" limactl disk unlock colima >/dev/null 2>&1 || true
+    colima start || { echo "FATAL: colima not available even after stop --force"; exit 1; }
+  fi
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "FATAL: colima reports started but docker is not usable"; exit 1
 fi
 
 # 2. Recreate the fleet (fresh containers; --remove-orphans clears stale ones).
@@ -32,14 +57,48 @@ docker compose down --remove-orphans || true
 docker compose up -d
 
 # 3. Prune offline/ghost org runner registrations the ephemeral fleet left behind
-# on unclean shutdowns (harmless but they clutter the org list). Best-effort.
-if command -v gh >/dev/null 2>&1; then
-  gh api orgs/spore-host/actions/runners --paginate \
-    --jq '.runners[] | select(.status=="offline") | .id' 2>/dev/null \
-    | while read -r id; do
-        [ -n "$id" ] && gh api -X DELETE "orgs/spore-host/actions/runners/$id" >/dev/null 2>&1 \
-          && echo "pruned offline runner $id"
-      done
+# on unclean shutdowns (harmless but they clutter the org list, and they make
+# "is the fleet up?" unanswerable at a glance).
+#
+# This used to be gated on `command -v gh`. `gh` is NOT installed on orion, so the
+# whole block silently no-opped on every boot — it read as a safety net without
+# being one (#518). Use curl + jq (both present: /usr/bin/curl, /usr/bin/jq) with
+# the ACCESS_TOKEN already in .env — the same token entrypoint.sh mints
+# registration tokens with, so this needs no new credential.
+ORG="${ORG_NAME:-spore-host}"
+if [ -f "$DEPLOY_DIR/.env" ]; then
+  # Read ACCESS_TOKEN without exporting the whole .env or logging the value.
+  ACCESS_TOKEN=$(sed -n 's/^ACCESS_TOKEN=//p' "$DEPLOY_DIR/.env" | head -1)
+fi
+if [ -z "${ACCESS_TOKEN:-}" ]; then
+  echo "WARN: no ACCESS_TOKEN available — skipping offline-runner prune"
+elif ! command -v jq >/dev/null 2>&1; then
+  echo "WARN: jq not found — skipping offline-runner prune"
+else
+  gh_api() { # gh_api <method> <path>
+    curl -fsS -X "$1" \
+      -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/$2"
+  }
+  if ! runners_json=$(gh_api GET "orgs/${ORG}/actions/runners?per_page=100"); then
+    echo "WARN: could not list org runners (check ACCESS_TOKEN admin:org scope) — prune skipped"
+  else
+    pruned=0
+    # Only offline AND not busy: never delete a registration mid-job.
+    for id in $(printf '%s' "$runners_json" \
+                | jq -r '.runners[] | select(.status=="offline" and .busy==false) | .id'); do
+      if gh_api DELETE "orgs/${ORG}/actions/runners/${id}" >/dev/null; then
+        echo "pruned offline runner ${id}"
+        pruned=$((pruned + 1))
+      else
+        echo "WARN: failed to prune offline runner ${id}"
+      fi
+    done
+    echo "offline-runner prune: ${pruned} removed"
+    online=$(printf '%s' "$runners_json" | jq -r '[.runners[]|select(.status=="online")]|length')
+    echo "org runners online before prune: ${online}"
+  fi
 fi
 
 echo "[$(date -u +%FT%TZ)] spore-ci-runners boot-recreate done"

--- a/infra/ci-runners/entrypoint.sh
+++ b/infra/ci-runners/entrypoint.sh
@@ -46,9 +46,37 @@ fi
 grep -q '^FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=' /home/runner/.env 2>/dev/null \
   || echo 'FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true' >> /home/runner/.env
 
-# --replace lets a reused container (same name, leftover .runner config from the
-# prior cycle or a host reboot) re-register cleanly instead of refusing with
-# "already configured" and crash-looping under restart: always (spore-host#381).
+# Clear any stale LOCAL registration before configuring.
+#
+# `--replace` (below) resolves the *server-side* name conflict only. The check that
+# actually fires on a reused container is local: config.sh refuses outright when
+# /home/runner/.runner exists —
+#
+#   Cannot configure the runner because it is already configured.
+#   To reconfigure the runner, run 'config.cmd remove' or './config.sh remove' first.
+#
+# On a clean exit the `trap cleanup EXIT` below removes the registration, so
+# .runner is gone. On an UNCLEAN stop (host reboot, VM killed, OOM) the trap never
+# runs, .runner survives, and `restart: always` then restarts that container into an
+# unbreakable crash-loop. That is exactly what happened to all 6 runners on
+# 2026-08-01 despite --replace being present (#518) — so do the local removal
+# ourselves rather than assuming --replace covers it.
+if [ -f /home/runner/.runner ]; then
+  echo "stale .runner from an unclean stop — removing local registration first (#518)"
+  RM_TOKEN=$(curl -fsSL -X POST \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/orgs/${ORG_NAME}/actions/runners/remove-token" | jq -r .token)
+  if [ -n "$RM_TOKEN" ] && [ "$RM_TOKEN" != "null" ]; then
+    ./config.sh remove --token "$RM_TOKEN" || true
+  fi
+  # config.sh remove can itself fail against a registration the server already
+  # dropped; the local files are what block config.sh, so clear them regardless.
+  rm -f /home/runner/.runner /home/runner/.credentials /home/runner/.credentials_rsaparams 2>/dev/null || true
+fi
+
+# --replace additionally lets us take over a registration the server still lists
+# under this name (e.g. the ghost from a killed container) instead of erroring.
 ./config.sh \
   --url "https://github.com/${ORG_NAME}" \
   --token "$RUNNER_TOKEN" \

--- a/infra/ci-runners/host.spore-ci-runners.plist
+++ b/infra/ci-runners/host.spore-ci-runners.plist
@@ -10,9 +10,14 @@
     cp host.spore-ci-runners.plist ~/Library/LaunchAgents/com.spore.ci-runners.plist
     launchctl load -w ~/Library/LaunchAgents/com.spore.ci-runners.plist
 
-  It waits for colima (the docker backend) to be up, then `down --remove-orphans
-  && up -d` from the deploy dir, then prunes any leftover offline org runners.
-  Idempotent and safe to run repeatedly.
+  It waits for colima (the docker backend) to be up — escalating to
+  `colima stop --force` + `colima start` if the VM came back `Broken`, which
+  plain `colima start` cannot recover (spore-host#518) — then `down
+  --remove-orphans && up -d` from the deploy dir, then prunes any leftover
+  offline org runners. Idempotent and safe to run repeatedly.
+
+  Logs: /tmp/spore-ci-runners.{out,err}.log — read these FIRST when the fleet is
+  down after a boot; the 2026-08-01 outage was fully diagnosable from out.log.
 -->
 <plist version="1.0">
 <dict>

--- a/web/app/disclosure.test.ts
+++ b/web/app/disclosure.test.ts
@@ -1,8 +1,10 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   atLeast,
   DEFAULT_LEVEL,
   isLevel,
+  LEVEL_CONTROL_NAME,
   LEVEL_INFO,
   LEVELS,
   loadLevel,
@@ -125,5 +127,36 @@ describe("LEVEL_INFO", () => {
     // union without an entry here is a type error, not a blank tooltip.
     const check: Record<DisclosureLevel, unknown> = LEVEL_INFO;
     expect(check).toBeTruthy();
+  });
+});
+
+describe("LEVEL_CONTROL_NAME", () => {
+  // A source scan, not a DOM assertion, because the failure this guards against is
+  // cross-file: the control was called "Detail", lagotto and terminal each told the
+  // user so in a warning about losing a running watch or SSM session, and renaming it
+  // to "Mode" left both pointing at a control that no longer existed. Every per-file
+  // test still passed. Nothing but a scan catches that.
+  const SRC = ["shell.ts", "surfaces/lagotto.ts", "surfaces/terminal.ts"];
+  const read = (f: string) => readFileSync(new URL(f, import.meta.url), "utf8");
+
+  it("is what every reference to the control interpolates", () => {
+    for (const f of SRC) {
+      const src = read(f);
+      // Skip comments: they explain the rename, so they legitimately say "Detail".
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+      expect(code, `${f} interpolates the constant`).toContain("LEVEL_CONTROL_NAME");
+      // No hard-coded name in a user-visible string. `<b>Mode</b>` and "changing Mode"
+      // are exactly what drifted.
+      expect(code, `${f} has no hard-coded control name`).not.toMatch(
+        /<b>\s*(Mode|Detail)\s*<\/b>|(changing|switching|change this any time with)\s+(the\s+)?(Mode|Detail|detail level)/i,
+      );
+    }
+  });
+
+  it("names a control the user can find", () => {
+    // The name has to match the header label, or the instruction is unfollowable.
+    expect(read("shell.ts")).toContain('class="portal-level-label"');
+    expect(LEVEL_CONTROL_NAME.trim()).toBe(LEVEL_CONTROL_NAME);
+    expect(LEVEL_CONTROL_NAME.length).toBeGreaterThan(0);
   });
 });

--- a/web/app/disclosure.ts
+++ b/web/app/disclosure.ts
@@ -17,6 +17,16 @@ export type DisclosureLevel = "guided" | "standard" | "expert";
 /** Ordered least- to most-revealing. Index is the comparison key. */
 export const LEVELS: readonly DisclosureLevel[] = ["guided", "standard", "expert"] as const;
 
+/**
+ * What the header control is called, wherever anything refers the user to it.
+ *
+ * One constant because the name has already drifted once: the control was labelled
+ * "Detail", two surfaces told the user so in a warning, and renaming it to "Mode" left
+ * lagotto and terminal pointing at a control that no longer existed. Someone told a
+ * running SSM session ends when they touch X needs X to be findable.
+ */
+export const LEVEL_CONTROL_NAME = "Mode";
+
 /** Human labels + one line of what each level is FOR, shown in the picker. */
 export const LEVEL_INFO: Record<DisclosureLevel, { label: string; blurb: string }> = {
   guided: {

--- a/web/app/shell.ts
+++ b/web/app/shell.ts
@@ -5,7 +5,14 @@ import { surfaces, findSurface } from "./surfaces/registry.js";
 import type { PortalConfig, SurfaceContext, Disposable } from "./surfaces/types.js";
 import type { SessionController } from "./session.js";
 import { startSignIn } from "./auth/globus-login.js";
-import { DEFAULT_LEVEL, isLevel, LEVEL_INFO, LEVELS, type DisclosureLevel } from "./disclosure.js";
+import {
+  DEFAULT_LEVEL,
+  isLevel,
+  LEVEL_CONTROL_NAME,
+  LEVEL_INFO,
+  LEVELS,
+  type DisclosureLevel,
+} from "./disclosure.js";
 
 export class Shell {
   private navEl!: HTMLElement;
@@ -111,7 +118,7 @@ export class Shell {
                  tabindex="${l === current ? "0" : "-1"}">${escapeHtml(LEVEL_INFO[l].label)}</button>`,
     ).join("");
     el.innerHTML = `
-      <span class="portal-level-label" id="portal-level-label">Mode</span>
+      <span class="portal-level-label" id="portal-level-label">${escapeHtml(LEVEL_CONTROL_NAME)}</span>
       <div class="portal-level-group" role="radiogroup" aria-labelledby="portal-level-label"
            >${buttons}</div>
       <span class="portal-level-blurb">${escapeHtml(LEVEL_INFO[current].blurb)}</span>`;
@@ -345,7 +352,7 @@ export class Shell {
     this.bannerEl.className = "portal-banner info";
     this.bannerEl.innerHTML = `Showing ${escapeHtml(
       LEVEL_INFO[level].label.toLowerCase(),
-    )} controls. Change this any time with <b>Mode</b> in the header.
+    )} controls. Change this any time with <b>${escapeHtml(LEVEL_CONTROL_NAME)}</b> in the header.
       <button class="portal-banner-x" aria-label="Dismiss">×</button>`;
     this.bannerEl.querySelector(".portal-banner-x")!.addEventListener("click", () => {
       this.hideBanner();

--- a/web/app/surfaces/lagotto.ts
+++ b/web/app/surfaces/lagotto.ts
@@ -29,6 +29,7 @@ import { CapacityWatcher, type CapacityFinder, type FinderInstanceType, type Fin
 import type { MatchResult, Watch } from "@spore-host/lagotto-ts";
 import { onDemandPrice } from "@spore-host/truffle-ts";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+import { LEVEL_CONTROL_NAME } from "../disclosure.js";
 
 /** Poll cadence offered in the UI. A browser tab is a short-lived watcher. */
 const INTERVALS = [
@@ -67,7 +68,7 @@ export const lagottoSurface: ToolSurface = {
           <b>${escapeHtml(region)}</b> until it appears — the same matching the
           <code>lagotto</code> CLI does, running in this tab against your own account.</p>
         <p class="lagotto-hint warn">A watch lives only as long as this tab. Closing it,
-          reloading, or switching the detail level in the header stops the watch — nothing
+          reloading, or changing <b>${escapeHtml(LEVEL_CONTROL_NAME)}</b> in the header stops the watch — nothing
           keeps checking on your behalf. For a watch that outlives a browser, use the
           <code>lagotto</code> CLI.</p>
       </div>

--- a/web/app/surfaces/terminal.ts
+++ b/web/app/surfaces/terminal.ts
@@ -7,6 +7,7 @@
 import { SSMClient, StartSessionCommand, TerminateSessionCommand } from "@aws-sdk/client-ssm";
 import { attachTerminal, type AttachedTerminal } from "@spore-host/spawn-ts/terminal";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
+import { LEVEL_CONTROL_NAME } from "../disclosure.js";
 
 export const terminalSurface: ToolSurface = {
   id: "terminal",
@@ -100,8 +101,8 @@ export const terminalSurface: ToolSurface = {
         // click in the header drops a shell the user is typing into. Naming it is
         // the cheap half of the fix; not losing the session is issue-sized.
         status.className = "terminal-status warn";
-        status.textContent =
-          "Connected. Leaving this page, reloading, or changing the detail level in the header ends this session.";
+        // `textContent`, so the name is interpolated raw rather than escaped.
+        status.textContent = `Connected. Leaving this page, reloading, or changing ${LEVEL_CONTROL_NAME} in the header ends this session.`;
         // Un-hide BEFORE attach so xterm's fit addon measures a real size.
         termHost.hidden = false;
         attached = await attachTerminal(


### PR DESCRIPTION
Fixes the three defects behind the 2026-08-01 outage (#518), where a reboot left
the fleet offline ~5.5h with no self-healing and no alert. All `Test` /
`E2E Tier 0` jobs on spawn, truffle, lagotto and miniwdl-spawn sat queued.

## 1. `boot-recreate.sh` couldn't recover a `Broken` colima VM

The VM came back `Broken` (`vz driver is running but host agent is not`). The
script's only recovery is `colima start`, which **fails on `Broken`** — it exits 1
during inspection without attempting a boot. From `/tmp/spore-ci-runners.out.log`:

```
waiting for colima/docker (36)…
colima/docker not up — trying 'colima start'
level=fatal msg="errors inspecting instance: [vz driver is running but host agent is not]"
FATAL: colima not available
```

Now escalates to `colima stop --force` (→ `Stopped` in ~1s) + retry, and releases a
stale lima disk lock. Escalation triggers on **any** failed start rather than a
parsed status string — the point is not to exit while an untried recovery exists.

## 2. The offline-runner prune was dead code

Gated on `command -v gh`; **`gh` is not installed on orion** (`ls
/opt/homebrew/bin/gh` → no such file). It silently no-opped on every boot while
reading as a working safety net.

Rewritten on `curl` + `jq` (`/usr/bin/` both) with the `ACCESS_TOKEN` already in
`.env` — the same token `entrypoint.sh` mints registration tokens with, so **no new
credential**. It now also refuses to delete a `busy` registration (never kill a
runner mid-job) and logs failures instead of swallowing them.

## 3. `--replace` does not prevent the crash-loop it was added for

All 6 containers crash-looped on `Cannot configure the runner because it is already
configured` **with `--replace` live in the image** (verified: image md5 matches the
versioned entrypoint, flag present).

`--replace` resolves the *server-side* name conflict. The check that fires is
**local** — `config.sh` refuses whenever `/home/runner/.runner` exists (confirmed
present in a running container). An unclean stop skips the `trap cleanup EXIT` that
would remove it, then `restart: always` loops forever. `entrypoint.sh` now removes
the stale local registration first: `config.sh remove` when a token can be minted,
plus an unconditional `rm -f .runner .credentials*` since the local files are what
block `config.sh`.

## Verification

- Fixed `boot-recreate.sh` **ran on orion with the fleet idle** (checked
  `busy=0` and no in-progress runs first): completed clean, the prune step
  executed for the first time ever, 6/6 online after, no crash-loops.
- `bash -n` clean on both scripts; `shellcheck -S warning` clean apart from one
  pre-existing SC2115 I left alone.
- Prune `jq` selectors validated read-only against the live org API (correctly
  selected 0 of 6 to delete; online-count expr → 6).
- `.env` token extraction preserves `=` inside values and skips comments.
- The new `entrypoint.sh` block is **`set -e` safe**: simulated a failed token mint
  (401) and confirmed it falls through to the unconditional `rm` without aborting —
  important, because a token failure must not brick the container when local file
  removal alone is sufficient.

**Not verified live:** defect 3 needs an image rebuild on the host to take effect,
which is a deploy action outside this PR. See below.

## Deploy note (required for defect 3)

`entrypoint.sh` is **baked into the image** — merging this does not fix the running
fleet. With the fleet idle:

```sh
scp infra/ci-runners/{Dockerfile,entrypoint.sh} orion.local:~/spore-runner/
ssh orion.local 'export PATH=/opt/homebrew/bin:$PATH
  cd ~/spore-runner && docker build -t spore-runner:latest .
  bash ~/spore-runner-deploy/boot-recreate.sh'
```
Defects 1 and 2 are already live on the host (that's how they were verified);
`boot-recreate.sh` there is byte-identical to this branch's copy.

## Docs

The README asserted `--replace` fixed the reboot crash-loop — now known false, so
that's corrected rather than left to mislead the next reader. Added the `Broken`-VM
runbook, the "`gh` is absent on orion" trap, a host-drift check, and an explicit
warning that changing `entrypoint.sh` requires an image rebuild.