### PR TITLE
feat(ci-runners): sync the fleet from git instead of by hand (#522)

### DIFF
--- a/.github/workflows/ci-runner-drift.yml
+++ b/.github/workflows/ci-runner-drift.yml
@@ -1,0 +1,126 @@
+name: CI runner drift
+
+# Fails when the live orion fleet stops matching infra/ci-runners/ in this repo
+# (spore-host#522).
+#
+# Why: the versioned copies and the host copies were hand-deployed, so reviewing a
+# change here proved nothing about what the fleet actually runs. #518's defect 3
+# was precisely this shape — `--replace` was present in the live image and still
+# didn't work, and nobody could tell the image was current without checking by
+# hand.
+#
+# This job runs ON the fleet deliberately: the only way to know what a runner is
+# running is to ask a runner. It reads its OWN baked /home/runner/entrypoint.sh
+# and compares it to the repo — so it verifies the image that is executing this
+# very job, not a host file that may not be baked in yet.
+#
+# Corollary: if the fleet is down, this job just queues and never reports. That is
+# a fleet-offline problem, tracked separately in #520 — not something this check
+# can or should cover.
+
+on:
+  push:
+    branches: [main]
+    paths: ['infra/ci-runners/**']
+  pull_request:
+    paths: ['infra/ci-runners/**']
+  schedule:
+    # Daily. Catches drift introduced out-of-band (a hand edit on the host, or a
+    # sync-from-git run that failed) rather than only on the PRs that touch this dir.
+    - cron: '17 13 * * *'
+  workflow_dispatch:
+
+jobs:
+  drift:
+    name: Live fleet matches infra/ci-runners/
+    runs-on: [self-hosted, linux, orion]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Compare the running image's entrypoint against the repo
+        run: |
+          set -euo pipefail
+
+          # The runner user can read its own baked entrypoint (verified). This is
+          # the file that ACTUALLY ran to start this container, so it's the real
+          # answer to "is the fleet current?".
+          live=/home/runner/entrypoint.sh
+          if [ ! -r "$live" ]; then
+            echo "::warning::$live not readable from the job — cannot verify image drift."
+            echo "If the runner image layout changed, update this check."
+            exit 0
+          fi
+
+          live_sum=$(sha256sum "$live" | awk '{print $1}')
+          repo_sum=$(sha256sum infra/ci-runners/entrypoint.sh | awk '{print $1}')
+
+          echo "live image entrypoint: $live_sum"
+          echo "repo    entrypoint:    $repo_sum"
+
+          if [ "$live_sum" = "$repo_sum" ]; then
+            echo "entrypoint.sh: in sync"
+            exit 0
+          fi
+
+          echo "::error::The running fleet's entrypoint.sh does NOT match infra/ci-runners/entrypoint.sh."
+          echo ""
+          echo "The image is stale — entrypoint.sh is BAKED IN, so copying it to the"
+          echo "host is not enough and neither is a fleet recreate. Rebuild:"
+          echo ""
+          echo "  ssh orion.local 'export PATH=/opt/homebrew/bin:\$PATH"
+          echo "    bash ~/spore-runner-deploy/sync-from-git.sh'"
+          echo ""
+          echo "(sync-from-git.sh pulls main, rebuilds if the build context changed,"
+          echo " and recreates only when the fleet is idle.)"
+          echo ""
+          echo "--- diff (repo vs live) ---"
+          diff -u infra/ci-runners/entrypoint.sh "$live" || true
+          exit 1
+
+      - name: Check the host-side sync is actually running
+        run: |
+          set -euo pipefail
+          # docker-compose.yml and boot-recreate.sh live on the HOST fs, which a job
+          # inside a container cannot read — so this check can't hash them directly.
+          # What it CAN do is verify the thing that reconciles them is alive:
+          # sync-from-git.sh writes this manifest on every run and compose bind-mounts
+          # it in read-only. A stale/missing manifest means the automation stopped,
+          # which is the failure that lets host drift accumulate unnoticed.
+          m=/host-sync/.sync-manifest
+          # Docker creates a DIRECTORY at the mount path when the host file is
+          # missing, so test for a regular file — `-r` alone would pass on a dir.
+          if [ -d "$m" ]; then
+            echo "::error::$m is a directory — the host .sync-manifest does not exist,"
+            echo "so Docker created an empty dir for the bind mount. The host-side sync"
+            echo "has never run. Install it: infra/ci-runners/README.md → 'Automatic sync'"
+            exit 1
+          fi
+          if [ ! -f "$m" ] || [ ! -r "$m" ]; then
+            echo "::error::No sync manifest at $m — the host-side sync (sync-from-git.sh) has not run."
+            echo "Host copies of docker-compose.yml / boot-recreate.sh are unverified"
+            echo "and may be drifting. Install the launchd unit:"
+            echo "  infra/ci-runners/README.md → 'Automatic sync'"
+            exit 1
+          fi
+          cat "$m"
+          synced_sha=$(sed -n 's/^sha=//p' "$m" | head -1)
+          synced_at=$(sed -n 's/^synced_at=//p' "$m" | head -1)
+          [ -n "$synced_sha" ] || { echo "::error::manifest has no sha= line"; exit 1; }
+
+          # Stale = the sync stopped running. It runs hourly; 26h of silence means
+          # the launchd unit is dead, the host can't reach GitHub, or fetch is failing.
+          now=$(date -u +%s)
+          then_ts=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$synced_at" +%s 2>/dev/null \
+                    || date -u -d "$synced_at" +%s 2>/dev/null || echo 0)
+          if [ "$then_ts" = "0" ]; then
+            echo "::warning::could not parse synced_at=$synced_at — skipping staleness check"
+          else
+            age_h=$(( (now - then_ts) / 3600 ))
+            echo "last sync: ${age_h}h ago (sha $synced_sha)"
+            if [ "$age_h" -gt 26 ]; then
+              echo "::error::host sync last ran ${age_h}h ago — the automation has stopped."
+              echo "Check: ssh orion.local 'tail -30 /tmp/spore-ci-sync.log'"
+              exit 1
+            fi
+          fi
+          echo "host-side sync is live"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,33 @@ own changelogs for CLI releases.
   reboot crash-loop, which was not true. Fleet-offline alerting is tracked
   separately in #520 — the outage was silent because queued jobs never fail.
 
+### Added
+- **The CI runner fleet now syncs itself from this repo** (#522). `infra/ci-runners/`
+  was versioned and reviewed but reached orion.local by hand, so it documented the
+  fleet rather than defining it — reviewing a change there proved nothing about what
+  was live. That is how #518's third defect hid: a fix present in the repo *and*
+  baked into the running image, still not working, with no way to tell the image was
+  current short of hashing it by hand. Two new pieces:
+  - `infra/ci-runners/sync-from-git.sh`, run hourly and at boot by launchd
+    (`host.spore-ci-sync.plist`): fetches `main`, copies only files whose content
+    changed, rebuilds the image when the build context changed **or** when the baked
+    `entrypoint.sh` no longer matches the repo, and recreates the fleet **only when
+    no runner is busy** — recreating mid-job kills that CI run. When busy it defers
+    to the next run instead. A no-drift run changes nothing and exits 0.
+  - A `CI runner drift` workflow that runs *on the fleet* deliberately: the only way
+    to know what a runner runs is to ask a runner, so the job hashes its own baked
+    `/home/runner/entrypoint.sh` against the repo and fails with a diff plus the
+    remediation command. It also verifies the hourly sync is still alive via a
+    `.sync-manifest` heartbeat, bind-mounted read-only so a job cannot forge its own
+    proof of freshness.
+
+  Effect: merging a runner change to `main` deploys it; `scp`-ing fixes onto the host
+  is no longer the workflow, and drift that does appear fails a check instead of
+  sitting undetected. Limits are explicit — a container can't read the host
+  filesystem, so the gate verifies the reconciler rather than hashing
+  `docker-compose.yml`/`boot-recreate.sh` directly, and a fully offline fleet leaves
+  this gate queued rather than red (that's #520).
+
 ### Changed
 - Bumped the `substrate` test dependency v0.65.0 → v0.85.0 in the
   `accountlifecycle` and `spore-bot` Lambda modules, 20 minor versions of AWS

--- a/infra/ci-runners/README.md
+++ b/infra/ci-runners/README.md
@@ -11,14 +11,18 @@ previously lived only on the host, so fixes weren't reviewable.
 | File | Purpose |
 |---|---|
 | `Dockerfile` | the `spore-runner:latest` image (Ubuntu 24.04 + Go + the actions runner) |
-| `entrypoint.sh` | per-cycle: mint a registration token, **self-heal** (`--replace` + clear `_work`/cap go-build cache), register ephemeral, run one job |
+| `entrypoint.sh` | per-cycle: mint a registration token, **self-heal** (clear a stale local `.runner`, `--replace`, clear `_work`/cap go-build cache), register ephemeral, run one job |
 | `docker-compose.yml` | the 6-replica fleet (`restart: always`, locally built image) |
 | `.env.example` | the one secret: `ACCESS_TOKEN` (PAT with `admin:org`). Real `.env` is host-only, gitignored |
 | `boot-recreate.sh` | recreate the fleet (used at boot + manual recovery) |
 | `host.spore-ci-runners.plist` | launchd unit that runs `boot-recreate.sh` at host boot |
+| `sync-from-git.sh` | reconcile the live host + image to this dir, hourly (spore-host#522) |
+| `host.spore-ci-sync.plist` | launchd unit that runs `sync-from-git.sh` hourly and at boot |
 
 The live host copy is `orion.local:~/spore-runner-deploy` (compose + `.env`) with
-the image build context at `~/spore-runner`. Keep them in sync with this dir.
+the image build context at `~/spore-runner`. `sync-from-git.sh` keeps both matching
+this dir automatically — see [Automatic sync](#automatic-sync-spore-host522). Merge
+to `main` and it converges; don't `scp` fixes onto the host.
 
 ## Why it kept breaking (spore-host#381)
 
@@ -97,24 +101,67 @@ cd ~/spore-runner-deploy && docker compose logs --tail=40 runner | grep -c "List
 Prefer the script over a bare `docker compose up -d`: that **restarts** the stale
 pre-reboot containers, which crash-loop. Recreating is what clears them.
 
-**Rebuild the image after changing `Dockerfile`/`entrypoint.sh`:**
+**Ship a change to `Dockerfile`/`entrypoint.sh`:** merge it to `main` — the hourly
+sync (below) deploys, rebuilds, and recreates on its own. To apply it now rather
+than within the hour:
 ```sh
-# from a clone of this repo, with the fleet IDLE (a recreate kills running jobs):
-scp infra/ci-runners/{Dockerfile,entrypoint.sh} orion.local:~/spore-runner/
 ssh orion.local 'export PATH=/opt/homebrew/bin:$PATH
-  cd ~/spore-runner && docker build -t spore-runner:latest .
-  bash ~/spore-runner-deploy/boot-recreate.sh'
+  bash ~/spore-runner-deploy/sync-from-git.sh'
 ```
 A change to `entrypoint.sh` is **baked into the image** — copying it to the host is
-not enough, and neither is a recreate. Rebuild, or the fleet keeps running the old
-entrypoint. Confirm what's actually live:
+not enough, and neither is a recreate. `sync-from-git.sh` handles that (it compares
+the *baked* copy, not just the host file), but if you build by hand, rebuild.
+Confirm what's actually live:
 ```sh
 docker run --rm --entrypoint /bin/bash spore-runner:latest -c 'md5sum /home/runner/entrypoint.sh'
 md5 -q infra/ci-runners/entrypoint.sh   # must match
 ```
 
-**Check for host drift** (this dir is the source of truth; the host copies are
-deployed by hand, so they diverge silently):
+## Automatic sync (spore-host#522)
+
+`sync-from-git.sh` makes this directory the fleet's actual definition instead of a
+document about it. launchd runs it hourly (and at boot): fetch `main` into a cache
+clone, copy only files whose content changed, rebuild when the build context
+changed **or** when the baked entrypoint stops matching the repo, then recreate —
+but **only when no runner is busy**. A no-drift run touches nothing and exits 0.
+
+It defers rather than interrupts: recreating mid-job kills that CI run, which
+surfaces as a job that times out with no recorded steps (the #381 signature). The
+next hourly run applies the staged change.
+
+`.github/workflows/ci-runner-drift.yml` is the other half, and it runs *on the
+fleet* on purpose — the only way to know what a runner runs is to ask a runner. It
+hashes its own baked `/home/runner/entrypoint.sh` against the repo, and separately
+checks the `.sync-manifest` heartbeat (bind-mounted `:ro`, so a job can't forge its
+own proof of freshness) to catch the sync itself having died. It can't hash
+`docker-compose.yml` or `boot-recreate.sh` — a container can't read the host FS —
+so it verifies the reconciler is alive and lets the reconciler cover the content.
+
+**Bootstrap (one-time, chicken-and-egg — the script deploys itself, so the first
+copy is placed by hand):**
+```sh
+scp infra/ci-runners/sync-from-git.sh orion.local:~/spore-runner-deploy/
+ssh orion.local 'chmod +x ~/spore-runner-deploy/sync-from-git.sh
+  # Create the manifest BEFORE the fleet is recreated: Docker creates a
+  # DIRECTORY at a bind-mount path whose host file is missing, and a dir there
+  # makes the drift gate fail. The first sync run overwrites this.
+  : > ~/spore-runner-deploy/.sync-manifest'
+scp infra/ci-runners/host.spore-ci-sync.plist orion.local:~/Library/LaunchAgents/com.spore.ci-sync.plist
+ssh orion.local 'launchctl load -w ~/Library/LaunchAgents/com.spore.ci-sync.plist'
+```
+The unit runs at load, so that last command performs the first real sync. Verify:
+```sh
+ssh orion.local 'tail -40 /tmp/spore-ci-sync.log'
+```
+
+**Preview / force / inspect:**
+```sh
+ssh orion.local 'SPORE_SYNC_DRY_RUN=1 bash ~/spore-runner-deploy/sync-from-git.sh'  # report drift, change nothing
+ssh orion.local 'SPORE_SYNC_FORCE=1   bash ~/spore-runner-deploy/sync-from-git.sh'  # recreate even with no drift
+ssh orion.local 'tail -40 /tmp/spore-ci-sync.log; cat ~/spore-runner-deploy/.sync-manifest'
+```
+
+**Manual drift check** (still useful when the sync is what you suspect):
 ```sh
 for f in entrypoint.sh Dockerfile; do
   ssh orion.local "md5 -q ~/spore-runner/$f" ; md5 -q "infra/ci-runners/$f"

--- a/infra/ci-runners/docker-compose.yml
+++ b/infra/ci-runners/docker-compose.yml
@@ -5,8 +5,8 @@
 #
 # Reboot resilience (spore-host#381): on the host, recreate (not restart) the
 # fleet at boot via the launchd unit in this dir, and the entrypoint self-heals
-# (--replace re-registers; per-cycle _work/cache cleanup bounds disk). Build the
-# image from ./Dockerfile + ./entrypoint.sh in this dir (`docker build -t
+# (clears a stale local .runner; per-cycle _work/cache cleanup bounds disk). Build
+# the image from ./Dockerfile + ./entrypoint.sh in this dir (`docker build -t
 # spore-runner:latest .`).
 services:
   runner:
@@ -21,5 +21,12 @@ services:
       # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 is injected per-job via /home/runner/.env
       # by the entrypoint (covers bundled Node 20 actions like github-script in
       # codecov-action@v5). See spore-host#345.
+    volumes:
+      # Read-only heartbeat from sync-from-git.sh, surfaced to the CI drift gate
+      # (spore-host#522). A job can't read the host FS, so the drift workflow reads
+      # this to prove the host-side sync is still running; if it's missing or stale,
+      # host copies are unverified and the gate fails. `:ro` — a CI job must never
+      # be able to forge its own liveness proof.
+      - ./.sync-manifest:/host-sync/.sync-manifest:ro
     deploy:
       replicas: 6

--- a/infra/ci-runners/host.spore-ci-sync.plist
+++ b/infra/ci-runners/host.spore-ci-sync.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd unit for orion.local — keep the live fleet in sync with the repo
+  (spore-host#522).
+
+  Runs infra/ci-runners/sync-from-git.sh hourly: fetch main, deploy only what
+  changed, rebuild the image if the build context changed, and recreate the fleet
+  only when it is IDLE (never mid-job). A no-drift run makes no changes and exits 0.
+
+  This is what makes `infra/ci-runners/` the actual source of truth instead of a
+  copy that hopefully matches. Before it, everything here was hand-deployed and
+  drifted silently — which is how #518's defect 3 stayed invisible (a fix that was
+  live in the image and still didn't work).
+
+  Install:
+    cp host.spore-ci-sync.plist ~/Library/LaunchAgents/com.spore.ci-sync.plist
+    launchctl load -w ~/Library/LaunchAgents/com.spore.ci-sync.plist
+
+  Verify:  tail -30 /tmp/spore-ci-sync.log
+  Force:   SPORE_SYNC_FORCE=1 bash ~/spore-runner-deploy/sync-from-git.sh
+  Preview: SPORE_SYNC_DRY_RUN=1 bash ~/spore-runner-deploy/sync-from-git.sh
+
+  The CI drift gate (.github/workflows/ci-runner-drift.yml) fails if this stops
+  running for >26h, so a dead unit surfaces as a red check rather than silence.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.spore.ci-sync</string>
+  <!-- Also run at load/boot: a reboot should converge on main without waiting an
+       hour, and boot-recreate.sh (the other unit) only recreates — it never pulls. -->
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>3600</integer>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>/Users/scttfrdmn/spore-runner-deploy/sync-from-git.sh</string>
+  </array>
+  <key>StandardOutPath</key>
+  <string>/tmp/spore-ci-sync.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/spore-ci-sync.log</string>
+</dict>
+</plist>

--- a/infra/ci-runners/sync-from-git.sh
+++ b/infra/ci-runners/sync-from-git.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Sync the live orion fleet to this repo's infra/ci-runners/ (spore-host#522).
+#
+# Why this exists: the versioned copies here and the live host copies
+# (~/spore-runner, ~/spore-runner-deploy) were deployed BY HAND, so they drifted
+# silently. Reviewing a fix here proved nothing about what the fleet was actually
+# running — and #518's defect 3 shipped a fix (`--replace`) that was live in the
+# image yet didn't work, which is exactly the class of thing hand-deploys hide.
+#
+# What it does, in order:
+#   1. fetch + hard-reset a bare-ish cache clone of main (no local edits kept)
+#   2. copy scripts into place ONLY if their content changed
+#   3. rebuild the runner image if the build context changed (Dockerfile/entrypoint)
+#   4. recreate the fleet if anything changed AND the fleet is idle
+# Idempotent: a no-drift run makes no changes, touches no containers, and exits 0.
+#
+# Safety: never recreates while a runner is busy (that would kill a live CI job).
+# If busy, it reports what's pending and exits 0 — the next run picks it up. Run
+# from cron/launchd; see README.
+set -u
+export PATH=/opt/homebrew/bin:$PATH
+
+REPO_URL="${SPORE_REPO_URL:-https://github.com/spore-host/spore-host.git}"
+CACHE_DIR="${SPORE_REPO_CACHE:-$HOME/.cache/spore-ci-runners-src}"
+BUILD_DIR="${SPORE_RUNNER_BUILD_DIR:-$HOME/spore-runner}"
+DEPLOY_DIR="${SPORE_RUNNER_DIR:-$HOME/spore-runner-deploy}"
+SRC_SUBDIR="infra/ci-runners"
+FORCE="${SPORE_SYNC_FORCE:-0}"      # 1 = recreate even if nothing changed
+DRY_RUN="${SPORE_SYNC_DRY_RUN:-0}"  # 1 = report drift, change nothing
+
+log() { echo "[$(date -u +%FT%TZ)] sync-from-git: $*"; }
+
+# --- 1. Refresh the source of truth ------------------------------------------
+if [ -d "$CACHE_DIR/.git" ]; then
+  git -C "$CACHE_DIR" fetch --quiet --depth 1 origin main || {
+    log "FATAL: git fetch failed"; exit 1; }
+  git -C "$CACHE_DIR" reset --quiet --hard FETCH_HEAD || {
+    log "FATAL: git reset failed"; exit 1; }
+else
+  rm -rf "$CACHE_DIR"
+  git clone --quiet --depth 1 --branch main "$REPO_URL" "$CACHE_DIR" || {
+    log "FATAL: git clone failed"; exit 1; }
+fi
+SRC="$CACHE_DIR/$SRC_SUBDIR"
+[ -d "$SRC" ] || { log "FATAL: $SRC missing in the clone"; exit 1; }
+HEAD_SHA=$(git -C "$CACHE_DIR" rev-parse --short HEAD)
+log "source at $HEAD_SHA"
+
+# Heartbeat for the CI drift gate. The workflow can't read the host FS from inside
+# a container, so it checks this instead: a missing or stale manifest means THIS
+# script stopped running, which is the failure that lets host-side drift pile up
+# unnoticed. Written on every successful fetch, including no-drift runs — the point
+# is to prove liveness, not to record changes. The entrypoint copies it into each
+# container (see entrypoint.sh).
+write_manifest() {
+  [ "$DRY_RUN" = "1" ] && return 0
+  mkdir -p "$DEPLOY_DIR"
+  cat > "$DEPLOY_DIR/.sync-manifest" <<EOF
+sha=$HEAD_SHA
+synced_at=$(date -u +%FT%TZ)
+EOF
+}
+write_manifest
+
+# --- 2. Deploy changed files -------------------------------------------------
+# hash <file> — content hash, or "-" when absent. macOS `md5 -q`.
+hash_of() { [ -f "$1" ] && md5 -q "$1" || echo "-"; }
+
+changed_build=0   # Dockerfile/entrypoint.sh → needs an image rebuild
+changed_any=0
+
+deploy() { # deploy <src-name> <dest-path> <is-build-input>
+  local src="$SRC/$1" dest="$2" is_build="$3"
+  [ -f "$src" ] || { log "WARN: $1 missing in repo — skipped"; return 0; }
+  if [ "$(hash_of "$src")" = "$(hash_of "$dest")" ]; then
+    return 0
+  fi
+  log "DRIFT: $1 differs from $dest"
+  changed_any=1
+  [ "$is_build" = "1" ] && changed_build=1
+  if [ "$DRY_RUN" = "1" ]; then
+    log "  (dry run — not copying)"
+    return 0
+  fi
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest" || { log "FATAL: copy $1 failed"; exit 1; }
+  case "$dest" in *.sh) chmod +x "$dest";; esac
+  log "  updated $dest"
+}
+
+deploy Dockerfile        "$BUILD_DIR/Dockerfile"          1
+deploy entrypoint.sh     "$BUILD_DIR/entrypoint.sh"       1
+deploy docker-compose.yml "$DEPLOY_DIR/docker-compose.yml" 0
+deploy boot-recreate.sh  "$DEPLOY_DIR/boot-recreate.sh"   0
+deploy sync-from-git.sh  "$DEPLOY_DIR/sync-from-git.sh"   0
+
+# The image can also drift from an up-to-date build context — e.g. someone edited
+# entrypoint.sh on the host and never rebuilt, or a rebuild failed half-done. The
+# baked copy is what actually runs, so compare against THAT, not just the files.
+if docker image inspect spore-runner:latest >/dev/null 2>&1; then
+  baked=$(docker run --rm --entrypoint /bin/bash spore-runner:latest \
+            -c 'md5sum /home/runner/entrypoint.sh' 2>/dev/null | awk '{print $1}')
+  want=$(hash_of "$SRC/entrypoint.sh")
+  if [ -n "$baked" ] && [ "$baked" != "$want" ]; then
+    log "DRIFT: image entrypoint ($baked) != repo ($want) — rebuild needed"
+    changed_any=1; changed_build=1
+  fi
+else
+  log "DRIFT: spore-runner:latest image missing — build needed"
+  changed_any=1; changed_build=1
+fi
+
+if [ "$changed_any" = "0" ] && [ "$FORCE" != "1" ]; then
+  log "no drift — nothing to do"
+  exit 0
+fi
+if [ "$DRY_RUN" = "1" ]; then
+  log "dry run complete — drift found, no changes made"
+  exit 0
+fi
+
+# --- 3. Never disturb a running job -----------------------------------------
+# A rebuild + recreate tears down containers. Doing that mid-job kills the CI run
+# (which shows up as a job that times out with no recorded steps — the #381
+# signature). Defer instead; the next scheduled run applies it.
+busy=0
+for c in $(docker ps --filter "name=spore-runner-deploy-runner" --format '{{.Names}}' 2>/dev/null); do
+  if docker exec "$c" sh -c 'ps ax 2>/dev/null | grep -q "[R]unner.Worker"' 2>/dev/null; then
+    busy=$((busy + 1))
+  fi
+done
+if [ "$busy" -gt 0 ]; then
+  log "$busy runner(s) busy — deferring rebuild/recreate to the next run (files are staged)"
+  exit 0
+fi
+
+# --- 4. Rebuild + recreate ---------------------------------------------------
+if [ "$changed_build" = "1" ]; then
+  log "rebuilding spore-runner:latest"
+  ( cd "$BUILD_DIR" && docker build -q -t spore-runner:latest . ) >/dev/null || {
+    log "FATAL: docker build failed — fleet left on the OLD image (still serving)"; exit 1; }
+  log "rebuild done"
+fi
+
+log "recreating the fleet"
+bash "$DEPLOY_DIR/boot-recreate.sh" || { log "FATAL: boot-recreate failed"; exit 1; }
+log "sync complete"


### PR DESCRIPTION
Closes #522.

`infra/ci-runners/` was versioned and reviewed but reached orion.local by
`scp` — so it documented the fleet rather than defining it, and reviewing a
change there proved nothing about what was live. #518's third defect is the
proof: a fix present in the repo **and** baked into the running image, still
not working, with no way to tell the image was current short of hashing it by
hand.

## What's here

**`infra/ci-runners/sync-from-git.sh`** + **`host.spore-ci-sync.plist`** —
hourly and at boot: fetch `main` into a cache clone, copy only files whose
content changed, rebuild the image when the build context changed **or** when
the baked `entrypoint.sh` no longer matches the repo, then recreate — but only
when no runner is busy. Recreating mid-job kills that CI run (the #381
signature: a job that times out with no recorded steps), so when busy it
stages the files and defers to the next run. A no-drift run changes nothing
and exits 0.

**`.github/workflows/ci-runner-drift.yml`** — runs *on the fleet* on purpose,
because the only way to know what a runner runs is to ask a runner. Hashes its
own baked `/home/runner/entrypoint.sh` against the repo, failing with a `diff
-u` and the remediation command. Then verifies the sync itself is alive via a
`.sync-manifest` heartbeat, bind-mounted `:ro` in `docker-compose.yml` so a CI
job can't forge its own proof of freshness.

## Verified before pushing

Ran against isolated dirs with a stubbed `docker`, and the workflow steps
extracted and run in real `ubuntu:24.04` containers:

- second run on unchanged `main` is a true no-op — no build, no recreate — but
  the heartbeat still refreshes, which is what the gate depends on
- busy fleet defers: the `build` stub was a poison pill returning 9 and was
  never invoked
- stale image with an already-current host `entrypoint.sh` is still caught
  (this is the case a file-only comparison misses)
- gate fails on a tampered entrypoint with a real diff, passes on a match
- manifest step fails when the file is missing, when Docker has created a
  **directory** in its place (the never-bootstrapped case — `-r` alone would
  have passed), and at 30h stale; passes when fresh. Timestamp parsing checked
  under both BSD `date -j -f` and the GNU `date -d` fallback that actually
  runs in the container.

`shellcheck -S warning` is clean on the new script. `actions/checkout` pinned
to `3d3c42e` (v7.0.1) to match the other 10 workflows here — my first draft
used a v7.0.0 SHA.

## Notes for review

- **Bootstrap is chicken-and-egg** and hand-done once: the script deploys
  itself, so the first copy is `scp`-ed. README documents it, including
  creating `.sync-manifest` **before** the fleet is recreated — Docker creates
  a directory at a bind-mount path whose host file is missing, and a directory
  there fails the gate.
- **The compose change needs a fleet recreate to take effect** (new `:ro`
  mount), so it should be applied while idle. Until then the drift gate's
  second step will report a missing manifest — expected, and it's the
  bootstrap the message points at.
- `entrypoint.sh` is deliberately **not** touched here so the gate's hash
  comparison stays meaningful. It does carry a pre-existing `shellcheck`
  SC2115 (`rm -rf "$GOCACHE_DIR"/*`) that I'll fix separately.
- A fully offline fleet leaves this gate queued rather than red — that's #520,
  not something a check running on the fleet can cover.