### PR TITLE
chore: make branch hygiene checkable, so #519 can't repeat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,84 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # Catches a PR that carries another in-flight PR's commits, which is how #519
+  # ended up merging as an empty commit: #521 was branched from a tree still
+  # holding #519's work, merged first, and took the portal fix with it. #519 then
+  # had nothing to apply — and an empty commit matches no path filter, so the PR
+  # that existed to fix two user-facing strings triggered neither web-ci.yml nor
+  # deploy-site.yaml. Nothing was red. The work just wasn't where its PR said.
+  #
+  # Unconditional (no paths: filter) so it can be a required check without
+  # deadlocking PRs that don't touch the filtered directories.
+  branch-hygiene:
+    name: Branch hygiene
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    # Job-scoped rather than widening the workflow's `contents: read`: this is the
+    # only job that needs to enumerate other open PRs.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Full history: the merge-base and the per-commit reachability checks
+          # below are meaningless against a depth-1 clone.
+          fetch-depth: 0
+
+      - name: PR is non-empty and self-contained
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          echo "merge-base: $base"
+
+          # 1. An empty PR means someone else already merged this work, so the
+          #    deploy this PR implies will never fire. This is the state #519 was
+          #    in by the time it merged — though not when it was opened, which is
+          #    why check 2 below is the one that would actually have caught it.
+          if [ -z "$(git diff --name-only "$base" "$HEAD_SHA")" ]; then
+            echo "::error::This PR has an empty diff against its merge-base."
+            echo "Another PR has probably already carried these commits. Nothing"
+            echo "would deploy: an empty merge commit matches no path filter."
+            exit 1
+          fi
+          echo "PR diff is non-empty"
+
+          # 2. No commit here may also belong to another OPEN PR.
+          #
+          # Testing against origin/main is not enough and it is worth being precise
+          # about why: when #521 was open, the portal commit it had absorbed had not
+          # yet merged, so "is it on main?" answered no for both of its commits. The
+          # detectable signal at that moment was that #519 was open with the same
+          # commit in its head. That is what this checks.
+          bad=0
+          others="$(gh pr list --state open --json number,headRefOid \
+                      --jq ".[] | select(.number != $PR) | \"\(.number) \(.headRefOid)\"")"
+          while read -r c; do
+            [ -z "$c" ] && continue
+            while read -r n oid; do
+              [ -z "${oid:-}" ] && continue
+              # Fetch the other PR's head so reachability is answerable locally.
+              git fetch --quiet origin "pull/$n/head" 2>/dev/null || continue
+              if git merge-base --is-ancestor "$c" FETCH_HEAD 2>/dev/null; then
+                echo "::error::Commit ${c:0:7} ($(git log -1 --format=%s "$c")) is also in open PR #$n."
+                echo "This branch was cut from unmerged work. Whichever PR merges first"
+                echo "ships both changes; the other merges empty and deploys nothing."
+                bad=1
+              fi
+            done <<< "$others"
+          done < <(git rev-list "$base..$HEAD_SHA")
+          [ "$bad" -eq 0 ] || {
+            echo "Branch from origin/main with a clean tree — see CONTRIBUTING.md."
+            exit 1
+          }
+          echo "no commits shared with another open PR"
+
   lambda-tests:
     name: Lambda module tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Added
+- **Branch hygiene is now checked, not just documented.** PR #521 was branched from
+  a working tree that still held PR #519's portal commit, so #521's head carried
+  both changes. #521 merged first and took the portal fix with it; #519 then merged
+  as an **empty commit** (`131f02b`). Because `deploy-site.yaml` and `web-ci.yml`
+  are path-filtered on `web/**`, an empty commit matched neither — so the PR whose
+  entire purpose was correcting two user-facing strings ran no web tests and
+  triggered no site deploy. Nothing was red; the work simply wasn't where its PR
+  said it was, and establishing that the fix was live took a bundle-level audit of
+  what S3 was actually serving.
+  - `scripts/branch-preflight.sh` — run before opening a PR. Checks: not on `main`,
+    clean tree, based on `origin/main` history, every commit unique to this branch,
+    and (advisory) a single topic. `--fix` prints recovery commands.
+  - A `Branch hygiene` job in `ci.yml` — fails a PR with an empty diff, or one
+    carrying a commit that also belongs to another **open** PR. Comparing against
+    open PR heads rather than `main` is the load-bearing detail: when #521 was open,
+    the absorbed portal commit had not yet merged, so "is it on main?" answered no
+    for both of its commits.
+  - `CONTRIBUTING.md` gains a **Branching and merging** section; `CLAUDE.md`'s Git
+    section gains the rule and the post-merge verification steps.
+  - Repo setting: `delete_branch_on_merge` is now **on**. It was off, which is how
+    66 stale local branches accumulated before being swept.
+
 ### Fixed
 - **CI runner fleet: a host reboot no longer leaves the fleet dead** (#518). On
   2026-08-01 the whole self-hosted fleet stayed offline for ~5.5h and every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,46 @@
 - Branch naming: `feat/`, `fix/`, `refactor/` prefixes
 - PR per feature/fix; link to issue
 
+### Branching: always cut from `origin/main`, with a clean tree
+
+```bash
+git fetch origin main
+git status --porcelain              # must be empty
+git checkout -b fix/123-thing origin/main
+```
+
+**Never** `git checkout -b` from a dirty tree or from a `HEAD` carrying unmerged
+work. `main` is squash-merged and linear, so a topic branch being a few commits
+behind the tip is normal and needs no rebase — but a branch cut from *another
+branch* silently adopts that branch's commits.
+
+Run `scripts/branch-preflight.sh` before opening a PR. It checks the four things
+that actually broke: not on `main`, clean tree, based on `origin/main` history,
+and every commit unique to this branch. `--fix` prints recovery commands.
+
+**Why this is a rule and not a preference.** PR #521 (a CI-runner fix) was branched
+from a tree still holding PR #519's portal commit, so #521's head contained both.
+#521 merged first and carried the portal fix; #519 then merged as an **empty
+commit** (`131f02b`). Because `deploy-site.yaml` and `web-ci.yml` are path-filtered
+on `web/**`, an empty commit matched neither — so the PR whose whole purpose was
+fixing two user-facing strings produced no Web CI run and no site deploy, and
+confirming the fix was live took a bundle-level audit of what S3 was serving.
+
+Corollaries:
+- One topic per PR. A diff spanning `web/` + `infra/` + `lambda/` is usually the
+  dirty-tree symptom, not a design.
+- After a merge, verify the merge commit is **non-empty** when it should have
+  shipped something: `git show --stat <sha>`. An empty diff means another PR
+  already carried your work.
+- For a `web/**` or `docs/**` change, confirm the deploy workflow actually ran —
+  a path-filtered workflow that never triggers looks identical to a passing one.
+- Branches are **not** auto-deleted on merge (`delete_branch_on_merge` is off).
+  Delete yours after merge, or they accumulate — 66 had to be swept once already.
+  The safe test for "is this branch merged?" is **not** `git branch --merged`
+  (squash-merge defeats ancestry) and **not** `git diff main <branch>` (a stale
+  branch reports main's newer files as deletions). Compare the branch tip to the
+  `headRefOid` GitHub recorded for its merged PR.
+
 ## Pre-commit Checks
 - Run before every commit: `gofmt`, `go vet`, `staticcheck`
 - Smoke tests: `go test -short ./...`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,55 @@ Each Go tool follows the same conventions (see the repo's `CLAUDE.md` / `Makefil
 - **Commits:** [Conventional Commits](https://www.conventionalcommits.org/)
   (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`), branch prefixes `feat/` `fix/`
   `docs/`, one PR per change, link the issue.
+- **Branching:** always cut from `origin/main` with a clean tree, and run
+  `scripts/branch-preflight.sh` before opening the PR — see
+  [Branching and merging](#branching-and-merging) below.
 - **Versioning:** [SemVer 2.0.0](https://semver.org) + a Keep-a-Changelog
   `CHANGELOG.md`; update `## [Unreleased]` in the **same PR** as any user-facing change.
 - **Docs:** the site is VitePress under `docs/`. `cd docs && npm install && npm run
   docs:dev` to preview; `npm run build` must pass. CLI references are generated —
   don't hand-edit generated pages.
+
+## Branching and merging
+
+`main` is **squash-merged and linear** — one commit per PR, no merge commits. It
+also **auto-deploys**: `web/**` publishes to spore.host and `docs/**` to
+docs.spore.host on push. So a merge is a release.
+
+Start every branch the same way:
+
+```bash
+git fetch origin main
+git status --porcelain                        # must be empty
+git checkout -b fix/123-short-name origin/main
+scripts/branch-preflight.sh                   # before you open the PR
+```
+
+Being a few commits behind `main` is fine and needs no rebase; squash-merge handles
+it. What is **not** fine is branching from a dirty tree or from a `HEAD` that holds
+unmerged work — the new branch silently adopts those commits, and whichever PR
+merges first ships them under its own number. The second one then merges **empty**.
+
+That happened: #521 was cut from a tree still holding #519's commit, merged first,
+and carried it. #519 landed as an empty commit — which matched neither the
+`web/**` path filter on `deploy-site.yaml` nor `web-ci.yml`, so the PR that existed
+to fix two user-facing strings ran no web tests and triggered no deploy. Nothing was
+red; the work simply wasn't where its PR said it was.
+
+After merging:
+
+- Check the merge commit isn't empty when it should have shipped something:
+  `git show --stat <sha>`.
+- For `web/**` or `docs/**`, confirm the deploy workflow ran —
+  `gh run list --commit <sha>`. A path-filtered workflow that never fires looks
+  exactly like one that passed.
+- **Delete your branch.** Auto-delete-on-merge is off, so they accumulate.
+
+To tell whether an old branch is safe to delete, compare its tip to the head SHA
+GitHub recorded for its merged PR (`gh pr list --state merged --json
+headRefName,headRefOid`). Don't trust `git branch --merged` — squash-merge breaks
+ancestry — and don't read `git diff main <branch>`, where a stale branch appears to
+delete every file `main` has gained since.
 
 ## Cost safety (important)
 

--- a/scripts/branch-preflight.sh
+++ b/scripts/branch-preflight.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Check that the current branch is a clean, single-topic branch off origin/main
+# before you open a PR.
+#
+# This exists because of a specific failure, not as a style preference. PR #521
+# (a CI-runner fix) was branched from a working tree that still held PR #519's
+# portal commit, so #521's head contained BOTH changes. #521 merged first and
+# carried the portal fix with it; #519 then merged as an EMPTY commit (131f02b).
+#
+# The damage wasn't cosmetic. deploy-site.yaml and web-ci.yml are path-filtered on
+# `web/**`, so an empty merge commit matched neither: the PR whose entire purpose
+# was fixing two user-facing strings produced no Web CI run and no site deploy,
+# and it took a bundle-level audit of what was actually being served to establish
+# whether the fix was live at all.
+#
+# Both symptoms — the empty commit and the swept-in unrelated files — come from
+# one root cause: branching off a dirty HEAD instead of off origin/main. That is
+# mechanically detectable, which is what this script does.
+#
+# Usage:  scripts/branch-preflight.sh          # check the current branch
+#         scripts/branch-preflight.sh --fix    # print the commands to fix it
+set -uo pipefail
+
+fail=0
+FIX=0
+[ "${1:-}" = "--fix" ] && FIX=1
+
+say()  { printf '%s\n' "$*"; }
+bad()  { printf '  \033[31mFAIL\033[0m  %s\n' "$*"; fail=1; }
+ok()   { printf '  \033[32mok\033[0m    %s\n' "$*"; }
+warn() { printf '  \033[33mwarn\033[0m  %s\n' "$*"; }
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+say "branch-preflight: $branch"
+
+# ── 1. Not on main ───────────────────────────────────────────────────────────
+# main auto-deploys (deploy-site.yaml on web/**, docs.yaml on docs/**), so a
+# commit made directly here publishes without ever having been a PR.
+if [ "$branch" = "main" ]; then
+  bad "you are on main — main auto-deploys; work on a topic branch"
+else
+  ok "not on main"
+fi
+
+# ── 2. Clean tree ────────────────────────────────────────────────────────────
+# A dirty tree is how unrelated files get swept into a commit. It happened in
+# this repo: two infra/ci-runners/ files landed in a portal commit and had to be
+# unstaged after the fact.
+if [ -n "$(git status --porcelain)" ]; then
+  bad "working tree is dirty — commit, stash, or restore before opening a PR:"
+  git status --short | sed 's/^/          /'
+else
+  ok "working tree clean"
+fi
+
+git fetch origin main --quiet 2>/dev/null || warn "could not fetch origin/main — comparing against a possibly stale ref"
+
+# ── 3. Branched off origin/main ──────────────────────────────────────────────
+# The load-bearing check. If the merge-base isn't an ancestor of origin/main,
+# this branch was cut from someone else's work (or your own unmerged work) and
+# will carry their commits into your PR.
+base="$(git merge-base HEAD origin/main 2>/dev/null)"
+if [ -z "$base" ]; then
+  bad "no merge-base with origin/main — is this branch related to main at all?"
+elif ! git merge-base --is-ancestor "$base" origin/main; then
+  bad "merge-base ${base:0:7} is not an ancestor of origin/main"
+else
+  behind=$(git rev-list --count "$base..origin/main")
+  # Being behind is fine and normal under squash-merge — it is NOT an error.
+  # It is only worth naming because it's the condition under which two PRs
+  # touching the same files silently overlap.
+  if [ "$behind" -gt 0 ]; then
+    ok "based on origin/main history (${behind} commit(s) behind tip — fine for squash-merge)"
+  else
+    ok "based on origin/main tip"
+  fi
+fi
+
+# ── 4. Only your own commits ─────────────────────────────────────────────────
+# The check that would have caught #521. Every commit unique to this branch must
+# be absent from origin/main. If a commit here belongs to another in-flight PR,
+# that PR's content ships under YOUR PR number — and theirs merges empty.
+extra=$(git rev-list --count "origin/main..HEAD" 2>/dev/null || echo 0)
+if [ "$extra" -eq 0 ]; then
+  warn "no commits yet on this branch"
+else
+  ok "$extra commit(s) ahead of origin/main"
+  # Commits reachable from HEAD but not origin/main that ALSO appear on another
+  # local or remote branch are the tell: shared, not yours alone.
+  shared=""
+  while read -r c; do
+    [ -z "$c" ] && continue
+    others=$(git branch -a --contains "$c" --format='%(refname:short)' 2>/dev/null \
+      | grep -vxF "$branch" | grep -v '^origin/HEAD$' | tr '\n' ' ')
+    [ -n "$others" ] && shared="${shared}          ${c:0:7} $(git log -1 --format=%s "$c") → also on: $others
+"
+  done < <(git rev-list "origin/main..HEAD")
+  if [ -n "$shared" ]; then
+    bad "commits on this branch also live on other branches (another PR's work?):"
+    printf '%s' "$shared"
+  else
+    ok "every commit is unique to this branch"
+  fi
+fi
+
+# ── 5. Single topic ──────────────────────────────────────────────────────────
+# Advisory only — a legitimately cross-cutting change exists. But a PR spanning
+# web/ AND infra/ AND lambda/ is usually the dirty-tree symptom, not a design.
+if [ "$extra" -gt 0 ]; then
+  # Top-level DIRECTORIES only. Counting root files too made this fire on a
+  # perfectly coherent change that happened to touch CHANGELOG.md + CLAUDE.md +
+  # CONTRIBUTING.md — a warning that cries wolf on the common case gets ignored,
+  # which is worse than not having it.
+  areas=$(git diff --name-only origin/main...HEAD 2>/dev/null \
+    | awk -F/ 'NF>1 {print $1}' | sort -u | tr '\n' ' ')
+  n=$(printf '%s' "$areas" | wc -w | tr -d ' ')
+  if [ "$n" -gt 3 ]; then
+    warn "touches $n top-level areas ($areas) — is this one topic?"
+  else
+    ok "touches: ${areas:-nothing}"
+  fi
+fi
+
+say ""
+if [ "$fail" -ne 0 ]; then
+  say "branch-preflight: FAILED"
+  if [ "$FIX" -eq 1 ]; then
+    say ""
+    say "To recut this branch cleanly from origin/main, keeping only your own work:"
+    say "  git fetch origin main"
+    say "  git stash                      # if the tree is dirty"
+    say "  git checkout -b ${branch}-clean origin/main"
+    say "  git cherry-pick <your-sha>...  # only YOUR commits"
+    say "  git stash pop                  # if you stashed"
+  else
+    say "Re-run with --fix to print recovery commands."
+  fi
+  exit 1
+fi
+say "branch-preflight: ok — safe to open a PR"


### PR DESCRIPTION
## What happened

PR #521 was branched from a working tree that still held PR #519's portal commit `d90b5cb`, so #521's head carried **both** changes. #521 merged first and took the portal fix with it; #519 then merged as an **empty commit** (`131f02b`).

That wasn't cosmetic. `deploy-site.yaml` and `web-ci.yml` are path-filtered on `web/**`, so an empty commit matched neither — the PR whose entire purpose was correcting two user-facing strings ran **no web tests and triggered no site deploy**. Nothing was red; the work just wasn't where its PR said it was, and establishing that the fix was live took a bundle-level audit of what S3 was serving.

The same dirty-tree habit had already swept two unrelated `infra/ci-runners/` files into a portal commit earlier the same day. One root cause: branching off a dirty `HEAD` instead of `origin/main`.

## What this adds

The branching model itself is fine — 0 merge commits in the last 200, PRs average ~1.3 commits, all based on `main`. Only one empty commit exists in that whole range. So this doesn't change the model; it makes the one detectable mistake detected.

- **`scripts/branch-preflight.sh`** — not on `main`, clean tree, based on `origin/main` history, every commit unique to this branch, single topic (advisory). `--fix` prints recovery commands. shellcheck-clean.
- **A `Branch hygiene` job in `ci.yml`** — fails a PR with an empty diff, or one carrying a commit that also belongs to another **open** PR.
- **Docs** — `CONTRIBUTING.md` gains a *Branching and merging* section; `CLAUDE.md`'s Git section gains the rule plus post-merge verification.

### The load-bearing detail

Comparing against **open PR heads**, not `main`. My first cut of the CI check tested "is this commit already on `main`?" — I replayed it against the real SHAs and it **passed**, because when #521 was open the absorbed portal commit hadn't merged yet. The detectable signal at that moment was that #519 was open with the same commit in its head.

## Verification

- Reconstructed the real #521/#519 overlap with throwaway branches: preflight names the foreign commit *and* the branch it came from, exit 1.
- Replayed the CI logic against the actual SHAs (`base 8b6b782`, `head 01e40b9`, other-PR head `d90b5cb`): correctly blocks #521 and names #519.
- Note check 1 (empty diff) would **not** have caught #519 at PR time — its diff was 6 files when opened. Check 2 is the one that would have.
- `pull-requests: read` is scoped to the one job rather than widening the workflow's `contents: read`.
- Job is unconditional (no `paths:` filter) so it can be a required check without deadlocking PRs that miss the filtered dirs.
- This PR was itself cut from `origin/main` with a clean tree and passes its own preflight.

## Repo settings

- `delete_branch_on_merge` → **on** (was off — how 66 stale branches accumulated).
- **Not changed, needs your call:** `allow_merge_commit` and `allow_rebase_merge` are still enabled though history is 100% squash-merged. Disabling them affects all collaborators, so I left it.
- `main` has **no branch protection at all** — no required checks, no required review, on a branch that auto-deploys to spore.host. Worth considering separately; `Lambda module tests`, `Docs build + link check`, the four `security.yml` checks and this new `Branch hygiene` are all unconditional and safe to require. `web-ci.yml` and `ci-runner-drift.yml` are path-filtered and must **not** be required.