### PR TITLE
docs: record what main enforces, and why two checks are deliberately not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **`main` is now a protected branch** (#524 follow-up). It had **no** protection at
+  all — no required checks, no restriction on direct pushes — on a branch that
+  auto-deploys to spore.host and docs.spore.host. Now: no force pushes, no deletion,
+  linear history required, and six checks required before merge (`Branch hygiene`,
+  `Docs build + link check`, `Go Vulnerability Check`, `Secret Scan (gitleaks)`,
+  `Trivy Security Scan`, `Semgrep SAST`). No review requirement — the repo is
+  effectively single-committer.
+  - `Lambda module tests` is deliberately **not** required: it's a matrix job, so its
+    check name carries the coverage floor (`lambda/rest-api, 10`). Editing a floor
+    renames the check, and a required check that never reports blocks every PR.
+  - `web-ci.yml` / `ci-runner-drift.yml` are deliberately **not** required: both are
+    `paths:`-filtered, and a check that doesn't fire is indistinguishable from one
+    still pending.
+  - `enforce_admins` is off, so an admin retains an escape hatch for an urgent fix.
+  - The required-check list and both omissions are documented in `CONTRIBUTING.md`,
+    since a protection rule whose rationale lives only in the API is one nobody can
+    safely change later.
 - **Branch hygiene is now checked, not just documented.** PR #521 was branched from
   a working tree that still held PR #519's portal commit, so #521's head carried
   both changes. #521 merged first and took the portal fix with it; #519 then merged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,38 @@ it. What is **not** fine is branching from a dirty tree or from a `HEAD` that ho
 unmerged work — the new branch silently adopts those commits, and whichever PR
 merges first ships them under its own number. The second one then merges **empty**.
 
+### What `main` enforces
+
+`main` is protected: no force pushes, no deletion, linear history required, and
+these checks must pass before a merge —
+
+| Required check | Workflow |
+|---|---|
+| `Branch hygiene` | `ci.yml` |
+| `Docs build + link check` | `ci.yml` |
+| `Go Vulnerability Check` | `security.yml` |
+| `Secret Scan (gitleaks)` | `security.yml` |
+| `Trivy Security Scan` | `security.yml` |
+| `Semgrep SAST` | `security.yml` |
+
+No review is required — the repo is effectively single-committer, so requiring one
+would only mean overriding it every time.
+
+Two deliberate omissions, both of which would otherwise deadlock every PR:
+
+- **`Lambda module tests` is not required.** It's a matrix job, so GitHub appends the
+  matrix values to the check name (`Lambda module tests (lambda/rest-api, 10)`).
+  That `10` is the coverage floor — editing any floor renames the check, and a
+  required check that never reports blocks all PRs until protection is edited to
+  match. It still runs and still reports on every PR.
+- **`web-ci.yml` and `ci-runner-drift.yml` are not required.** Both are
+  `paths:`-filtered, so they don't run on a PR that misses their directories. A
+  required check that never fires is indistinguishable from one still pending.
+
+`enforce_admins` is **off**, so an admin can still push directly or merge red. That
+is a deliberate escape hatch for an urgent fix, not an invitation — the checks exist
+because `main` deploys.
+
 That happened: #521 was cut from a tree still holding #519's commit, merged first,
 and carried it. #519 landed as an empty commit — which matched neither the
 `web/**` path filter on `deploy-site.yaml` nor `web-ci.yml`, so the PR that existed

--- a/scripts/branch-preflight.sh
+++ b/scripts/branch-preflight.sh
@@ -116,8 +116,12 @@ if [ "$extra" -gt 0 ]; then
   n=$(printf '%s' "$areas" | wc -w | tr -d ' ')
   if [ "$n" -gt 3 ]; then
     warn "touches $n top-level areas ($areas) — is this one topic?"
+  elif [ "$n" -gt 0 ]; then
+    ok "touches: $areas"
   else
-    ok "touches: ${areas:-nothing}"
+    # Only root-level files (CHANGELOG.md, CONTRIBUTING.md, …). Say so rather than
+    # reporting "nothing", which reads as a broken check on a real diff.
+    ok "touches: root files only"
   fi
 fi
 


### PR DESCRIPTION
Follow-up to #524. `main` now has branch protection; this records the configuration where someone changing it later will actually look.

`main` had **no** protection at all — no required checks, nothing stopping a direct push — on a branch that auto-deploys to spore.host and docs.spore.host.

## Now enforced

No force pushes, no deletion, linear history, and six required checks: `Branch hygiene`, `Docs build + link check`, `Go Vulnerability Check`, `Secret Scan (gitleaks)`, `Trivy Security Scan`, `Semgrep SAST`. No review requirement — the repo is effectively single-committer, so requiring one would only mean overriding it every time.

## Two omissions that are load-bearing

Both would deadlock every PR if required, which is why they're documented rather than just left out:

- **`Lambda module tests`** is a matrix job, so GitHub appends the matrix values to the check name — `Lambda module tests (lambda/rest-api, 10)`. That `10` is the coverage floor. Requiring it means editing any floor renames a required check, and a required check that never reports blocks all PRs until protection is edited to match. It still runs and reports on every PR.
- **`web-ci.yml` / `ci-runner-drift.yml`** are `paths:`-filtered, so they don't run on a PR missing their directories. A required check that never fires is indistinguishable from one still pending — the same class of trap as the empty commit that started this.

## Honest about the limit

`enforce_admins` is **off**, so an admin can still push directly or merge red. That's a deliberate escape hatch for an urgent fix on a deploying branch, and the docs say so rather than implying the gate is absolute.

## Also

Fixes a cosmetic bug in `scripts/branch-preflight.sh` from #524: after I narrowed the topic check to directories, a root-files-only change reported `touches: nothing`, which reads as a broken check on a real diff. Now says `root files only`. Caught by running the script on this very branch.