### PR TITLE
fix(portal): a Mode change no longer silently loses a lagotto watch (#513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ own changelogs for CLI releases.
 
 ## [Unreleased]
 
+### Fixed
+- **Changing Mode no longer silently loses a running capacity watch** (#513, part 1).
+  A Mode change re-mounts the current page, which aborted the watch *and* cleared the
+  instance types, price cap, zones and cadence describing it — with nothing on screen
+  saying either had happened. The settings now survive (in the URL, as the query on
+  **Find instances** and the window on **Cost history** already did), and the page says
+  the watch stopped and offers **Resume watching**.
+  - The poll is deliberately **not** resumed automatically. A query is replayable data;
+    a watch is a live loop polling your own AWS account every interval, and the URL
+    outlives the tab — so a page you didn't ask to load must not start spending on your
+    behalf. The parameters come back; the decision stays yours.
+  - The notice only appears when a watch was genuinely interrupted (a Mode change, a
+    reload, an expired session) — not after you stop one yourself — and it appears once.
+    A warning that cries wolf is one you learn to ignore, which costs exactly the case
+    it exists for.
+  - The remaining half of #513 (guided shape cards for this page, so it can be used
+    without knowing instance-type names) is still open.
+
 ### Added
 - **`main` is now a protected branch** (#524 follow-up). It had **no** protection at
   all — no required checks, no restriction on direct pushes — on a branch that

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -24,9 +24,11 @@ before choosing — it used to be a tooltip on each dropdown option, which Safar
 never rendered at all.
 
 Changing the mode **rebuilds the page you're on**, so anything the page was holding
-would be lost. It isn't: your truffle query, the cost window and table view, and
-the team you had open all live in the address bar (`#/truffle?q=nvidia+h100`) and
-come back at the new level. That also makes them bookmarkable and shareable.
+would be lost. Mostly it isn't — your truffle query, the cost window and table view,
+the team you had open, and a capacity watch's settings all live in the address bar
+(`#/truffle?q=nvidia+h100`) and come back at the new level, which also makes them
+bookmarkable and shareable. Two things genuinely stop, because they're live rather
+than replayable: see [what a Mode change keeps](#what-changing-mode-does-and-doesn-t-cost-you).
 
 Raising the level from inside a page — the **Show me all the options →** buttons —
 puts one dismissible line at the top of the window saying what changed and that

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -168,6 +168,29 @@ Two rules held throughout:
   button is the chart's non-visual equivalent, not a density control, and the people
   who need it are the least likely to have raised the mode.
 
+## What changing Mode does and doesn't cost you
+
+Changing Mode rebuilds the page you're on — that is how the new mode takes effect.
+Anything the page was holding in memory would go with it, so the things worth keeping
+are written into the address bar and restored on the way back:
+
+| Page | Kept across a Mode change |
+|---|---|
+| **Find instances** | Your query, re-run at the new level |
+| **Cost history** | The time window, and whether you were reading the table |
+| **Teams** | The team you had open |
+| **Watch capacity** | The instance types, price cap, zones and cadence you entered |
+
+Two things genuinely stop, because they are live rather than replayable:
+
+- **A capacity watch.** Its settings come back and you get a **Resume watching**
+  button, but it does not restart by itself. A watch polls your own AWS account on
+  a timer, and a page you didn't ask to load — a bookmark opened the next morning —
+  should not start spending on your behalf.
+- **A terminal session.** The connection is gone; reconnect from the page.
+
+Both say so before you touch the control, and the watch says so again afterwards.
+
 ## Notes
 
 - The default for a first-time visitor is **Guided**. If the default were Standard,

--- a/web/app/surfaces/lagotto.test.ts
+++ b/web/app/surfaces/lagotto.test.ts
@@ -1,0 +1,329 @@
+// What happens to a running watch when the surface goes away, and back.
+//
+// A Mode change re-mounts the current surface — that IS how a level change
+// propagates — and lagotto's dispose() aborts the poll. What shipped therefore
+// killed the watch AND cleared the four fields describing it, silently. So the
+// behaviour under test is a pair, and neither half is sufficient alone:
+//
+//   - the form comes back, so the user doesn't retype a pattern, an AZ list and a
+//     price cap from memory;
+//   - the poll does NOT come back by itself, because it bills
+//     DescribeInstanceTypeOfferings against the user's own account every interval,
+//     and a mount they didn't ask for (a bookmark opened tomorrow — the hash
+//     outlives the tab) must not start spending on their behalf.
+//
+// The negative assertions are the load-bearing ones: that a mount does not
+// auto-poll, and that a watch the user *stopped* on purpose produces no "your watch
+// was stopped" notice on the next mount. A notice that cries wolf is one the user
+// learns to ignore, which costs exactly the case it was built for.
+//
+// The EC2 client is mocked at the module boundary. What's under test is the
+// surface's lifecycle, not the two AWS calls — those are asserted through
+// portalCapacityFinder's own inputs where it matters (that a poll happened at all).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionController } from "../session.js";
+import type { PortalConfig, SurfaceContext } from "./types.js";
+import type { DisclosureLevel } from "../disclosure.js";
+import { readHashParam } from "../hashstate.js";
+
+/** Every DescribeInstanceTypeOfferings the surface issues, so a poll is observable. */
+let searches = 0;
+
+vi.mock("@aws-sdk/client-ec2", () => {
+  class DescribeInstanceTypeOfferingsCommand {
+    constructor(public input: unknown) {}
+  }
+  class DescribeSpotPriceHistoryCommand {
+    constructor(public input: unknown) {}
+  }
+  class EC2Client {
+    destroy = vi.fn();
+    async send(cmd: unknown): Promise<unknown> {
+      if (cmd instanceof DescribeInstanceTypeOfferingsCommand) {
+        searches++;
+        // No offerings → no match → poll keeps going, which is the state a watch
+        // spends all its time in and the only one an abort is interesting from.
+        return { InstanceTypeOfferings: [] };
+      }
+      return { SpotPriceHistory: [] };
+    }
+  }
+  return { EC2Client, DescribeInstanceTypeOfferingsCommand, DescribeSpotPriceHistoryCommand };
+});
+
+const { lagottoSurface } = await import("./lagotto.js");
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+const config = { region: "us-east-1" } as PortalConfig;
+
+function ctxAt(level: DisclosureLevel = "standard"): SurfaceContext {
+  const session = new SessionController("us-east-1", null);
+  session.setLevel(level);
+  vi.spyOn(session, "getCreds").mockReturnValue({
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    sessionToken: "token",
+  } as never);
+  return { session, config, level, navigate: vi.fn() };
+}
+
+/** Fill the form as a user would, firing the events the surface listens for. */
+function fill(host: HTMLElement, v: { pattern?: string; max?: string; azs?: string; spot?: boolean }): void {
+  const set = (sel: string, value: string) => {
+    const el = host.querySelector<HTMLInputElement>(sel)!;
+    el.value = value;
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  };
+  if (v.pattern !== undefined) set(".lagotto-pattern", v.pattern);
+  if (v.max !== undefined) set(".lagotto-maxprice", v.max);
+  if (v.azs !== undefined) set(".lagotto-azs", v.azs);
+  if (v.spot !== undefined) {
+    const el = host.querySelector<HTMLInputElement>(".lagotto-spot")!;
+    el.checked = v.spot;
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+}
+
+/**
+ * Fire an expiry transition through the session's real listener set.
+ *
+ * Same idiom as shell.test.ts: arming the timer with a near-past expiration would
+ * make this depend on wall-clock scheduling, and calling the surface's handler
+ * directly would decouple the test from the `onExpiry` wiring it exists to cover.
+ * `clear()` deliberately does NOT emit — it tears the session down without
+ * announcing it — so driving expiry through clear() would prove nothing here.
+ */
+function fireExpiry(session: SessionController, state: "warning" | "expired"): void {
+  const listeners = (session as unknown as { expiryListeners: Set<(s: string) => void> })
+    .expiryListeners;
+  for (const fn of listeners) fn(state);
+}
+
+const start = (host: HTMLElement) =>
+  host.querySelector<HTMLFormElement>(".lagotto-form")!.dispatchEvent(new Event("submit", { cancelable: true }));
+
+describe("lagottoSurface across a re-mount", () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    searches = 0;
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    // The surface persists to the hash, so a leftover param from an earlier test
+    // would pre-fill or falsely "resume" the next one.
+    location.hash = "#/lagotto";
+  });
+
+  it("records the form in the hash as it is filled in", async () => {
+    const d = await lagottoSurface.mount(host, ctxAt());
+    await settle();
+    fill(host, { pattern: "trn2.*", max: "12.50", azs: "us-east-1a, us-east-1b", spot: true });
+    expect(readHashParam("pattern")).toBe("trn2.*");
+    expect(readHashParam("max")).toBe("12.50");
+    expect(readHashParam("azs")).toBe("us-east-1a, us-east-1b");
+    expect(readHashParam("spot")).toBe("1");
+    d.dispose();
+  });
+
+  it("omits the default cadence and an unchecked Spot from the hash", async () => {
+    // Otherwise every visit writes `?every=60000&spot=` and the URL stops being
+    // something a user would paste to a colleague.
+    const d = await lagottoSurface.mount(host, ctxAt());
+    await settle();
+    fill(host, { pattern: "p5.*" });
+    expect(readHashParam("every")).toBeNull();
+    expect(readHashParam("spot")).toBeNull();
+    d.dispose();
+  });
+
+  it("restores the form at the new level", async () => {
+    const first = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    fill(host, { pattern: "trn2.*", max: "12.5", azs: "us-east-1b", spot: true });
+    host.querySelector<HTMLSelectElement>(".lagotto-interval")!.value = "300000";
+    host.querySelector<HTMLSelectElement>(".lagotto-interval")!.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // What the shell does on a Mode change.
+    first.dispose();
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("expert"));
+    await settle();
+
+    expect(host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value).toBe("trn2.*");
+    expect(host.querySelector<HTMLInputElement>(".lagotto-maxprice")!.value).toBe("12.5");
+    expect(host.querySelector<HTMLInputElement>(".lagotto-azs")!.value).toBe("us-east-1b");
+    expect(host.querySelector<HTMLSelectElement>(".lagotto-interval")!.value).toBe("300000");
+    expect(host.querySelector<HTMLInputElement>(".lagotto-spot")!.checked).toBe(true);
+    second.dispose();
+  });
+
+  it("says the watch stopped, and does not silently resume it", async () => {
+    // The whole issue. A watch is a live billing loop, so the re-mount restores the
+    // parameters and hands the decision back to the user.
+    const first = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    fill(host, { pattern: "p5.*" });
+    start(host);
+    await settle();
+    expect(searches).toBeGreaterThan(0);
+    expect(readHashParam("watching")).toBe("1");
+
+    first.dispose();
+    await settle();
+    const searchesAtDispose = searches;
+
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("expert"));
+    await settle();
+
+    const notice = host.querySelector<HTMLElement>(".lagotto-resume");
+    expect(notice).not.toBeNull();
+    expect(notice!.hidden).toBe(false);
+    expect(notice!.textContent).toMatch(/stopped/i);
+    expect(host.querySelector(".lagotto-resume-go")).not.toBeNull();
+    // Not auto-resumed: no further AWS call was made by the act of mounting.
+    expect(searches).toBe(searchesAtDispose);
+    // And the form the user would resume with is intact.
+    expect(host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value).toBe("p5.*");
+    second.dispose();
+  });
+
+  it("resumes on the button, and only then", async () => {
+    const first = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    fill(host, { pattern: "p5.*" });
+    start(host);
+    await settle();
+    first.dispose();
+    await settle();
+
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    const before = searches;
+    host.querySelector<HTMLButtonElement>(".lagotto-resume-go")!.click();
+    await settle();
+
+    expect(searches).toBeGreaterThan(before);
+    expect(host.querySelector<HTMLButtonElement>(".lagotto-stop")!.hidden).toBe(false);
+    expect(host.querySelector<HTMLElement>(".lagotto-resume")!.hidden).toBe(true);
+    second.dispose();
+  });
+
+  it("shows no notice when the user stopped the watch on purpose", async () => {
+    // Stop is not an interruption. Telling someone their watch "was stopped" when
+    // they stopped it is the cry-wolf case that makes the real notice ignorable.
+    const first = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    fill(host, { pattern: "p5.*" });
+    start(host);
+    await settle();
+    host.querySelector<HTMLButtonElement>(".lagotto-stop")!.click();
+    await settle();
+    expect(readHashParam("watching")).toBeNull();
+
+    first.dispose();
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    expect(host.querySelector<HTMLElement>(".lagotto-resume")!.hidden).toBe(true);
+    second.dispose();
+  });
+
+  it("shows no notice when a watch was never started", async () => {
+    const first = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    fill(host, { pattern: "p5.*", azs: "us-east-1a" });
+    first.dispose();
+
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("expert"));
+    await settle();
+    expect(host.querySelector<HTMLElement>(".lagotto-resume")!.hidden).toBe(true);
+    // The form still came back — persistence is not conditional on having watched.
+    expect(host.querySelector<HTMLInputElement>(".lagotto-azs")!.value).toBe("us-east-1a");
+    second.dispose();
+  });
+
+  it("persists an all-defaults watch, which fires no input event", async () => {
+    // The gap a per-field `input` listener alone leaves: accept every default, hit
+    // Start, change Mode — a live watch lost with nothing recorded to resume from.
+    const first = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    const preset = host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value;
+    expect(preset).not.toBe(""); // the surface ships a default pattern
+    start(host);
+    await settle();
+    expect(readHashParam("pattern")).toBe(preset);
+
+    first.dispose();
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("expert"));
+    await settle();
+    expect(host.querySelector<HTMLElement>(".lagotto-resume")!.hidden).toBe(false);
+    expect(host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value).toBe(preset);
+    second.dispose();
+  });
+
+  it("tells the user once, not on every later mount", async () => {
+    // The flag is consumed when shown. Leaving it set would replay "your watch
+    // stopped" for the rest of the session, long after it was true.
+    const first = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    start(host);
+    await settle();
+    first.dispose();
+    await settle();
+
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("expert"));
+    await settle();
+    expect(host.querySelector<HTMLElement>(".lagotto-resume")!.hidden).toBe(false);
+    second.dispose();
+
+    host.innerHTML = "";
+    const third = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    expect(host.querySelector<HTMLElement>(".lagotto-resume")!.hidden).toBe(true);
+    third.dispose();
+  });
+
+  it("offers a resume after a session expiry, not a dead form", async () => {
+    // Expiry aborts the poll because the creds it signs with are gone — but the
+    // watch is still wanted. After signing back in the user should get their
+    // parameters and one click, not a blank form and no explanation.
+    const ctx = ctxAt("standard");
+    const first = await lagottoSurface.mount(host, ctx);
+    await settle();
+    fill(host, { pattern: "trn2.*" });
+    start(host);
+    await settle();
+
+    fireExpiry(ctx.session, "expired");
+    await settle();
+    // The poll really did stop — otherwise the rest of this asserts nothing.
+    expect(host.querySelector<HTMLButtonElement>(".lagotto-start")!.hidden).toBe(false);
+    expect(host.querySelector(".lagotto-result")!.textContent).toMatch(/expired/i);
+    expect(readHashParam("watching")).toBe("1");
+
+    first.dispose();
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    expect(host.querySelector<HTMLElement>(".lagotto-resume")!.hidden).toBe(false);
+    expect(host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value).toBe("trn2.*");
+    second.dispose();
+  });
+
+  it("cleans up at every level", async () => {
+    for (const level of ["guided", "standard", "expert"] as const) {
+      host.innerHTML = "";
+      const d = await lagottoSurface.mount(host, ctxAt(level));
+      await settle();
+      d.dispose();
+      expect(host.querySelector(".lagotto-surface"), level).toBeNull();
+    }
+  });
+});

--- a/web/app/surfaces/lagotto.ts
+++ b/web/app/surfaces/lagotto.ts
@@ -30,6 +30,7 @@ import type { MatchResult, Watch } from "@spore-host/lagotto-ts";
 import { onDemandPrice } from "@spore-host/truffle-ts";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
 import { LEVEL_CONTROL_NAME } from "../disclosure.js";
+import { readHashParam, writeHashParams } from "../hashstate.js";
 
 /** Poll cadence offered in the UI. A browser tab is a short-lived watcher. */
 const INTERVALS = [
@@ -37,6 +38,9 @@ const INTERVALS = [
   { label: "1m", ms: 60_000 },
   { label: "5m", ms: 300_000 },
 ] as const;
+
+/** Pre-selected cadence, and the one value `every` is omitted from the hash for. */
+const DEFAULT_INTERVAL_MS = 60_000;
 
 export const lagottoSurface: ToolSurface = {
   id: "lagotto",
@@ -69,7 +73,8 @@ export const lagottoSurface: ToolSurface = {
           <code>lagotto</code> CLI does, running in this tab against your own account.</p>
         <p class="lagotto-hint warn">A watch lives only as long as this tab. Closing it,
           reloading, or changing <b>${escapeHtml(LEVEL_CONTROL_NAME)}</b> in the header stops the watch — nothing
-          keeps checking on your behalf. For a watch that outlives a browser, use the
+          keeps checking on your behalf, though your settings are kept and you'll be
+          offered a one-click resume. For a watch that outlives a browser, use the
           <code>lagotto</code> CLI.</p>
       </div>
 
@@ -112,6 +117,7 @@ export const lagottoSurface: ToolSurface = {
         </div>
       </form>
 
+      <div class="lagotto-resume" hidden></div>
       <div class="lagotto-result" aria-live="polite"></div>
       <ol class="lagotto-log" aria-live="polite"></ol>`;
     host.appendChild(root);
@@ -125,10 +131,85 @@ export const lagottoSurface: ToolSurface = {
     const startBtn = root.querySelector<HTMLButtonElement>(".lagotto-start")!;
     const stopBtn = root.querySelector<HTMLButtonElement>(".lagotto-stop")!;
     const onceBtn = root.querySelector<HTMLButtonElement>(".lagotto-once")!;
+    const resume = root.querySelector<HTMLElement>(".lagotto-resume")!;
     const result = root.querySelector<HTMLElement>(".lagotto-result")!;
     const log = root.querySelector<HTMLElement>(".lagotto-log")!;
 
     let aborter: AbortController | null = null;
+    // True once the watch was ended by something other than the user: a re-mount
+    // (dispose) or credential expiry. Both are cases where "your watch stopped"
+    // is news, so the `watching` flag must survive into the next mount.
+    let interrupted = false;
+
+    // ── Surviving a re-mount ──────────────────────────────────────────────────
+    //
+    // Changing Mode re-mounts this surface (that IS how a level change propagates),
+    // and dispose() aborts the poll. What shipped therefore killed a running watch
+    // and handed back a blank form — the user lost both the watch and the four
+    // fields describing it, with nothing saying so. Issue #513: "either the watch
+    // should survive the remount, or the surface should say what happened — the
+    // current behaviour is the worst of both."
+    //
+    // The form is restored from the hash, following costs/truffle/teams. The poll is
+    // NOT auto-resumed, and that asymmetry is deliberate: truffle's `?q=` is
+    // replayable data, whereas a watch is a live loop billing DescribeInstanceType-
+    // Offerings against the user's account every interval. Silently restarting it on
+    // a mount the user didn't ask for — including a bookmark opened tomorrow, since
+    // the hash outlives the tab — spends their money on their behalf. So the params
+    // come back, the loop doesn't, and a Resume button says exactly what happened.
+    //
+    // Scope, stated plainly: the hash belongs to the *route*, so this covers a Mode
+    // change and a reload of #/lagotto — the reported case — and not navigating to
+    // another surface, which replaces the hash before dispose() runs. Same boundary
+    // as truffle's `?q=` and costs' `?days=`; a store that survived navigation would
+    // be a different mechanism, not a bigger version of this one.
+    const fields = { pattern: patternEl, max: maxPriceEl, azs: azsEl } as const;
+    for (const [key, el] of Object.entries(fields)) {
+      const v = readHashParam(key);
+      if (v !== null) el.value = v;
+    }
+    const urlEvery = Number(readHashParam("every"));
+    if (INTERVALS.some((i) => i.ms === urlEvery)) intervalEl.value = String(urlEvery);
+    spotEl.checked = readHashParam("spot") === "1";
+
+    /** Mirror the form into the hash. Defaults are omitted so the URL stays short. */
+    function saveForm(): void {
+      writeHashParams({
+        pattern: patternEl.value.trim() || null,
+        max: maxPriceEl.value.trim() || null,
+        azs: azsEl.value.trim() || null,
+        every: Number(intervalEl.value) === DEFAULT_INTERVAL_MS ? null : intervalEl.value,
+        spot: spotEl.checked ? "1" : null,
+      });
+    }
+
+    /**
+     * Tell the user their watch stopped, and offer one click to restart it.
+     *
+     * Only shown when a watch was actually running when the surface went away —
+     * `watching=1` is written on start and cleared on every other exit (stop, match,
+     * error, session expiry), so this can't fire for someone who merely filled the
+     * form in and navigated off.
+     */
+    function showResumeIfInterrupted(): void {
+      if (readHashParam("watching") !== "1") return;
+      // Consume the flag: the user has now been told. Leaving it set would replay
+      // "your watch stopped" on every later mount, including ones where nothing was
+      // running — and a notice that cries wolf is one the user learns to ignore.
+      writeHashParams({ watching: null });
+      resume.hidden = false;
+      resume.className = "lagotto-resume";
+      // Deliberately does not name a cause. The flag survives a Mode change, a
+      // reload, and a re-sign-in after expiry; "when you changed Mode" would be
+      // wrong in two of the three, and the actionable part is identical in all.
+      resume.innerHTML = `<span>Your watch was stopped — nothing has been checking since.
+        Your settings below are as you left them.</span>
+        <button type="button" class="lagotto-resume-go">Resume watching</button>`;
+      resume.querySelector<HTMLButtonElement>(".lagotto-resume-go")!.addEventListener("click", () => {
+        resume.hidden = true;
+        void startWatching();
+      });
+    }
 
     /** Read the form into a lagotto Watch. Throws on an invalid pattern. */
     function readWatch(): Watch {
@@ -243,6 +324,15 @@ export const lagottoSurface: ToolSurface = {
       const intervalMs = Number(intervalEl.value);
       aborter = new AbortController();
       setRunning(true);
+      // Save unconditionally here, not just on `input`: a user who accepts every
+      // default and hits Start has fired no input event, so without this the one
+      // case with a live watch to lose would be the one with nothing persisted.
+      saveForm();
+      // Recorded while the poll is live so a re-mount can tell "your watch was
+      // interrupted" from "you never started one". Cleared in the finally below,
+      // which every exit path runs through.
+      writeHashParams({ watching: "1" });
+      resume.hidden = true;
       log.replaceChildren();
       result.className = "lagotto-result";
       result.textContent = `Watching ${watch.instanceTypePattern} in ${region}…`;
@@ -264,6 +354,11 @@ export const lagottoSurface: ToolSurface = {
       } finally {
         aborter = null;
         setRunning(false);
+        // Not cleared when the watch was interrupted rather than stopped: that is
+        // precisely the case the next mount needs to know about. Clearing it here
+        // would also let this settling promise write to the hash of whatever
+        // surface replaced us, which is not ours to touch.
+        if (!interrupted) writeHashParams({ watching: null });
       }
     }
 
@@ -278,14 +373,24 @@ export const lagottoSurface: ToolSurface = {
       void startWatching();
     };
     const onOnce = () => void checkOnce();
+    // `input` on the whole form covers all four fields and the checkbox, including a
+    // paste and an autofill, which a per-element keyup would miss.
+    const onInput = () => saveForm();
     form.addEventListener("submit", onSubmit);
+    form.addEventListener("input", onInput);
+    form.addEventListener("change", onInput); // <select> and the checkbox
     stopBtn.addEventListener("click", stopWatching);
     onceBtn.addEventListener("click", onOnce);
+
+    showResumeIfInterrupted();
 
     // Federated creds are what the EC2 client signs with — a poll that outlives
     // them would just log AuthFailure every interval, so stop and say why.
     const offExpiry = ctx.session.onExpiry((state) => {
       if (state === "expired") {
+        // Interrupted, not stopped: the watch the user asked for is still wanted,
+        // so keep `watching=1` and let the mount after re-sign-in offer Resume.
+        if (aborter) interrupted = true;
         aborter?.abort();
         showError("Session expired — sign in again to keep watching.");
       }
@@ -293,9 +398,14 @@ export const lagottoSurface: ToolSurface = {
 
     return {
       dispose() {
+        // Set before the abort so startWatching's finally can tell a dispose-driven
+        // abort (leave `watching=1` for the next mount) from a user Stop.
+        interrupted = true;
         offExpiry();
         aborter?.abort();
         form.removeEventListener("submit", onSubmit);
+        form.removeEventListener("input", onInput);
+        form.removeEventListener("change", onInput);
         stopBtn.removeEventListener("click", stopWatching);
         onceBtn.removeEventListener("click", onOnce);
         ec2.destroy();

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -816,6 +816,14 @@ footer {
 .lagotto-actions button { font: inherit; cursor: pointer; padding: 0.45rem 1rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
 .lagotto-start { border-color: var(--lagotto) !important; background: var(--lagotto) !important; color: #fff !important; }
 .lagotto-actions button:disabled { opacity: 0.6; cursor: default; }
+/* "Your watch was stopped — Resume". Rendered in the truffle warn colour rather than
+   the lagotto accent: this is a notice about something that is NOT happening, and the
+   accent is what this surface uses for a live watch and for a match. */
+.lagotto-resume { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; margin: 0 0 1rem; padding: 0.6rem 0.9rem; border: 1px solid var(--truffle); border-radius: var(--radius); background: var(--truffle-bg); color: var(--truffle); font-size: 0.9rem; }
+/* The message shrinks so the button keeps its row; it only stacks below on a
+   genuinely narrow viewport, where stacking is the right answer anyway. */
+.lagotto-resume span { flex: 1 1 20ch; }
+.lagotto-resume-go { font: inherit; cursor: pointer; margin-left: auto; flex: 0 0 auto; padding: 0.35rem 0.9rem; border-radius: var(--radius); border: 1px solid var(--lagotto); background: var(--lagotto); color: #fff; }
 .lagotto-result { color: var(--text-muted); font-size: 0.9rem; min-height: 1.2em; }
 .lagotto-result.error { color: var(--accent-red); }
 .lagotto-match { border: 1px solid var(--lagotto); border-radius: var(--radius); padding: 0.8rem 1rem; background: var(--lagotto-bg); }


### PR DESCRIPTION
Closes the first half of #513. The guided shape cards (the second half) stay open.

## The problem

Changing **Mode** re-mounts the current surface — that *is* how a level change
propagates — and lagotto's `dispose()` aborts the poll. So touching the header
control killed a running watch **and** cleared the four fields describing it, with
nothing on screen saying either had happened. The issue put it well: *"either the
watch should survive the remount, or the surface should say what happened — the
current behaviour is the worst of both."*

## What this does

The form persists to the hash and is restored at mount, following the precedent
already set by `costs.ts` (`days`, `table`), `truffle.ts` (`q`) and `teams.ts`
(`team`). The poll is **not** auto-resumed; a notice says the watch stopped and
offers one click to restart it.

That asymmetry is the design decision, not an omission. Truffle's `?q=` is
replayable *data*. A watch is a live loop billing `DescribeInstanceTypeOfferings`
against the user's own account every interval, and the hash outlives the tab — so
auto-resuming would mean a bookmark opened tomorrow starts spending on their behalf.
The parameters come back; the decision stays theirs.

The notice fires only on a genuine interruption. `watching=1` is written while the
poll is live and cleared on a user **Stop**, a match, or an error, but kept across a
`dispose()` or a credential expiry — and it's consumed when shown, so "your watch
stopped" isn't replayed for the rest of the session. A notice that cries wolf is one
the user learns to ignore, which costs exactly the case it was built for.

Expiry is treated as an interruption on purpose: the watch is still wanted, so after
signing back in the user gets their parameters and a button rather than a blank form.

## Verification

- 11 new tests in `web/app/surfaces/lagotto.test.ts`; **166 pass** overall, typecheck
  and both builds clean.
- **8 of the 10 original tests fail against the pre-fix surface** (checked by
  stashing only `lagotto.ts`) — the assertions are real, not decorative.
- The expiry test drives `onExpiry`'s actual listener set (the `shell.test.ts`
  idiom) and asserts the poll really stopped first, so the rest isn't vacuous.
  `session.clear()` deliberately does not emit, so driving it through `clear()`
  would have proved nothing.
- Drove the rendered notice in Chromium against the built stylesheet — vitest runs
  under happy-dom, which applies no CSS, so nothing else here established that the
  notice is visible or laid out. Fixed a wrap in the process (92px → 67px).

## Scope, stated plainly

The hash belongs to the *route*, so this covers a Mode change and a reload of
`#/lagotto` — the reported case — and not navigating to another surface, which
replaces the hash before `dispose()` runs. Same boundary as truffle's `?q=`; a store
that survived navigation would be a different mechanism, not a bigger version of
this one.