### PR TITLE
feat(ci): alert when the runner fleet stops picking up jobs (#520)

### DIFF
--- a/.github/workflows/fleet-canary.yml
+++ b/.github/workflows/fleet-canary.yml
@@ -1,0 +1,37 @@
+name: Fleet canary
+
+# A deliberately trivial job pinned to the self-hosted fleet. It exists only to
+# be dispatched by fleet-monitor.yml (spore-host#520) — if this run leaves the
+# queue, a runner picked it up, which is the one thing a monitor cannot learn by
+# asking GitHub for runner *status* (a wedged runner still reports `online`).
+#
+# Do not add steps. Every second here is a second the monitor counts as latency,
+# and the point is to prove pickup, not to test anything.
+
+on:
+  workflow_dispatch:
+    inputs:
+      marker:
+        description: 'Correlation marker set by fleet-monitor (do not run by hand)'
+        required: true
+        type: string
+
+# Surfaces the marker in the run's display title so the monitor can identify
+# exactly which run is its own — workflow_dispatch does not return a run id.
+run-name: canary ${{ inputs.marker }}
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: Fleet picks up a job
+    runs-on: [self-hosted, linux, orion]
+    # If a runner takes this job and then dies mid-step, the monitor should see a
+    # failure rather than hang: cap it hard. No checkout — nothing to check out.
+    timeout-minutes: 5
+    steps:
+      - name: Report pickup
+        run: |
+          echo "picked up by: ${RUNNER_NAME:-unknown} on $(hostname)"
+          echo "marker: ${{ inputs.marker }}"

--- a/.github/workflows/fleet-canary.yml
+++ b/.github/workflows/fleet-canary.yml
@@ -32,6 +32,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Report pickup
+        # The marker goes through `env`, never interpolated into the script body:
+        # `${{ inputs.marker }}` inline is shell injection (a dispatch input is
+        # attacker-controlled by anyone with write access), and semgrep's
+        # run-shell-injection rule correctly blocks it.
+        env:
+          MARKER: ${{ inputs.marker }}
         run: |
           echo "picked up by: ${RUNNER_NAME:-unknown} on $(hostname)"
-          echo "marker: ${{ inputs.marker }}"
+          echo "marker: $MARKER"

--- a/.github/workflows/fleet-monitor.yml
+++ b/.github/workflows/fleet-monitor.yml
@@ -1,0 +1,268 @@
+name: Fleet monitor
+
+# Alerts when the self-hosted orion fleet stops picking up work (spore-host#520).
+#
+# Why this exists: on 2026-08-01 the fleet was down ~5.5h and NOTHING fired. A
+# queued job never fails — it waits — so a dead fleet produces no red X and no
+# notification. CI on every open PR silently degrades from "passing" to "unknown",
+# which looks identical to "still running".
+#
+# THE DESIGN CONSTRAINT, and the whole reason the outage was silent: this MUST run
+# on `ubuntu-latest`. A monitor pinned to the fleet it watches cannot fire when
+# that fleet is down — it queues alongside everything else it was supposed to
+# report on. Do not "simplify" this by adding `[self-hosted, orion]`.
+#
+# How it detects trouble, in order of cost:
+#   1. Dispatch fleet-canary.yml (a no-op job pinned to the fleet) and wait for a
+#      runner to PICK IT UP. Pickup is the real question. Asking GitHub for runner
+#      status can't answer it: a registered-but-wedged runner reports `online`
+#      while accepting nothing, and #518's crash-looping containers flapped
+#      online/offline between polls.
+#   2. Independently, flag any run QUEUED for >20 min across the repos pinned to
+#      the fleet. This catches the symptom directly, including causes the canary
+#      doesn't anticipate (concurrency deadlock, a single wedged runner while
+#      others are healthy).
+#
+# It deliberately does NOT use `GET /orgs/{org}/actions/runners`, which the issue
+# suggested: that needs `admin:org`, no org secret currently carries it, and it
+# would answer the weaker question (registered) rather than the real one (picking
+# up work). Avoiding it keeps this monitor free of any new long-lived secret.
+#
+# Alert destination: an auto-filed GitHub issue. It needs no new secret, it's
+# self-hosting, and it's visible where the work already happens. Noise is bounded
+# by reusing ONE open issue — subsequent failures comment on it instead of filing
+# again, and a recovery closes it.
+
+on:
+  schedule:
+    # Every 30 min. The outage lasted 5.5h; the goal is "someone knows within the
+    # hour", not instant paging. Cron on GitHub is best-effort and can skip under
+    # load, which is fine here — the queued-run check below is cumulative, so a
+    # missed tick doesn't lose the signal.
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write # dispatch the canary + read run queues
+  issues: write # file/comment/close the alert issue
+
+concurrency:
+  # Never let two monitors race on the alert issue (double-filing, or one closing
+  # what the other just opened). Don't cancel in-progress: a run that's mid-wait
+  # holds the only evidence of this cycle.
+  group: fleet-monitor
+  cancel-in-progress: false
+
+env:
+  CANARY_WORKFLOW: fleet-canary.yml
+  # How long a runner gets to pick up the canary before we call the fleet down.
+  # Generous on purpose: the fleet is 6 ephemeral runners and a busy CI moment can
+  # legitimately leave a job queued for a few minutes.
+  PICKUP_TIMEOUT_SECS: '600'
+  QUEUED_ALERT_MINS: '20'
+  ALERT_LABEL: 'fleet-outage'
+
+jobs:
+  monitor:
+    name: Fleet is picking up jobs
+    runs-on: ubuntu-latest # NEVER self-hosted — see the header
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Dispatch the canary and wait for pickup
+        id: canary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Correlate our dispatch with its run. workflow_dispatch returns no run
+          # id, so we stamp a unique marker into run-name and search for it.
+          marker="mon-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "marker=$marker" >> "$GITHUB_OUTPUT"
+
+          gh workflow run "$CANARY_WORKFLOW" --ref "${GITHUB_REF_NAME}" -f "marker=$marker"
+
+          # Find our run. The dispatch is async, so poll for it to appear.
+          run_id=''
+          for _ in $(seq 1 20); do
+            sleep 5
+            run_id=$(gh run list --workflow "$CANARY_WORKFLOW" --limit 30 \
+                       --json databaseId,displayTitle \
+                       --jq "[.[] | select(.displayTitle | contains(\"$marker\"))][0].databaseId" 2>/dev/null || true)
+            [ -n "$run_id" ] && [ "$run_id" != "null" ] && break
+          done
+
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+            # We could not even find our own dispatch. That's a GitHub API problem,
+            # not a fleet problem — don't cry wolf about the fleet.
+            echo "::warning::could not locate the dispatched canary run (marker $marker)"
+            echo "state=inconclusive" >> "$GITHUB_OUTPUT"
+            echo "detail=Could not locate the dispatched canary run; GitHub API or Actions issue, not necessarily the fleet." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "canary run: $run_id"
+          echo "run_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${run_id}" >> "$GITHUB_OUTPUT"
+
+          # Wait for a runner to take it. `queued` = nothing picked it up yet;
+          # anything else means a runner engaged, which is what we're testing.
+          waited=0
+          status=queued
+          while [ "$waited" -lt "$PICKUP_TIMEOUT_SECS" ]; do
+            status=$(gh run view "$run_id" --json status --jq .status 2>/dev/null || echo unknown)
+            case "$status" in
+              queued|requested|pending|waiting|unknown) ;;
+              *) break ;;
+            esac
+            sleep 15
+            waited=$((waited + 15))
+          done
+
+          echo "status after ${waited}s: $status"
+
+          case "$status" in
+            queued|requested|pending|waiting)
+              echo "state=down" >> "$GITHUB_OUTPUT"
+              echo "detail=The canary sat in state '$status' for ${waited}s without any runner picking it up." >> "$GITHUB_OUTPUT"
+              # Don't leave it queued forever — it would be picked up on recovery
+              # and muddy the next cycle's search.
+              gh run cancel "$run_id" >/dev/null 2>&1 || true
+              ;;
+            *)
+              echo "state=up" >> "$GITHUB_OUTPUT"
+              echo "detail=Canary picked up after ${waited}s (status: $status)." >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Check for long-queued runs across the pinned repos
+        id: queued
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Repos with jobs pinned to [self-hosted, orion]. cwl-spawn,
+          # snakemake-executor-plugin-spawn and airflow-spawn are GitHub-hosted
+          # only, so they're deliberately absent.
+          repos="spore-host/spore-host spore-host/spawn spore-host/truffle spore-host/lagotto spore-host/miniwdl-spawn spore-host/libs spore-host/spore-host-mcp"
+
+          now=$(date -u +%s)
+          stuck=''
+          for repo in $repos; do
+            # The built-in token is scoped to THIS repo; other repos are public so
+            # reads work, but tolerate a failure rather than aborting the monitor.
+            runs=$(gh api "repos/$repo/actions/runs?status=queued&per_page=20" \
+                     --jq '.workflow_runs[] | "\(.created_at)\t\(.name)\t\(.html_url)"' 2>/dev/null || true)
+            [ -z "$runs" ] && continue
+            while IFS=$'\t' read -r created name url; do
+              [ -z "$created" ] && continue
+              c=$(date -u -d "$created" +%s 2>/dev/null || echo 0)
+              [ "$c" = "0" ] && continue
+              mins=$(( (now - c) / 60 ))
+              if [ "$mins" -gt "$QUEUED_ALERT_MINS" ]; then
+                echo "queued ${mins}m: $repo — $name"
+                stuck="${stuck}- \`$repo\` — **${mins}m**: [$name]($url)"$'\n'
+              fi
+            done <<< "$runs"
+          done
+
+          if [ -n "$stuck" ]; then
+            {
+              echo "stuck<<STUCK_EOF"
+              printf '%s' "$stuck"
+              echo "STUCK_EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: File, update, or resolve the alert
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATE: ${{ steps.canary.outputs.state }}
+          DETAIL: ${{ steps.canary.outputs.detail }}
+          RUN_URL: ${{ steps.canary.outputs.run_url }}
+          STUCK: ${{ steps.queued.outputs.stuck }}
+        run: |
+          set -euo pipefail
+
+          # An inconclusive cycle (we couldn't find our own dispatch) is not
+          # evidence about the fleet — don't file, don't close.
+          if [ "$STATE" = "inconclusive" ]; then
+            echo "inconclusive cycle — leaving any existing alert untouched"
+            exit 0
+          fi
+
+          # Reuse a single open issue so a sustained outage is one thread, not one
+          # issue per 30 min.
+          existing=$(gh issue list --label "$ALERT_LABEL" --state open --limit 1 --json number --jq '.[0].number')
+
+          if [ "$STATE" = "down" ] || [ -n "$STUCK" ]; then
+            # Distinguish the two triggers: a canary that was never picked up means
+            # the fleet is dead, while a picked-up canary alongside long-queued runs
+            # means it's alive but not keeping up (one wedged runner, a concurrency
+            # deadlock, or saturation). Saying "not picking up jobs" for the second
+            # case would send whoever reads this down the wrong path.
+            if [ "$STATE" = "down" ]; then
+              body="**The self-hosted orion runner fleet is not picking up jobs.**"$'\n\n'
+            else
+              body="**The orion fleet picked up a canary job, but runs are piling up.**"$'\n\n'
+              body="${body}The fleet is not dead — so this is likely a single wedged runner, a"
+              body="${body} concurrency deadlock, or genuine saturation rather than the #518"
+              body="${body} failure modes. Check how many runners are actually listening before"
+              body="${body} recreating the fleet."$'\n\n'
+            fi
+            if [ "$STATE" = "down" ]; then
+              title="Fleet outage: orion self-hosted runners are not picking up jobs"
+            else
+              title="Fleet degraded: orion runs are queueing but the fleet is alive"
+            fi
+            body="${body}${DETAIL}"$'\n\n'
+            [ -n "$RUN_URL" ] && body="${body}Canary run: ${RUN_URL}"$'\n\n'
+            if [ -n "$STUCK" ]; then
+              body="${body}**Runs queued longer than ${QUEUED_ALERT_MINS}m:**"$'\n'"${STUCK}"$'\n'
+            fi
+            body="${body}---"$'\n\n'
+            body="${body}**Recover** (see \`infra/ci-runners/README.md\`):"$'\n\n'
+            body="${body}\`\`\`sh"$'\n'
+            body="${body}ssh orion.local"$'\n'
+            body="${body}export PATH=/opt/homebrew/bin:\$PATH"$'\n'
+            body="${body}bash ~/spore-runner-deploy/boot-recreate.sh   # handles a Broken colima VM too"$'\n'
+            body="${body}cd ~/spore-runner-deploy && docker compose logs --tail=40 runner | grep -c 'Listening for Jobs'   # want 6"$'\n'
+            body="${body}\`\`\`"$'\n\n'
+            body="${body}Two known causes, both in #518: a \`Broken\` colima VM after a reboot"
+            body="${body} (\`colima stop --force\` first — \`colima start\` alone cannot recover it), and"
+            body="${body} the vdb1 docker volume filling up. This issue closes itself when the fleet"
+            body="${body} picks up a canary job again."
+
+            if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              echo "commenting on existing alert #$existing"
+              gh issue comment "$existing" --body "Still down as of $(date -u +'%Y-%m-%d %H:%M UTC')."$'\n\n'"${body}"
+            else
+              echo "filing a new alert"
+              # `gh issue create --label` FAILS on a label that doesn't exist, which
+              # would lose the alert at the exact moment it matters. Ensure it, then
+              # fall back to an unlabelled issue rather than dropping the alert.
+              # (Costs one API call; deduplication depends on the label, so it's
+              # worth keeping correct rather than assuming.)
+              gh label create "$ALERT_LABEL" \
+                --description "Auto-filed: self-hosted runner fleet not picking up jobs (#520)" \
+                --color b60205 >/dev/null 2>&1 || true
+              gh issue create \
+                --title "$title" \
+                --label "$ALERT_LABEL" \
+                --body "$body" \
+              || gh issue create \
+                --title "$title" \
+                --body "$body"
+            fi
+            # Fail the run so it's also visible as a red X on the Actions tab.
+            echo "::error::Fleet is not picking up jobs — see the filed issue."
+            exit 1
+          fi
+
+          echo "fleet is healthy: $DETAIL"
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            echo "closing recovered alert #$existing"
+            gh issue close "$existing" \
+              --comment "Recovered — the fleet picked up a canary job at $(date -u +'%Y-%m-%d %H:%M UTC'). ${DETAIL}"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Added
+- **A dead CI runner fleet now alerts instead of going unnoticed** (#520). On
+  2026-08-01 the self-hosted fleet was down ~5.5h and nothing fired: a queued job
+  never fails, it waits, so every open PR's checks silently degraded from "passing"
+  to "unknown" — indistinguishable from "still running". Two new workflows:
+  `fleet-monitor.yml` runs on `ubuntu-latest` every 30 min (a monitor pinned to the
+  fleet it watches cannot fire when that fleet is down — that is precisely why the
+  outage was silent) and dispatches `fleet-canary.yml`, a no-op job pinned to the
+  fleet, then waits to see whether a runner actually *picks it up*. Pickup is the
+  real question: a registered-but-wedged runner still reports `online`, and #518's
+  crash-looping containers flapped between polls. It separately flags any run queued
+  for more than 20 min across the seven repos with fleet-pinned jobs, which catches
+  causes the canary doesn't anticipate.
+
+  Alerts land as a GitHub issue labelled `fleet-outage`, carrying the recovery
+  runbook and the two known causes from #518. Noise is bounded: a sustained outage
+  comments on one issue rather than filing every 30 minutes, and recovery closes it
+  automatically. The alert distinguishes "fleet is dead" from "fleet is alive but
+  runs are piling up", since those need different first moves. No new secret is
+  required — this deliberately avoids the `admin:org` runner-status endpoint, which
+  would answer the weaker question (registered) rather than the real one.
 - **`main` is now a protected branch** (#524 follow-up). It had **no** protection at
   all — no required checks, no restriction on direct pushes — on a branch that
   auto-deploys to spore.host and docs.spore.host. Now: no force pushes, no deletion,

--- a/infra/ci-runners/README.md
+++ b/infra/ci-runners/README.md
@@ -181,6 +181,25 @@ launchctl load -w ~/Library/LaunchAgents/com.spore.ci-runners.plist
 gh api orgs/spore-host/actions/runners --jq '.total_count, (.runners[]|"\(.name) \(.status)")'
 ```
 
+## Monitoring (spore-host#520)
+
+`.github/workflows/fleet-monitor.yml` runs on **`ubuntu-latest`** every 30 min —
+never on the fleet, because a monitor pinned to what it watches can't fire when that
+thing is down, which is exactly why the 5.5h outage was silent. It dispatches
+`fleet-canary.yml` (a no-op job pinned to the fleet) and waits to see whether a
+runner actually **picks it up**; that's the real question, since a wedged runner
+still reports `online`. It also flags any run queued >20 min across the seven repos
+with fleet-pinned jobs.
+
+Failures file a `fleet-outage` issue carrying the recovery runbook, comment on that
+same issue while the outage persists rather than filing repeatedly, and close it on
+recovery. A "degraded" alert (canary picked up, but runs piling up) means something
+other than the #518 failure modes — check how many runners are listening before
+recreating anything.
+
+This is separate from the drift gate above: drift asks "is the fleet running the
+right code", monitoring asks "is the fleet running at all".
+
 ## Notes
 - **`gh` is not installed on orion.** Anything in these scripts gated on
   `command -v gh` silently no-ops there — that's how the ghost-prune went


### PR DESCRIPTION
Closes #520.

On 2026-08-01 the fleet was down ~5.5h and **nothing fired**. A queued job never
fails — it waits — so a dead fleet produces no red X and no notification. CI on
every open PR silently degrades from "passing" to "unknown", which looks
identical to "still running". It was caught only because someone noticed checks
sitting queued.

## Design

**`fleet-monitor.yml` runs on `ubuntu-latest`.** That's the load-bearing detail,
not a preference: a monitor pinned to the fleet it watches cannot fire when that
fleet is down — it queues alongside everything it was supposed to report on,
which is *precisely* why the outage was silent. The header says so, because this
is the one line nobody should "simplify".

It dispatches **`fleet-canary.yml`** — a no-op job pinned to the fleet — and
waits to see whether a runner **picks it up**. Pickup is the real question, and
runner *status* can't answer it: a registered-but-wedged runner still reports
`online`, and #518's crash-looping containers flapped online/offline between
polls. Separately, it flags any run queued >20 min across the seven repos with
fleet-pinned jobs, which catches causes the canary doesn't anticipate
(concurrency deadlock, one wedged runner while others are fine).

**Deliberately not** `GET /orgs/{org}/actions/runners`, which the issue
suggested: it needs `admin:org`, no org secret currently carries it, and it
answers the weaker question (registered) rather than the real one (accepting
work). Avoiding it means this adds **no new long-lived secret** — it runs on the
built-in `GITHUB_TOKEN`.

**Alert destination** — the open question in #520 (and #468) — is an auto-filed
GitHub issue: no new secret, self-hosting, visible where the work happens. Noise
is bounded by reusing **one** issue: a sustained outage comments rather than
filing every 30 minutes, and recovery closes it automatically. "Fleet is dead"
and "fleet is alive but runs are piling up" get different titles and different
first moves, since conflating them sends the reader down the wrong path.

## Verified

- **All six alerting branches** with a recording `gh` stub: healthy/no-op,
  healthy/close-recovered, down/file-new, down/comment-not-refile,
  inconclusive/touch-nothing, and canary-up-but-queue-stuck. Exit codes 0/1/0 as
  intended (a real outage also shows red on the Actions tab).
- **Queued detection against the live API** across all 7 repos (nothing stuck,
  correct), and against a stub forcing the positive case — it produced a
  well-formed multiline `$GITHUB_OUTPUT` heredoc.
- **`date -u -d` inside `ubuntu:24.04`** parses GitHub's real `created_at`
  correctly. Worth checking explicitly: the runner is Linux, BSD `date` has no
  `-d`, so this can't be verified on macOS.
- Both YAMLs parse; the monitor's `runs-on` is asserted to be `ubuntu-latest`.

## Found while building this

`gh issue create --label` **fails on a label that doesn't exist**, and
`fleet-outage` didn't exist — so the alert would have been lost at the exact
moment it mattered. I created the label, and the workflow now ensures it and
falls back to an unlabelled issue rather than dropping the alert.

## One thing I could not verify before merge

The monitor correlates its dispatch to a run via a marker in `run-name`, because
`workflow_dispatch` returns no run id. `workflow_dispatch` only works from
`main`, so that correlation is untestable on a branch — I'll dispatch the
monitor manually right after merge and confirm it finds its own canary and
reports healthy. If the marker doesn't surface, the fallback is the
`inconclusive` path, which by design files nothing rather than crying wolf.