### PR TITLE
feat(portal): guided shape cards for Watch capacity (#513, part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Fixed
+- **"Your watch was stopped" no longer appears on a page you just opened** (#513).
+  The notice is hidden with the HTML `hidden` attribute, and the attribute was being
+  set correctly — but the stylesheet gives that element a `display: flex`, which
+  out-specifies the browser's own `[hidden] { display: none }` rule. So it showed on
+  **every** visit to **Watch capacity**, including the first, telling people a watch
+  had stopped when they had never started one. That is exactly the cry-wolf failure
+  the show-once logic was written to prevent, reintroduced a layer below it. The unit
+  tests asserted the `hidden` property, which was right; only a real browser could see
+  the rule losing. It also moved above the picker — at Guided the card list is about a
+  thousand pixels tall, so a notice below it sat under the fold.
 - **Changing Mode no longer silently loses a running capacity watch** (#513, part 1).
   A Mode change re-mounts the current page, which aborted the watch *and* cleared the
   instance types, price cap, zones and cadence describing it — with nothing on screen
@@ -28,10 +38,40 @@ own changelogs for CLI releases.
     reload, an expired session) — not after you stop one yourself — and it appears once.
     A warning that cries wolf is one you learn to ignore, which costs exactly the case
     it exists for.
-  - The remaining half of #513 (guided shape cards for this page, so it can be used
-    without knowing instance-type names) is still open.
+  - The other half of #513 — the guided card list below — completes it.
 
 ### Added
+- **Watch capacity can be used without knowing instance-type names** (#513, part 2).
+  At **Guided**, the page's fields — a glob or regular expression over instance-type
+  names, a comma-separated zone list, a price cap in $/hr — are replaced by a short
+  list of things worth waiting for: the big training GPUs, the newest ones, an older
+  cheaper one, a small one for inference, an AWS training chip. Each resolves through
+  the bundled offline catalog to a real type at a real price, so it still needs no AI,
+  no network and no credentials. This is the page where the split matters most rather
+  than least: whoever *needs* it is by definition someone whose launch just failed for
+  capacity, and at that moment `p5.*` is precisely the string they don't have.
+  - **It is not the launch list.** You don't wait for a `t4g.xlarge` — offering one
+    would offer a poll that succeeds on its first check every time, teaching the user
+    the page does nothing. The order is inverted too: the H100 leads, because whoever
+    is here already knows they want the scarce thing, and the easier alternatives
+    follow so a $55/hr quote beside an empty log has somewhere to go.
+  - **The cost line is a rate, not a total.** "About $110 for 2 hours" describes a
+    run, and this page starts a poll, which is free. It shows the hourly rate, what a
+    day of it costs, and that watching costs nothing. A family with no listed price
+    says so rather than showing nothing — the unpriced families are the scarce ones
+    this page exists for, and blank would read as free on the most expensive hardware
+    AWS rents.
+  - **Picking a card watches the whole family**, `p5.*` rather than `p5.48xlarge`. A
+    `p5.4xlarge` freeing up while the 48xlarge is still full is a match you want, and
+    pinning the exact type would silently discard it.
+  - The fields are **hidden, not removed**: the cards write into them and the watch
+    reads out of them, so the URL persistence and **Resume watching** above work
+    unchanged at every level, with one source of truth for what's being watched.
+  - On a match, Guided names the type and zone and then points at **Mode**, not at
+    Instances — Guided's Instances page offers five launch shapes and only the H100
+    one is on this list, so "launch it from Instances" would send someone who waited
+    for a B200 to a picker that can't. Adding a $114/hr machine to a beginner's
+    one-click launcher is a deliberate omission there, not an oversight here.
 - **A dead CI runner fleet now alerts instead of going unnoticed** (#520). On
   2026-08-01 the self-hosted fleet was down ~5.5h and nothing fired: a queued job
   never fails, it waits, so every open PR's checks silently degraded from "passing"

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -158,6 +158,7 @@ isn't listed, it looks the same at every level.
 | **Find instances** | The curated picker instead of the query box | Query box | + per-result hardware detail and price provenance |
 | **Cost history** | Same chart and numbers, plainer labels, and a link to Instances to go stop something | Same chart, shorter labels | + compute/storage/network breakdown, window total, peak hour, a 1-year window, and where the series came from |
 | **Teams** | **Read-only.** Your teams and their members, with no forms. | Create teams, add and remove members, delete a team | + team ids, full ARNs, created dates, and who invited whom |
+| **Watch capacity** | A short list of things worth waiting for, instead of the pattern, price cap, zone and cadence fields. Picking one watches that whole instance family. | The fields, filled in by hand | + |
 | **Connect account** | Technical detail collapsed | Collapsed | Expanded — what the IAM role can do, before the button rather than after |
 
 Two rules held throughout:
@@ -170,6 +171,49 @@ Two rules held throughout:
   button is the chart's non-visual equivalent, not a density control, and the people
   who need it are the least likely to have raised the mode.
 
+### Waiting for capacity, without knowing instance-type names
+
+**Watch capacity** is the page where the split matters most, not least. Its fields
+ask for a glob or regular expression over instance-type names, a comma-separated
+list of availability zones, and a price cap in dollars per hour — every one of them
+only writable by someone who already knows the answer. And the person who *needs*
+this page is by definition someone whose launch just failed for capacity, so `p5.*`
+is exactly the string they don't have at that moment.
+
+So Guided asks *"What are you waiting for?"* and offers a short list instead:
+
+> **A GPU for a large training run** — H100-class. The hardest capacity to get, and
+> the usual reason to watch.
+> `p5.48xlarge` — 192 vCPU · 2048 GiB · 8× H100
+> $55.04/hr once you launch it — about $1,321 a day. Watching costs nothing.
+
+Four things about that list are deliberate:
+
+- **It is not the launch list.** You don't wait for a `t4g.xlarge`. Offering "A small
+  analysis" here would offer a poll that succeeds on its first check every time,
+  which teaches you the page does nothing. Everything on this list is hardware that
+  is genuinely and routinely unavailable — the only reason the page exists.
+- **The big GPU leads.** The launch list is ordered cheapest-first because the cheap
+  answer is usually right for someone choosing what to run. This one is read by
+  someone who already knows they want the scarce thing, so it leads with that, and
+  the easier-to-find alternatives follow — somewhere to go when you're looking at
+  $55/hr and an empty log.
+- **The cost line is a rate, not a total.** "About $110 for 2 hours" describes a run,
+  and this page starts no run — it starts a poll, which is free. What the figure is
+  *for* is deciding whether you want the thing at all, so it's the hourly rate plus
+  what a day of it costs, and it says the watching itself is free. A family with no
+  listed price says so: those are the most expensive machines AWS rents, and showing
+  nothing there would read as free.
+- **It watches the whole family, not the one machine.** Picking the H100 card watches
+  `p5.*`, not `p5.48xlarge`. You're waiting for capacity, and a `p5.4xlarge` coming
+  free while the 48xlarge is still full is a match you want to hear about.
+
+When a match comes in, Guided tells you the type and the zone and then points at
+**Mode** rather than at the Instances page — because Guided's Instances page offers
+five launch shapes and only the H100 one is on this list. Telling someone who just
+waited for a B200 to "launch it from Instances" would send them to a picker that
+can't. **Let me name the instance types →** moves up to Standard at any point.
+
 ## What changing Mode does and doesn't cost you
 
 Changing Mode rebuilds the page you're on — that is how the new mode takes effect.
@@ -181,7 +225,7 @@ are written into the address bar and restored on the way back:
 | **Find instances** | Your query, re-run at the new level |
 | **Cost history** | The time window, and whether you were reading the table |
 | **Teams** | The team you had open |
-| **Watch capacity** | The instance types, price cap, zones and cadence you entered |
+| **Watch capacity** | What was being watched — the instance types, price cap, zones and cadence, whether you typed them or picked a card |
 
 Two things genuinely stop, because they are live rather than replayable:
 

--- a/web/app/guided/picker.ts
+++ b/web/app/guided/picker.ts
@@ -43,6 +43,25 @@ export interface GuidedPickerOptions {
   finder?: typeof find;
   /** Shapes to offer. Defaults to the curated list; overridable for tests. */
   shapes?: readonly GuidedShape[];
+  /**
+   * Copy overrides, for a caller whose action is not "launch this".
+   *
+   * The cards, the three-state resolve (loading / no-match / lookup-failed) and the
+   * dispose safety are the parts worth sharing; the sentences around them are not
+   * universal. The capacity-watch surface asks "what are you waiting for?" and its
+   * answer is a poll, not a run — so the defaults here are the launch flow's and a
+   * second caller overrides them rather than re-implementing the list.
+   */
+  heading?: string;
+  hint?: string;
+  escapeLabel?: string;
+  /**
+   * Replaces the cost line on every card. A caller that isn't launching **must**
+   * override it: "about $0.54 for 4 hours" is a claim about a run, and on a surface
+   * that starts no run it is simply false. Owns both the priced and the
+   * unknown-price case, since a caller re-framing one must re-frame the other.
+   */
+  costLine?(rec: GuidedRecommendation): string;
 }
 
 /**
@@ -56,11 +75,15 @@ export function mountGuidedPicker(host: HTMLElement, opts: GuidedPickerOptions):
   const root = document.createElement("div");
   root.className = "guided-picker";
   root.innerHTML = `
-    <h2>What are you doing?</h2>
-    <p class="guided-hint">Pick the closest match. We'll choose a machine, show what
-      it costs per hour, and shut it down for you when the time's up.</p>
+    <h2>${escapeHtml(opts.heading ?? "What are you doing?")}</h2>
+    <p class="guided-hint">${escapeHtml(
+      opts.hint ??
+        "Pick the closest match. We'll choose a machine, show what it costs per hour, and shut it down for you when the time's up.",
+    )}</p>
     <div class="guided-cards"></div>
-    <button class="guided-escape" type="button">I know what I need →</button>`;
+    <button class="guided-escape" type="button">${escapeHtml(
+      opts.escapeLabel ?? "I know what I need →",
+    )}</button>`;
   host.appendChild(root);
 
   const cards = root.querySelector<HTMLElement>(".guided-cards")!;
@@ -96,7 +119,7 @@ export function mountGuidedPicker(host: HTMLElement, opts: GuidedPickerOptions):
         }
         card.classList.add("ready");
         card.disabled = false;
-        card.querySelector(".guided-card-machine")!.innerHTML = describe(rec);
+        card.querySelector(".guided-card-machine")!.innerHTML = describe(rec, opts.costLine);
         card.addEventListener("click", () => opts.onChoose({ shape, rec }));
       })
       .catch((err: unknown) => {
@@ -131,8 +154,15 @@ export function mountGuidedPicker(host: HTMLElement, opts: GuidedPickerOptions):
  * purpose — "cheapest of 194 that fit" tells the user a choice was made on their
  * behalf and roughly how much was on the table, where the bare recommendation reads
  * as the only thing available.
+ *
+ * `costLine` replaces the cost sentence for a caller that isn't launching. The specs
+ * and the match count are unconditional: they describe the machine, which is true
+ * whatever the caller then does with it.
  */
-function describe(rec: GuidedRecommendation): string {
+function describe(
+  rec: GuidedRecommendation,
+  costLine?: (rec: GuidedRecommendation) => string,
+): string {
   const i = rec.pick.instance;
   const gib = (i.memoryMib / 1024).toFixed(i.memoryMib % 1024 === 0 ? 0 : 1);
   const gpu = i.gpus ? ` · ${i.gpus}× ${escapeHtml(i.gpuModel ?? "GPU")}` : "";
@@ -141,6 +171,8 @@ function describe(rec: GuidedRecommendation): string {
     rec.totalMatches > 1
       ? `<span class="guided-card-alts">cheapest of ${rec.totalMatches} that fit</span>`
       : "";
+
+  if (costLine) return `<b>${specs}</b>${costLine(rec)}${of}`;
 
   if (rec.pricePerHour == null) {
     return `<b>${specs}</b><span class="guided-card-cost unknown">price unknown for this

--- a/web/app/guided/shapes.test.ts
+++ b/web/app/guided/shapes.test.ts
@@ -13,7 +13,14 @@
 
 import { describe, expect, it } from "vitest";
 import type { FindResult } from "@spore-host/truffle-ts";
-import { GUIDED_SHAPES, resolveAllShapes, resolveShape } from "./shapes.js";
+import { compilePattern } from "@spore-host/lagotto-ts";
+import {
+  GUIDED_SHAPES,
+  WATCH_SHAPES,
+  resolveAllShapes,
+  resolveShape,
+  watchPattern,
+} from "./shapes.js";
 
 describe("GUIDED_SHAPES", () => {
   it("has unique ids", () => {
@@ -195,6 +202,80 @@ describe("resolveShape error and absence handling", () => {
     // An estimate presented as a price is the same defect as a fabricated one,
     // just smaller — so the flag has to survive to the UI.
     expect(rec.priceIsEstimate).toBe(true);
+  });
+});
+
+// The capacity-watch list is a separate list for a reason, so it gets separate
+// assertions. Its failure mode is the opposite of GUIDED_SHAPES's: there, a card that
+// resolves to something expensive is the defect; here, a card that resolves to
+// something *cheap and abundant* is, because it would offer a watch that succeeds on
+// its first check and teach the user this page does nothing.
+describe("WATCH_SHAPES", () => {
+  it("has unique ids that don't collide with the launch shapes", () => {
+    const ids = WATCH_SHAPES.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    // Both lists feed `resolveShape` and both ids end up in URLs (`?shape=`), so a
+    // collision would make one list's card silently open the other's flow.
+    for (const id of ids) expect(GUIDED_SHAPES.map((s) => s.id)).not.toContain(id);
+  });
+
+  it("labels shapes in user vocabulary, not hardware vocabulary", () => {
+    for (const s of WATCH_SHAPES) {
+      expect(s.label, s.id).not.toMatch(/\b[a-z]\d[a-z]*\.\w+\b/);
+      expect(s.blurb.length, s.id).toBeGreaterThan(0);
+    }
+  });
+
+  it("resolves every shape to a real accelerator, not a cheap CPU box", async () => {
+    // The failure this catches for real: `trn2` looks like the obvious query for
+    // Trainium 2, but truffle-ts doesn't parse it as a family and returns 231 results
+    // spanning the whole catalog — so price-ranking resolves the card to a
+    // `t4g.nano` at $0.0042/hr. A card offering to watch for a t4g.nano is a card
+    // that never has anything to say, and the label would still read "An AWS
+    // training chip".
+    const recs = await resolveAllShapes(undefined, WATCH_SHAPES);
+    expect(recs).toHaveLength(WATCH_SHAPES.length);
+    recs.forEach((rec, i) => {
+      const shape = WATCH_SHAPES[i]!;
+      expect(rec, `${shape.id} resolved to nothing — "${shape.query}" matched no instance`).toBeDefined();
+      const inst = rec!.pick.instance;
+      // Every one of these is an accelerator family, so nothing here should be
+      // priced like a general-purpose box. $1/hr is well below the cheapest real
+      // candidate (inf1.xlarge at $0.228 is the floor of what these families cost)
+      // and well above every t-class/m-class type a mis-parsed query would return.
+      expect(inst.onDemandPrice ?? Infinity, `${shape.id} → ${inst.instanceType}`).toBeGreaterThan(0.2);
+      expect(inst.instanceType, shape.id).toMatch(/^[a-z0-9-]+\.[a-z0-9]+$/);
+    });
+  });
+
+  it("watches a whole family, as a glob lagotto can compile", async () => {
+    // A family and not the one cheapest type: the user is waiting for capacity, and
+    // `p5.48xlarge` being full while `p5.4xlarge` is free is a match they want. The
+    // pattern also has to survive lagotto's OWN glob→regex conversion, since that is
+    // what actually runs — asserting the string alone would not establish that.
+    const recs = await resolveAllShapes(undefined, WATCH_SHAPES);
+    for (const rec of recs) {
+      const pattern = watchPattern(rec!);
+      const type = rec!.pick.instance.instanceType;
+      expect(pattern, rec!.shape.id).toBe(`${rec!.pick.instance.instanceFamily}.*`);
+      const re = compilePattern(pattern);
+      expect(re.test(type), `${pattern} must match its own pick ${type}`).toBe(true);
+      // And must not match the rest of the catalog. `p5.*` matching `p5e.48xlarge`
+      // would widen the watch past the family the card named.
+      expect(re.test("t4g.nano"), pattern).toBe(false);
+    }
+  });
+
+  it("falls back to the exact type rather than a bare wildcard with no family", () => {
+    // `.*` here would silently watch every instance type in the region — a watch
+    // that matches instantly and reports something the user never asked about.
+    const rec = {
+      shape: WATCH_SHAPES[0]!,
+      pick: stub({ instanceType: "z9.custom", instanceFamily: "" }),
+      priceIsEstimate: false,
+      totalMatches: 1,
+    };
+    expect(watchPattern(rec)).toBe("z9.custom");
   });
 });
 

--- a/web/app/guided/shapes.ts
+++ b/web/app/guided/shapes.ts
@@ -106,6 +106,96 @@ export const GUIDED_SHAPES: readonly GuidedShape[] = [
   },
 ] as const;
 
+/**
+ * The shapes worth *waiting* for — the capacity-watch surface's list.
+ *
+ * A separate list rather than a filter over `GUIDED_SHAPES`, and the reason is the
+ * whole point of that page: you do not wait for a `t4g.xlarge`. Offering "A small
+ * analysis" as something to watch would offer a poll that succeeds on its first
+ * check, every time, which teaches the user the page does nothing. Everything here
+ * is hardware that is genuinely and routinely unavailable — which is the only reason
+ * `lagotto` exists.
+ *
+ * Led by the H100 rather than by the cheapest, inverting `GUIDED_SHAPES`'s order.
+ * That list is read by someone choosing what to run and the cheap answer is usually
+ * right; this one is read by someone who already knows they want the scarce thing.
+ * The easier-to-find alternatives follow it, so a user looking at $55/hr and an
+ * empty log has somewhere to go.
+ *
+ * `defaultTtlHours` is carried because `GuidedShape` requires it and it's the right
+ * value for the launch that follows a match. The watch surface itself never reads it.
+ */
+export const WATCH_SHAPES: readonly GuidedShape[] = [
+  {
+    id: "watch-h100",
+    label: "A GPU for a large training run",
+    blurb: "H100-class. The hardest capacity to get, and the usual reason to watch.",
+    query: "nvidia h100",
+    defaultTtlHours: 2,
+    wantsGpu: true,
+  },
+  {
+    id: "watch-newest-gpu",
+    label: "The newest GPUs",
+    blurb: "B200-class. Newer than H100, scarcer, and considerably more expensive.",
+    query: "nvidia b200",
+    defaultTtlHours: 2,
+    wantsGpu: true,
+  },
+  {
+    id: "watch-a100",
+    label: "An older large-training GPU",
+    blurb: "A100-class. Easier to find than an H100, and under half the price.",
+    query: "nvidia a100",
+    defaultTtlHours: 2,
+    wantsGpu: true,
+  },
+  {
+    id: "watch-small-gpu",
+    label: "One GPU for inference or a notebook",
+    blurb: "L4-class. Usually available — worth watching only if a launch just failed.",
+    query: "nvidia l4",
+    defaultTtlHours: 2,
+    wantsGpu: true,
+  },
+  {
+    id: "watch-trainium",
+    label: "An AWS training chip",
+    blurb: "Trainium. Cheaper per unit of training than the equivalent GPU, when free.",
+    // "trainium", not "trn2": truffle-ts's parser doesn't read `trn2` as a family and
+    // returns 231 results spanning every family in the catalog, so price-ranking them
+    // resolves this card to a `t4g.nano`. "trainium" resolves to trn1, which is what
+    // the catalog actually carries. A query that confidently returns the wrong thing
+    // is worse than one that returns nothing.
+    query: "trainium",
+    defaultTtlHours: 2,
+    // Trainium instances carry no `gpus`, so this must be false: `cheapest()` would
+    // otherwise find no GPU-bearing candidate, fall through to the unfiltered pool,
+    // and the flag would be a no-op that misdescribes the shape.
+    wantsGpu: false,
+  },
+] as const;
+
+/**
+ * The instance-type pattern to watch for a resolved shape: the machine's whole
+ * family, as a glob.
+ *
+ * A family rather than the one cheapest type, because the user is waiting for
+ * *capacity* — `p5.48xlarge` being unavailable while `p5.4xlarge` is free is a match
+ * they want to hear about, and pinning the exact type would silently discard it.
+ * lagotto's `compilePattern` reads `p5.*` as a glob (`^p5\..*$`), and the surface
+ * pushes that form to EC2's `instance-type` filter server-side, so it's also the
+ * cheap one to poll.
+ *
+ * Falls back to the exact type when the catalog carries no family: a watch for one
+ * machine is narrower than intended but still correct, whereas a bare `.*` would
+ * quietly watch every instance type in the region.
+ */
+export function watchPattern(rec: GuidedRecommendation): string {
+  const family = rec.pick.instance.instanceFamily?.trim();
+  return family ? `${family}.*` : rec.pick.instance.instanceType;
+}
+
 /** A resolved recommendation: the shape, the machine, and what it costs. */
 export interface GuidedRecommendation {
   shape: GuidedShape;

--- a/web/app/surfaces/lagotto.test.ts
+++ b/web/app/surfaces/lagotto.test.ts
@@ -23,15 +23,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionController } from "../session.js";
 import type { PortalConfig, SurfaceContext } from "./types.js";
-import type { DisclosureLevel } from "../disclosure.js";
+import { LEVEL_CONTROL_NAME, type DisclosureLevel } from "../disclosure.js";
+import { GUIDED_SHAPES, WATCH_SHAPES } from "../guided/shapes.js";
 import { readHashParam } from "../hashstate.js";
 
 /** Every DescribeInstanceTypeOfferings the surface issues, so a poll is observable. */
 let searches = 0;
+/** The `instance-type` filter values pushed server-side, so *what* is watched is too. */
+let searchFilters: string[] = [];
+/**
+ * Offerings the mocked EC2 returns. Empty by default (the state a watch spends all
+ * its time in); a test that needs a match sets it.
+ */
+let offerings: Array<{ InstanceType: string; Location: string }> = [];
 
 vi.mock("@aws-sdk/client-ec2", () => {
   class DescribeInstanceTypeOfferingsCommand {
-    constructor(public input: unknown) {}
+    constructor(public input: { Filters?: Array<{ Name?: string; Values?: string[] }> }) {}
   }
   class DescribeSpotPriceHistoryCommand {
     constructor(public input: unknown) {}
@@ -41,9 +49,10 @@ vi.mock("@aws-sdk/client-ec2", () => {
     async send(cmd: unknown): Promise<unknown> {
       if (cmd instanceof DescribeInstanceTypeOfferingsCommand) {
         searches++;
-        // No offerings → no match → poll keeps going, which is the state a watch
-        // spends all its time in and the only one an abort is interesting from.
-        return { InstanceTypeOfferings: [] };
+        for (const f of cmd.input.Filters ?? []) {
+          if (f.Name === "instance-type") searchFilters.push(...(f.Values ?? []));
+        }
+        return { InstanceTypeOfferings: offerings };
       }
       return { SpotPriceHistory: [] };
     }
@@ -108,6 +117,8 @@ describe("lagottoSurface across a re-mount", () => {
 
   beforeEach(() => {
     searches = 0;
+    searchFilters = [];
+    offerings = [];
     document.body.innerHTML = "";
     host = document.createElement("div");
     document.body.appendChild(host);
@@ -324,6 +335,220 @@ describe("lagottoSurface across a re-mount", () => {
       await settle();
       d.dispose();
       expect(host.querySelector(".lagotto-surface"), level).toBeNull();
+      // The picker resolves asynchronously, so a leaked one would keep writing into a
+      // detached DOM after the level change that removed it.
+      expect(host.querySelector(".guided-picker"), level).toBeNull();
     }
+  });
+});
+
+// This surface's form asks for a glob or a regex over instance-type names, an AZ list,
+// and a price cap in $/hr — every one of which is only writable by someone who already
+// knows the answer. And the user who *needs* this page is by definition someone whose
+// launch just failed for capacity, so it's the surface where the guided split matters
+// most, not least.
+describe("lagottoSurface at guided", () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    searches = 0;
+    searchFilters = [];
+    offerings = [];
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    location.hash = "#/lagotto";
+  });
+
+  const cards = () => [...host.querySelectorAll<HTMLButtonElement>(".guided-card")];
+  /** The picker resolves each card independently; wait for at least one to be clickable. */
+  const readyCard = async (): Promise<HTMLButtonElement> => {
+    for (let i = 0; i < 20; i++) {
+      const c = cards().find((el) => !el.disabled);
+      if (c) return c;
+      await settle();
+    }
+    throw new Error("no card resolved");
+  };
+
+  it("shows cards instead of the pattern, AZ and price fields", async () => {
+    const d = await lagottoSurface.mount(host, ctxAt("guided"));
+    await settle();
+    expect(cards().length).toBeGreaterThan(0);
+    // The fields still exist — they're the single source of what's being watched, and
+    // hiding rather than removing them is what keeps readWatch(), the hash persistence
+    // and the Resume path working unchanged at every level.
+    expect(host.querySelector(".lagotto-pattern")).not.toBeNull();
+    expect(host.querySelector(".lagotto-surface")!.className).toContain("lagotto-guided");
+    // But "Start watching" must not be offered: at guided the cards ARE the start
+    // control, and a button above no visible fields describes nothing.
+    expect(host.querySelector<HTMLButtonElement>(".lagotto-start")!.hidden).toBe(true);
+    d.dispose();
+  });
+
+  it("shows the fields and no cards from standard up", async () => {
+    for (const level of ["standard", "expert"] as const) {
+      host.innerHTML = "";
+      const d = await lagottoSurface.mount(host, ctxAt(level));
+      await settle();
+      expect(host.querySelector(".guided-card"), level).toBeNull();
+      expect(host.querySelector<HTMLButtonElement>(".lagotto-start")!.hidden, level).toBe(false);
+      d.dispose();
+    }
+  });
+
+  it("offers shapes worth waiting for, not the launch list", async () => {
+    // You do not wait for a t4g.xlarge. Offering "A small analysis" here would offer a
+    // poll that succeeds on its first check, forever — which teaches the user the page
+    // does nothing. Asserted through the rendered DOM rather than the constant, because
+    // the constant being right doesn't establish that this surface passes it.
+    const d = await lagottoSurface.mount(host, ctxAt("guided"));
+    await settle();
+    const labels = cards().map((c) => c.querySelector(".guided-card-label")!.textContent!);
+    expect(labels).toEqual(WATCH_SHAPES.map((s) => s.label));
+    for (const s of GUIDED_SHAPES) expect(labels).not.toContain(s.label);
+    d.dispose();
+  });
+
+  it("does not price a watch as if it were a launch", async () => {
+    // The launch flow's "about $110 for 2 hours" is a claim about a run, and this page
+    // starts no run — it starts a poll, which is free. Getting this wrong would quote a
+    // charge for the one action on the page that doesn't incur one.
+    const d = await lagottoSurface.mount(host, ctxAt("guided"));
+    const card = await readyCard();
+    // Collapsed: the copy is a wrapped template literal, so the words are separated by
+    // newlines in the DOM and a naive /once you launch it/ would fail on formatting.
+    const cost = card.querySelector(".guided-card-cost")!.textContent!.replace(/\s+/g, " ");
+    expect(cost).toMatch(/watching costs nothing/i);
+    expect(cost).toMatch(/once you launch it/i);
+    expect(cost).not.toMatch(/for \d+ hours/);
+    d.dispose();
+  });
+
+  it("starts a watch on the picked family, not on the one cheapest type", async () => {
+    // `p5.48xlarge` being full while `p5.4xlarge` is free is a match the user wants, so
+    // the watch is the family. Asserted on the filter the surface actually sent to EC2,
+    // which is the thing that decides what gets watched.
+    const d = await lagottoSurface.mount(host, ctxAt("guided"));
+    const card = await readyCard();
+    card.click();
+    await settle();
+
+    expect(searches).toBeGreaterThan(0);
+    expect(host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value).toMatch(/^[a-z0-9-]+\.\*$/);
+    expect(searchFilters.length).toBeGreaterThan(0);
+    // `p5.*` in EC2 filter syntax, where `.` is literal and `*` is the wildcard — the
+    // family, pushed server-side. Not `*`: a filter that matched everything would poll
+    // the whole region and match on the first check.
+    expect(searchFilters[0]).toMatch(/^[a-z0-9-]+\.\*$/);
+    // And the watch is live, so Stop is the way out.
+    expect(host.querySelector<HTMLButtonElement>(".lagotto-stop")!.hidden).toBe(false);
+    d.dispose();
+  });
+
+  it("hides the cards while a watch is running", async () => {
+    // Clicking a second card mid-watch would abandon the first without saying so.
+    // Making Stop the only way forward is the honest shape of "one watch per tab".
+    const d = await lagottoSurface.mount(host, ctxAt("guided"));
+    const card = await readyCard();
+    expect(host.querySelector<HTMLElement>(".lagotto-picker")!.hidden).toBe(false);
+    card.click();
+    await settle();
+    expect(host.querySelector<HTMLElement>(".lagotto-picker")!.hidden).toBe(true);
+
+    host.querySelector<HTMLButtonElement>(".lagotto-stop")!.click();
+    await settle();
+    expect(host.querySelector<HTMLElement>(".lagotto-picker")!.hidden).toBe(false);
+    d.dispose();
+  });
+
+  it("survives a Mode change into standard with the picked pattern intact", async () => {
+    // The two halves of #513 have to compose: a guided user picks a card, changes Mode,
+    // and lands in the standard form. The pattern the card chose must be there — it's
+    // the one thing they can't retype, having never seen it.
+    const first = await lagottoSurface.mount(host, ctxAt("guided"));
+    const card = await readyCard();
+    card.click();
+    await settle();
+    const pattern = host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value;
+    expect(pattern).toMatch(/\.\*$/);
+
+    first.dispose();
+    await settle();
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+
+    expect(host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value).toBe(pattern);
+    expect(host.querySelector<HTMLElement>(".lagotto-resume")!.hidden).toBe(false);
+    second.dispose();
+  });
+
+  it("names the type in the resume notice, since the fields aren't on screen", async () => {
+    // "Your settings below are as you left them" points at a form a guided user can't
+    // see and never filled in. The type is the one fact they need to decide whether to
+    // resume, and it's the one they never typed.
+    const first = await lagottoSurface.mount(host, ctxAt("guided"));
+    const card = await readyCard();
+    card.click();
+    await settle();
+    const pattern = host.querySelector<HTMLInputElement>(".lagotto-pattern")!.value;
+    first.dispose();
+    await settle();
+
+    host.innerHTML = "";
+    const second = await lagottoSurface.mount(host, ctxAt("guided"));
+    await settle();
+    const notice = host.querySelector<HTMLElement>(".lagotto-resume")!;
+    expect(notice.hidden).toBe(false);
+    expect(notice.textContent).toContain(pattern);
+    expect(notice.textContent).not.toMatch(/settings below/i);
+    second.dispose();
+  });
+
+  it("tells a guided user how to launch what it found", async () => {
+    // Guided mode's Instances page offers five LAUNCH shapes, and only the H100 one
+    // overlaps this list — so "launch it from Instances" would send someone who waited
+    // for a B200 to a picker that can't launch one. A dead end at the exact moment
+    // capacity is available is the most expensive place to have one.
+    offerings = [{ InstanceType: "p5.48xlarge", Location: "us-east-1b" }];
+    const d = await lagottoSurface.mount(host, ctxAt("guided"));
+    const card = await readyCard();
+    card.click();
+    await settle();
+
+    const next = host.querySelector(".lagotto-match-next");
+    expect(next, "expected a match with offerings present").not.toBeNull();
+    expect(next!.textContent).toContain("p5.48xlarge");
+    expect(next!.textContent).toContain("us-east-1b");
+    // Names the control that gets them there, rather than only the page.
+    expect(next!.textContent).toMatch(new RegExp(LEVEL_CONTROL_NAME));
+    expect(next!.textContent).toMatch(/standard/i);
+    d.dispose();
+  });
+
+  it("keeps the standard match copy at standard", async () => {
+    offerings = [{ InstanceType: "p5.48xlarge", Location: "us-east-1b" }];
+    const d = await lagottoSurface.mount(host, ctxAt("standard"));
+    await settle();
+    fill(host, { pattern: "p5.*" });
+    start(host);
+    await settle();
+    const next = host.querySelector(".lagotto-match-next")!;
+    expect(next.textContent).toMatch(/InsufficientInstanceCapacity/);
+    expect(next.textContent).not.toMatch(/switch/i);
+    d.dispose();
+  });
+
+  it("raises the level rather than navigating on the escape", async () => {
+    // One level up is the pattern field, on this same surface — navigating elsewhere
+    // would answer a different question.
+    const ctx = ctxAt("guided");
+    const d = await lagottoSurface.mount(host, ctx);
+    await settle();
+    host.querySelector<HTMLButtonElement>(".guided-escape")!.click();
+    expect(ctx.session.level).toBe("standard");
+    expect(ctx.navigate).not.toHaveBeenCalled();
+    d.dispose();
   });
 });

--- a/web/app/surfaces/lagotto.ts
+++ b/web/app/surfaces/lagotto.ts
@@ -29,8 +29,10 @@ import { CapacityWatcher, type CapacityFinder, type FinderInstanceType, type Fin
 import type { MatchResult, Watch } from "@spore-host/lagotto-ts";
 import { onDemandPrice } from "@spore-host/truffle-ts";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
-import { LEVEL_CONTROL_NAME } from "../disclosure.js";
+import { atLeast, LEVEL_CONTROL_NAME } from "../disclosure.js";
 import { readHashParam, writeHashParams } from "../hashstate.js";
+import { mountGuidedPicker } from "../guided/picker.js";
+import { WATCH_SHAPES, watchPattern, type GuidedRecommendation } from "../guided/shapes.js";
 
 /** Poll cadence offered in the UI. A browser tab is a short-lived watcher. */
 const INTERVALS = [
@@ -63,19 +65,32 @@ export const lagottoSurface: ToolSurface = {
     const watcher = new CapacityWatcher({ finder: portalCapacityFinder(ec2, region) });
 
     const root = document.createElement("div");
-    root.className = "lagotto-surface";
+    // The guided variant is a class on the root rather than a different template: the
+    // form still exists and is still the single source of what's being watched (see
+    // "Guided mode" below), so what differs is what's *shown*, which is CSS's job.
+    root.className = atLeast(ctx.level, "standard")
+      ? "lagotto-surface"
+      : "lagotto-surface lagotto-guided";
     root.innerHTML = `
       <div class="lagotto-head">
         <h2>Watch for capacity</h2>
-        <p class="lagotto-hint">Scarce instance types (<code>p5.*</code>, <code>trn2.*</code>)
+        <p class="lagotto-hint lagotto-hint-query">Scarce instance types (<code>p5.*</code>, <code>trn2.*</code>)
           come and go. Describe what you want and this polls
           <b>${escapeHtml(region)}</b> until it appears — the same matching the
           <code>lagotto</code> CLI does, running in this tab against your own account.</p>
+        <p class="lagotto-hint lagotto-hint-guided">The big GPUs are often all taken.
+          Pick what you're waiting for and this checks <b>${escapeHtml(region)}</b>
+          every minute until some appears, then tells you which zone to launch in.</p>
         <p class="lagotto-hint warn">A watch lives only as long as this tab. Closing it,
           reloading, or changing <b>${escapeHtml(LEVEL_CONTROL_NAME)}</b> in the header stops the watch — nothing
-          keeps checking on your behalf, though your settings are kept and you'll be
-          offered a one-click resume. For a watch that outlives a browser, use the
-          <code>lagotto</code> CLI.</p>
+          keeps checking on your behalf, though ${
+            // "your settings are kept" describes something a guided user never entered.
+            // What's kept is the same thing either way; only the name for it changes.
+            atLeast(ctx.level, "standard")
+              ? "your settings are kept"
+              : "what you picked is remembered"
+          } and you'll be offered a one-click resume. For a watch that outlives a
+          browser, use the <code>lagotto</code> CLI.</p>
       </div>
 
       <form class="lagotto-form">
@@ -117,7 +132,13 @@ export const lagottoSurface: ToolSurface = {
         </div>
       </form>
 
+      <!-- Resume BEFORE the picker, not after. At standard the picker is empty and the
+           order is unobservable; at guided the card list is ~1000px tall, so a notice
+           below it sits under the fold — telling a returning user their watch stopped
+           somewhere they will never look. Verified in a browser, not inferred: the
+           unit tests assert presence and can't see position. -->
       <div class="lagotto-resume" hidden></div>
+      <div class="lagotto-picker"></div>
       <div class="lagotto-result" aria-live="polite"></div>
       <ol class="lagotto-log" aria-live="polite"></ol>`;
     host.appendChild(root);
@@ -202,8 +223,18 @@ export const lagottoSurface: ToolSurface = {
       // Deliberately does not name a cause. The flag survives a Mode change, a
       // reload, and a re-sign-in after expiry; "when you changed Mode" would be
       // wrong in two of the three, and the actionable part is identical in all.
+      //
+      // Guided gets a different second sentence because the form it refers to isn't on
+      // screen at that level. Naming the type instead is the better answer anyway: it's
+      // the one fact the user needs to decide whether to resume, and at guided they
+      // never typed it, so "as you left them" would describe something they never did.
+      const what = patternEl.value.trim();
+      const reassure =
+        guided && what
+          ? `Still waiting for <code>${escapeHtml(what)}</code>.`
+          : "Your settings below are as you left them.";
       resume.innerHTML = `<span>Your watch was stopped — nothing has been checking since.
-        Your settings below are as you left them.</span>
+        ${reassure}</span>
         <button type="button" class="lagotto-resume-go">Resume watching</button>`;
       resume.querySelector<HTMLButtonElement>(".lagotto-resume-go")!.addEventListener("click", () => {
         resume.hidden = true;
@@ -229,11 +260,40 @@ export const lagottoSurface: ToolSurface = {
       };
     }
 
+    // ── Guided mode ───────────────────────────────────────────────────────────
+    //
+    // The form asks for a glob or a regex over instance-type names, an AZ list, and a
+    // price cap in $/hr. Every one of those is only writable by someone who already
+    // knows the answer — which makes this the surface where the guided/standard split
+    // matters most, not least: a user who *needs* this page is by definition someone
+    // whose launch just failed for capacity, and at that moment "p5.*" is exactly the
+    // string they don't have.
+    //
+    // So guided swaps the fields for the same curated cards the truffle and instances
+    // surfaces use, over WATCH_SHAPES rather than GUIDED_SHAPES — you do not wait for
+    // a t4g.xlarge, and offering one would be offering a poll that always succeeds
+    // immediately. Picking a card resolves a real instance type through the offline
+    // catalog, fills the form with its *family* glob, and starts the watch.
+    //
+    // The form is hidden rather than absent, and that is load-bearing rather than
+    // laziness: the picker writes into it, `readWatch()` reads out of it, and the
+    // hash restore + Resume path from #513 keeps working at every level without a
+    // second code path. One state, one reader.
+    const guided = !atLeast(ctx.level, "standard");
+    const picker = root.querySelector<HTMLElement>(".lagotto-picker")!;
+    let disposePicker: (() => void) | null = null;
+
     function setRunning(running: boolean): void {
-      startBtn.hidden = running;
+      // At guided the picker IS the start control, so a bare "Start watching" above
+      // no visible fields would be a button with nothing to describe what it starts.
+      startBtn.hidden = running || guided;
       stopBtn.hidden = !running;
       onceBtn.disabled = running;
       for (const el of [patternEl, maxPriceEl, azsEl, intervalEl, spotEl]) el.disabled = running;
+      // Choosing a second shape mid-watch would abandon the first without saying so.
+      // Hiding the cards while one is running makes Stop the only way forward, which
+      // is the honest shape of "one watch per tab".
+      if (guided) picker.hidden = running;
     }
 
     // What "Max $/hr" is compared against differs by an order of trustworthiness
@@ -263,6 +323,25 @@ export const lagottoSurface: ToolSurface = {
 
     function showMatch(m: MatchResult, spot: boolean): void {
       const azs = m.candidateAzs.length ? m.candidateAzs.join(", ") : "—";
+      // What to do next differs by level, because what's *available* next differs.
+      // Guided mode's Instances page offers five launch shapes, and only the H100 one
+      // overlaps this list — so telling a guided user who just waited for a B200 to
+      // "launch it from Instances" would send them to a picker that can't. Naming the
+      // control that can is the difference between an answer and a dead end.
+      //
+      // Not fixed by adding B200 cards to the launch picker: a $114/hr machine behind a
+      // beginner's single click is a deliberate omission there, not an oversight here.
+      const next = guided
+        ? `<p class="lagotto-match-next"><code>${escapeHtml(m.instanceType)}</code> is
+             free in <b>${escapeHtml(m.availabilityZone || m.region)}</b> right now.
+             To launch this exact type, switch
+             <b>${escapeHtml(LEVEL_CONTROL_NAME)}</b> to Standard and use
+             <a href="#/instances">Instances</a>. Capacity can vanish within minutes,
+             so it's worth doing now.</p>`
+        : `<p class="lagotto-match-next">Capacity is available now — launch it from
+             <a href="#/instances">Instances</a>. Availability can vanish between this
+             check and a launch; retry the next zone above on
+             <code>InsufficientInstanceCapacity</code>.</p>`;
       result.className = "lagotto-result found";
       result.innerHTML = `
         <div class="lagotto-match">
@@ -276,10 +355,7 @@ export const lagottoSurface: ToolSurface = {
             <dt>Zone</dt><dd>${escapeHtml(m.availabilityZone || "—")}</dd>
             <dt>Also offered in</dt><dd>${escapeHtml(azs)}</dd>
           </dl>
-          <p class="lagotto-match-next">Capacity is available now — launch it from
-            <a href="#/instances">Instances</a>. Availability can vanish between this
-            check and a launch; retry the next zone above on
-            <code>InsufficientInstanceCapacity</code>.</p>
+          ${next}
         </div>`;
     }
 
@@ -382,6 +458,39 @@ export const lagottoSurface: ToolSurface = {
     stopBtn.addEventListener("click", stopWatching);
     onceBtn.addEventListener("click", onOnce);
 
+    if (guided) {
+      // The initial state has to be set here too, not only in setRunning: nothing calls
+      // setRunning until a watch starts, so a bare "Start watching" would sit above no
+      // visible fields until the user clicked a card.
+      startBtn.hidden = true;
+      disposePicker = mountGuidedPicker(picker, {
+        shapes: WATCH_SHAPES,
+        heading: "What are you waiting for?",
+        hint: "Pick the closest match. We'll watch for anything in that family — a smaller one in the same family is still a machine you can use.",
+        // Not "I know what I need": the thing one level up is a pattern field, and the
+        // user who wants it wants to name types, not to be told they know things.
+        escapeLabel: "Let me name the instance types →",
+        // The cards must NOT say "about $X for 2 hours" here. That sentence describes a
+        // run, and this page starts no run — it starts a poll, which is free. What the
+        // price is for is deciding whether to want the thing at all, so it's rendered
+        // as a rate with what it would cost over a day, since capacity you're waiting
+        // for is capacity you plan to hold.
+        costLine: (rec) => watchCostLine(rec),
+        onChoose: (choice) => {
+          // Write the resolved family into the form and start. The form stays the one
+          // source of truth (see setRunning), so the hash persistence, the Resume
+          // notice and readWatch() all keep working with no guided-specific path.
+          patternEl.value = watchPattern(choice.rec);
+          maxPriceEl.value = "";
+          azsEl.value = "";
+          spotEl.checked = false;
+          syncPriceHint();
+          void startWatching();
+        },
+        onEscape: () => ctx.session.setLevel("standard"),
+      });
+    }
+
     showResumeIfInterrupted();
 
     // Federated creds are what the EC2 client signs with — a poll that outlives
@@ -401,6 +510,7 @@ export const lagottoSurface: ToolSurface = {
         // Set before the abort so startWatching's finally can tell a dispose-driven
         // abort (leave `watching=1` for the next mount) from a user Stop.
         interrupted = true;
+        disposePicker?.();
         offExpiry();
         aborter?.abort();
         form.removeEventListener("submit", onSubmit);
@@ -414,6 +524,33 @@ export const lagottoSurface: ToolSurface = {
     };
   },
 };
+
+/**
+ * The cost line on a guided watch card.
+ *
+ * The launch flow's "about $110 for 2 hours" is wrong here in a way that matters:
+ * this page starts a poll, not a run, and the poll is free. What the figure is *for*
+ * is deciding whether you want the thing at all — so it leads with the rate, and
+ * gives the per-day figure because capacity you queued for is capacity you intend to
+ * hold, and a day is the unit these machines get held for.
+ *
+ * An unknown price says so, and on this list that isn't an edge case: the p5e (H200)
+ * family carries no on-demand row at all, and the unpriced families are precisely
+ * the scarce ones this page exists for. Rendering nothing would read as free on the
+ * most expensive hardware AWS rents.
+ */
+function watchCostLine(rec: GuidedRecommendation): string {
+  if (rec.pricePerHour == null) {
+    return `<span class="guided-card-cost unknown">no listed price for this family —
+      these are usually the most expensive machines available, so check AWS pricing
+      before you launch one</span>`;
+  }
+  const est = rec.priceIsEstimate ? ", estimated" : "";
+  const perDay = rec.pricePerHour * 24;
+  return `<span class="guided-card-cost">$${rec.pricePerHour.toFixed(2)}/hr once you
+    launch it${est} — about $${Math.round(perDay).toLocaleString("en-US")} a day.
+    Watching costs nothing.</span>`;
+}
 
 // ── The CapacityFinder seam, implemented over the EC2 API ─────────────────────
 

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -820,6 +820,13 @@ footer {
    the lagotto accent: this is a notice about something that is NOT happening, and the
    accent is what this surface uses for a live watch and for a match. */
 .lagotto-resume { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; margin: 0 0 1rem; padding: 0.6rem 0.9rem; border: 1px solid var(--truffle); border-radius: var(--radius); background: var(--truffle-bg); color: var(--truffle); font-size: 0.9rem; }
+/* `display: flex` above out-specifies the UA's `[hidden] { display: none }`, so
+   without this the notice showed on EVERY mount — including the first — telling a
+   user who has never started a watch that theirs was stopped. Exactly the cry-wolf
+   failure the flag was designed to avoid, reintroduced one layer down. The unit tests
+   assert the `hidden` property, which was correctly set; nothing but a real browser
+   could see this, which is the argument for looking. */
+.lagotto-resume[hidden], .lagotto-picker[hidden] { display: none; }
 /* The message shrinks so the button keeps its row; it only stacks below on a
    genuinely narrow viewport, where stacking is the right answer anyway. */
 .lagotto-resume span { flex: 1 1 20ch; }
@@ -838,6 +845,21 @@ footer {
 .lagotto-match-next a { color: var(--lagotto); font-weight: 600; }
 .lagotto-log { list-style: none; margin: 1rem 0 0; padding: 0; font-family: ui-monospace, monospace; font-size: 0.8rem; color: var(--text-muted); max-height: 260px; overflow: auto; }
 .lagotto-log li { padding: 0.2rem 0; border-bottom: 1px solid var(--border); }
+/* Guided: the cards replace the fields. Only one of the two intro paragraphs is ever
+   shown, so each level gets copy written for it rather than one string hedged to fit
+   both. The form is HIDDEN, not absent — the picker writes into it and readWatch()
+   reads out of it, so the hash persistence and the Resume path work unchanged at
+   every level (see "Guided mode" in lagotto.ts). */
+.lagotto-hint-guided { display: none; }
+.lagotto-guided .lagotto-hint-query { display: none; }
+.lagotto-guided .lagotto-hint-guided { display: block; }
+.lagotto-guided .lagotto-fields, .lagotto-guided .lagotto-check, .lagotto-guided .lagotto-once { display: none; }
+/* Not `.lagotto-form { display: none }`: Stop has to stay reachable, and a display:none
+   ancestor would take it with it. The form collapses to nothing but its actions row. */
+.lagotto-guided .lagotto-form { margin: 0; }
+.lagotto-guided .lagotto-controls { margin-top: 0; }
+.lagotto-guided .guided-picker { max-width: none; }
+.lagotto-guided .guided-cards { margin-top: 1rem; }
 
 /* ── Guided mode (app/guided/) — the "anyone could use this" end of the
    disclosure axis. Bigger targets, fewer of them, and the cost always visible:


### PR DESCRIPTION
Closes #513. Part 1 (resume-after-remount) shipped as `154d1d1`; this is the deferred half.

## The problem

**Watch capacity** asks for a glob or regex over instance-type names, a comma-separated
availability-zone list, and a price cap in $/hr. Every one of those is only writable by
someone who already knows the answer.

Which makes this the surface where the Guided/Standard split matters **most**, not least.
Whoever *needs* this page is by definition someone whose launch just failed for capacity —
and at that moment `p5.*` is exactly the string they don't have.

## What this does

Guided asks *"What are you waiting for?"* and offers the same curated cards the truffle and
Instances surfaces use, over a new `WATCH_SHAPES` list. Picking one resolves a real instance
type through the bundled offline catalog, fills the form with its family glob, and starts the
watch. Still no AI, no network, no credentials.

### `WATCH_SHAPES` is a separate list, not a filter over `GUIDED_SHAPES`

You do not wait for a `t4g.xlarge`. Offering "A small analysis" as something to watch would
offer a poll that succeeds on its first check, forever — teaching the user the page does
nothing. Everything on this list is hardware that is genuinely and routinely unavailable,
which is the only reason `lagotto` exists.

The order is **inverted** relative to `GUIDED_SHAPES`, too. That list is cheapest-first
because it's read by someone choosing what to run and the cheap answer is usually right.
This one leads with the H100, because whoever is here already knows they want the scarce
thing — and the easier-to-find alternatives follow, so a user looking at $55/hr and an empty
log has somewhere to go.

### The cost line is a rate, not a total

"About $110 for 2 hours" is a claim about a **run**. This page starts a **poll**, which is
free. `watchCostLine()` leads with the rate, gives a per-day figure (capacity you queued for
is capacity you intend to hold), and closes with "Watching costs nothing."

An unpriced family says so, and on this list that isn't hypothetical: p5e (H200) carries no
on-demand row at all, and **the unpriced families are precisely the scarce ones this page
exists for.** Rendering nothing there would read as free on the most expensive hardware AWS
rents.

### It watches the family, not the one cheapest type

`watchPattern()` returns `p5.*`, not `p5.48xlarge`. The user is waiting for *capacity*, and a
`p5.4xlarge` freeing up while the 48xlarge is still full is a match they want; pinning the
exact type would silently discard it. Verified against lagotto's own `compilePattern` rather
than asserted as a string, since that conversion is what actually runs — and it's also the
cheap form to poll, because the surface pushes it to EC2's `instance-type` filter server-side.

Falls back to the exact type when the catalog carries no family. A bare `.*` would quietly
watch every instance type in the region and match on the first check.

### The query is `trainium`, not `trn2`

truffle-ts's parser doesn't read `trn2` as a family and returns **231 results spanning every
family in the catalog** — so price-ranking resolves that card to a **`t4g.nano` at
$0.0042/hr**, under a label reading "An AWS training chip". A query that confidently returns
the wrong thing is worse than one that returns nothing.

Caught by running `find()` against the real bundled catalog for eleven candidate queries
rather than picking plausible-looking strings.

### The form is hidden, not removed

Load-bearing rather than lazy: the picker writes into the form and `readWatch()` reads out of
it, so the hash persistence, the Resume notice and the `watching=1` flag from part 1 all keep
working at every level with **no guided-specific code path**. One state, one reader.
Implemented as a `.lagotto-guided` class + CSS, because what differs is what's *shown*.

### On a match, Guided points at Mode — not at Instances

Guided's Instances page offers five *launch* shapes and only the H100 one overlaps this list.
So "launch it from Instances" would send someone who just waited for a B200 to a picker that
can't. Guided's match copy names the **Mode** control instead.

Deliberately **not** fixed by adding B200 cards to the launch picker: a $114/hr machine
behind a beginner's single click is an omission on purpose there, not an oversight here.

## Also fixes a real defect from part 1

**`.lagotto-resume` was visible on every mount.** The `hidden` attribute was being set
correctly — but the stylesheet's author `display: flex` out-specifies the UA's
`[hidden] { display: none }`. So a user who had never started a watch was told theirs had
stopped: exactly the cry-wolf failure the consume-on-show flag was designed to prevent,
reintroduced one layer down.

```css
.lagotto-resume[hidden], .lagotto-picker[hidden] { display: none; }
```

The vitest suite asserts the `.hidden` property, which was right; happy-dom applies no CSS,
so nothing but a real browser could see this. Which is the argument for looking.

The notice also **moved above the picker**. At Guided the card list is ~1000px tall, so a
notice below it rendered at y=1203 — under the fold, telling a returning user their watch
stopped somewhere they will never look. Now y=209. Also only findable in a browser: the unit
tests can assert presence but not position.

## Verification

- `npx tsc --noEmit` clean, `npm run build` clean.
- **182 tests / 13 files pass** (was 166). +5 in `shapes.test.ts`, +12 in `lagotto.test.ts`.
- **All 14 new implementation-dependent tests verified failing** against the pre-change code
  (stashed `lagotto.ts` / `shapes.ts` / `picker.ts`, re-ran: 14 failed, 30 passed).
- The shape tests run against the **real bundled catalog**, not a fixture — a fixture would
  pass while the shipped page offered a watch for a `t4g.nano`. The price floor assertion
  (`> 0.2`) sits below inf1.xlarge's $0.228 and well above any t/m-class a mis-parsed query
  returns.
- Label assertions go **through the DOM**, not over the constant: `WATCH_SHAPES` being right
  doesn't establish that the surface passes it.
- **Driven in real Chromium at both levels.** Guided renders 5 cards with real types and
  prices (p5.48xlarge $55.04, p6-b200.48xlarge $113.93 "about $2,734 a day", p4d.24xlarge
  $21.96, g6.xlarge $0.80, trn1.2xlarge $1.34), the fields/Start/Check-once hidden; Standard
  the reverse with zero cards. Clicking the B200 card set `pattern = p6-b200.*`, hid the
  cards, showed Stop, logged "Watching p6-b200.* in us-east-1…". A Mode change into Standard
  carries the pattern across — the two halves of #513 composing.

Docs: a **Watch capacity** row in the per-page table (it had none), a new subsection on why
this page needs guided mode most, and the "Kept across a Mode change" row reworded — it read
*"the … you entered"*, which no longer holds at Guided, where the user entered nothing.
