### PR TITLE
fix(portal): scope ssm:StartSession to spawn-managed instances; pick an instance instead of typing an id (#512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Fixed
+- **`ssm:StartSession` is now scoped to spawn-managed instances** (#512). Both portal
+  IAM policies — the OIDC launch role in `infra/tofu/portal-oidc` and the BYOA
+  onboarding role in `deployment/cloudformation/portal-onboarding-role.yaml` — scoped
+  `ec2:TerminateInstances`/`StopInstances`/`StartInstances` to `spawn:managed=true`
+  and left `ssm:StartSession` on `instance/*` with no condition at all. A shell is at
+  least as powerful as a terminate, so this was the widest grant in the role: a portal
+  session could open a **root-capable shell on any SSM-registered instance in the
+  account** — an unrelated production box the portal never launched — while being
+  correctly denied permission to stop that same instance. The two statements sat next
+  to each other, and the destructive one's comment claimed a portal session "can't
+  touch unrelated instances".
+
+  The only thing narrowing it was `/^i-[0-9a-f]{8,}$/` on a text field in the browser,
+  which validates **syntax**, not authorization — it accepts every instance id in the
+  account, and it runs on the client, where an attacker would be.
+  - The condition key is `ssm:resourceTag/`, not `aws:ResourceTag/`: SSM evaluates the
+    target node's tags under its own service-specific key for `StartSession`.
+  - The session **documents** are a separate, deliberately unconditioned statement. A
+    document carries no `spawn:managed` tag, so folding it into the conditioned
+    statement would deny every session.
+  - **BYOA accounts must redeploy the CloudFormation template to pick this up**, and
+    the tofu side is a definition change — no workflow applies it.
 - **"Your watch was stopped" no longer appears on a page you just opened** (#513).
   The notice is hidden with the HTML `hidden` attribute, and the attribute was being
   set correctly — but the stylesheet gives that element a `display: flex`, which
@@ -41,6 +63,33 @@ own changelogs for CLI releases.
   - The other half of #513 — the guided card list below — completes it.
 
 ### Added
+- **Terminal offers a list of your machines instead of an empty id box** (#512). The
+  page asked for an instance id typed into a text field — an accurate description of
+  what SSM needs and a poor one of what anyone has. Getting an `i-0123456789abcdef0`
+  meant leaving for Instances, copying it, and coming back, so a surface that never
+  read `ctx.level` was effectively Expert-only without saying so. It now lists running
+  spawn-launched instances by name, type and spot status, from the same
+  `tag:spawn:managed=true` filter the Instances page uses — applied by AWS, not by the
+  page, so there is no client-side filtering to get wrong.
+  - Only **running** instances are offered. A stopped one fails inside SSM with a
+    message about the agent, which reads as a broken portal rather than a parked
+    machine.
+  - **Connect to an id instead →** keeps the old field, because a shell into something
+    the portal didn't launch is a legitimate thing to want. Hidden at **Guided**, where
+    an instance id isn't something the user has and offering to take one is a dead end
+    dressed as an option — with one exception: if the list **fails to load**, the
+    escape appears at Guided too, because a control you may not understand beats a page
+    with no way forward.
+  - "You have no instances" and "we couldn't ask" are reported as **different facts**.
+    Claiming the first when only the second is known sends someone hunting for machines
+    they have; a stopped-only account is told how many it has, since the fix there is
+    to start one rather than launch another.
+  - It reuses the Instances page's `EC2Provider` rather than adding a second
+    DescribeInstances client — the bundle cost is what deferred this from the original
+    disclosure pass, and it didn't materialise: the EC2 client hoisted into a shared
+    15 kB chunk, `terminal` grew 2.2 kB and `instances` **shrank** ~15 kB.
+  - The narrowing that matters is the IAM one above, not this picker. Listing makes the
+    spawn-managed set the *default* set; AWS is what makes it the *only* set.
 - **Watch capacity can be used without knowing instance-type names** (#513, part 2).
   At **Guided**, the page's fields — a glob or regular expression over instance-type
   names, a comma-separated zone list, a price cap in $/hr — are replaced by a short

--- a/deployment/cloudformation/portal-onboarding-role.yaml
+++ b/deployment/cloudformation/portal-onboarding-role.yaml
@@ -150,13 +150,35 @@ Resources:
                   - servicequotas:GetServiceQuota
                   - servicequotas:ListServiceQuotas
                 Resource: '*'
-              - Sid: SSMSession
+              # Scoped to spawn-managed instances, matching Lifecycle above. It
+              # previously was not, which made this the widest grant in the role: a
+              # shell is at least as powerful as a terminate, so StartSession against
+              # instance/* allowed a root-capable shell on ANY SSM-registered
+              # instance in the account — including ones the portal never launched —
+              # while ec2:TerminateInstances on that same instance was denied. The
+              # only thing narrowing it was a regex on a text field in the browser,
+              # which validates syntax, not authorization.
+              #
+              # ssm:resourceTag/, not aws:ResourceTag/: SSM evaluates the target
+              # node's tags under its own service-specific condition key here.
+              - Sid: SSMSessionOnManagedInstances
                 Effect: Allow
                 Action:
                   - ssm:StartSession
-                Resource:
-                  - 'arn:aws:ec2:*:*:instance/*'
-                  - 'arn:aws:ssm:*::document/SSM-SessionManagerRunShell'
+                Resource: 'arn:aws:ec2:*:*:instance/*'
+                Condition:
+                  StringEquals:
+                    'ssm:resourceTag/spawn:managed': 'true'
+              # The session document, deliberately NOT tag-conditioned and so a
+              # separate statement: a document carries no spawn:managed tag, so
+              # folding it into the statement above would deny every session. This
+              # grants the use of a shell document; the statement above decides which
+              # targets it may be pointed at.
+              - Sid: SSMSessionDocument
+                Effect: Allow
+                Action:
+                  - ssm:StartSession
+                Resource: 'arn:aws:ssm:*::document/SSM-SessionManagerRunShell'
               - Sid: SSMSessionManage
                 Effect: Allow
                 Action:

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -159,6 +159,7 @@ isn't listed, it looks the same at every level.
 | **Cost history** | Same chart and numbers, plainer labels, and a link to Instances to go stop something | Same chart, shorter labels | + compute/storage/network breakdown, window total, peak hour, a 1-year window, and where the series came from |
 | **Teams** | **Read-only.** Your teams and their members, with no forms. | Create teams, add and remove members, delete a team | + team ids, full ARNs, created dates, and who invited whom |
 | **Watch capacity** | A short list of things worth waiting for, instead of the pattern, price cap, zone and cadence fields. Picking one watches that whole instance family. | The fields, filled in by hand | + |
+| **Terminal** | A list of your running machines to pick from | + **Connect to an id instead →**, for something spawn didn't launch | + |
 | **Connect account** | Technical detail collapsed | Collapsed | Expanded — what the IAM role can do, before the button rather than after |
 
 Two rules held throughout:
@@ -213,6 +214,47 @@ When a match comes in, Guided tells you the type and the zone and then points at
 five launch shapes and only the H100 one is on this list. Telling someone who just
 waited for a B200 to "launch it from Instances" would send them to a picker that
 can't. **Let me name the instance types →** moves up to Standard at any point.
+
+### Opening a shell without knowing an instance id
+
+**Terminal** used to ask for one thing: an instance id, typed into an empty box.
+That is a fair description of what SSM needs and a poor description of what anyone
+has. Getting an `i-0123456789abcdef0` meant going to Instances, copying it, and
+coming back — so a page that never read **Mode** at all was Expert-only without ever
+saying so.
+
+It now lists your machines and you pick one:
+
+> `trial-run — t4g.xlarge`
+> `overnight-fit — g5.2xlarge (spot)`
+
+Only **running** machines are offered. A stopped one fails inside SSM with a message
+about the agent, which reads as a broken portal rather than a parked machine.
+
+The list is the machines **spawn launched** — it comes from the same
+`spawn:managed=true` filter the Instances page uses, applied by AWS rather than by
+the page. So the default set of things you can open a shell into is the set spawn is
+responsible for. **Connect to an id instead →** takes anything you can name, because
+a shell into a machine the portal didn't launch is a legitimate thing to want; it's
+hidden at Guided, where an instance id isn't something you have and offering to take
+one is a dead end dressed as an option.
+
+One exception, and it's the case that matters: if the list **can't be loaded**, the
+id field appears at Guided too. A control you may not understand beats a page with no
+way forward. The page also distinguishes *"you have no machines"* from *"we couldn't
+ask"* — reporting the first when it only knows the second sends you hunting for
+machines you have.
+
+**This is a usability fix that also narrowed a real permission.** The old box
+validated ids with a pattern — it checked that a string *looked* like an instance id,
+which is not the same as checking you're allowed to reach it. The IAM role scoped
+stopping and terminating to `spawn:managed=true` but left `ssm:StartSession`
+unscoped, so a portal session could open a root-capable shell on any SSM-registered
+machine in the account while being correctly denied permission to *stop* that same
+machine. A shell is at least as powerful as a stop. The role now scopes
+`ssm:StartSession` the same way, in AWS, where it's enforced — the picker is the
+part you can see, not the part doing the enforcing. If you onboarded an account with
+the CloudFormation template, redeploy it to pick this up.
 
 ## What changing Mode does and doesn't cost you
 

--- a/infra/tofu/portal-oidc/main.tf
+++ b/infra/tofu/portal-oidc/main.tf
@@ -252,9 +252,39 @@ resource "aws_iam_role_policy" "ssm_session" {
     Version = "2012-10-17"
     Statement = [
       {
+        # Scoped to spawn-managed instances, matching the "Lifecycle" statement
+        # above. It previously was not, and that was the widest grant in this role:
+        # a shell is at least as powerful as a terminate, so StartSession against
+        # `instance/*` let a portal session open a root-capable shell on ANY
+        # SSM-registered instance in the account — an unrelated production box the
+        # portal never launched — while ec2:TerminateInstances on the same instance
+        # was correctly denied. The only thing narrowing it was a client-side
+        # `/^i-[0-9a-f]{8,}$/` on a text field, which is a syntax check, not authz.
+        #
+        # `ssm:resourceTag/`, not `aws:ResourceTag/`: SSM evaluates the target
+        # node's tags under its own service-specific key for StartSession.
+        Sid      = "StartSessionOnManagedInstances"
         Effect   = "Allow"
         Action   = ["ssm:StartSession"]
-        Resource = ["arn:aws:ec2:*:*:instance/*", "arn:aws:ssm:*:*:document/AWS-StartInteractiveCommand", "arn:aws:ssm:*::document/SSM-SessionManagerRunShell"]
+        Resource = "arn:aws:ec2:*:*:instance/*"
+        Condition = {
+          StringEquals = { "ssm:resourceTag/spawn:managed" = "true" }
+        }
+      },
+      {
+        # The session documents, deliberately NOT tag-conditioned and therefore a
+        # separate statement. A document is not a tagged instance, so folding it in
+        # with the condition above would deny every session — the condition would be
+        # evaluated against a resource that carries no `spawn:managed` tag at all.
+        # This grants the right to use a shell document, not the right to reach any
+        # particular target; the statement above is what decides that.
+        Sid    = "StartSessionDocuments"
+        Effect = "Allow"
+        Action = ["ssm:StartSession"]
+        Resource = [
+          "arn:aws:ssm:*:*:document/AWS-StartInteractiveCommand",
+          "arn:aws:ssm:*::document/SSM-SessionManagerRunShell",
+        ]
       },
       {
         Effect   = "Allow"

--- a/web/app/surfaces/instances.test.ts
+++ b/web/app/surfaces/instances.test.ts
@@ -14,7 +14,7 @@
 // signal that spawn-ts moved.
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionController } from "../session.js";
 import type { PortalConfig, SurfaceContext } from "./types.js";
 import type { DisclosureLevel } from "../disclosure.js";
@@ -44,8 +44,8 @@ function hiddenSelectors(): string[] {
 function ctxAt(level: DisclosureLevel): SurfaceContext {
   const session = new SessionController("us-east-1", null);
   session.setLevel(level);
-  // The surface throws without creds. These are never used: the EC2Provider is
-  // constructed but the test never lets a request complete.
+  // The surface throws without creds. These are the AWS docs' example key, and they
+  // never reach AWS — `fetch` is stubbed below.
   vi.spyOn(session, "getCreds").mockReturnValue({
     accessKeyId: "AKIAIOSFODNN7EXAMPLE",
     secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -56,11 +56,29 @@ function ctxAt(level: DisclosureLevel): SurfaceContext {
 
 describe("instancesSurface disclosure", () => {
   let host: HTMLElement;
+  const realFetch = globalThis.fetch;
 
   beforeEach(() => {
     document.body.innerHTML = "";
     host = document.createElement("div");
     document.body.appendChild(host);
+    // Mounting this surface constructs a real EC2Provider and calls
+    // client.startMonitor(), which issues DescribeInstances immediately. Without
+    // this stub those requests go to the actual AWS endpoint and come back 401 —
+    // the run used to finish before the response landed, so it looked clean while
+    // this suite made unauthenticated calls to AWS from CI. An empty reservation
+    // set is enough: nothing here asserts on instance data.
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          `<?xml version="1.0" encoding="UTF-8"?><DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/"><requestId>test</requestId><reservationSet/></DescribeInstancesResponse>`,
+          { status: 200, headers: { "content-type": "text/xml" } },
+        ),
+    ) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
   });
 
   it("marks the host so the stylesheet can hide the Dashboard's forms at guided", async () => {

--- a/web/app/surfaces/terminal.harness.html
+++ b/web/app/surfaces/terminal.harness.html
@@ -1,0 +1,267 @@
+<!doctype html>
+<!--
+  Dev-only harness for the terminal surface. Mounts the REAL surface module at each
+  disclosure level with a stub SurfaceContext, a stubbed window.fetch answering the
+  EC2 DescribeInstances (Query/XML) and SSM StartSession/TerminateSession (JSON 1.1)
+  calls, and a stub WebSocket so attachTerminal's SsmSession.open() resolves and the
+  connected state actually renders.
+
+  This exists because the unit tests cannot see the thing most likely to break here:
+  happy-dom applies no CSS, so `pick.hidden = true` "passes" there even if a
+  `display:` rule overrides the UA's `[hidden]` sheet. That is exactly the
+  specificity trap that shipped the lagotto resume notice on every mount, and this
+  surface now keeps THREE mutually-hidden controls in the DOM at once.
+
+  Open at /app/surfaces/terminal.harness.html under `npm run dev`. Not a Vite build
+  input, so it never ships to spore.host.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>terminal harness</title>
+    <link rel="stylesheet" href="../../css/style.css" />
+    <style>
+      /* Each level gets its own mount point so all three are visible at once and
+         comparable by eye — the point of the pass. */
+      .rig { border-top: 1px solid var(--border); padding: 1rem 0; }
+      .rig h1 { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); }
+    </style>
+  </head>
+  <body>
+    <pre id="verdict"></pre>
+    <div class="rig"><h1>guided</h1><div id="guided" class="portal-main"></div></div>
+    <div class="rig"><h1>standard</h1><div id="standard" class="portal-main"></div></div>
+    <div class="rig"><h1>expert</h1><div id="expert" class="portal-main"></div></div>
+    <script>
+      if (location.search.includes("dark")) document.documentElement.setAttribute("data-theme", "dark");
+    </script>
+    <script type="module">
+      // ── Stubbed AWS ────────────────────────────────────────────────────────────
+      // Two instances running (one spot, one with a hostile Name tag), one stopped —
+      // so the "only running" filter and the escaping are both visible, not asserted.
+      const INSTANCES = `<?xml version="1.0" encoding="UTF-8"?>
+<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+  <requestId>req-1</requestId>
+  <reservationSet>
+    <item>
+      <instancesSet>
+        <item>
+          <instanceId>i-00000000000000a11</instanceId>
+          <instanceType>t4g.xlarge</instanceType>
+          <instanceState><code>16</code><name>running</name></instanceState>
+          <tagSet>
+            <item><key>spawn:managed</key><value>true</value></item>
+            <item><key>Name</key><value>trial-run</value></item>
+          </tagSet>
+        </item>
+        <item>
+          <instanceId>i-00000000000000b22</instanceId>
+          <instanceType>g5.2xlarge</instanceType>
+          <instanceState><code>16</code><name>running</name></instanceState>
+          <instanceLifecycle>spot</instanceLifecycle>
+          <tagSet>
+            <item><key>spawn:managed</key><value>true</value></item>
+            <item><key>Name</key>&lt;img src=x onerror=alert(1)&gt;</item>
+          </tagSet>
+        </item>
+        <item>
+          <instanceId>i-00000000000000c33</instanceId>
+          <instanceType>m7i.large</instanceType>
+          <instanceState><code>80</code><name>stopped</name></instanceState>
+          <tagSet>
+            <item><key>spawn:managed</key><value>true</value></item>
+            <item><key>Name</key><value>parked</value></item>
+          </tagSet>
+        </item>
+      </instancesSet>
+    </item>
+  </reservationSet>
+</DescribeInstancesResponse>`;
+
+      const calls = [];
+      // ?fail — make DescribeInstances reject, to see the failed-lookup branch and
+      // (at guided) the escape hatch appearing where it is normally hidden.
+      // ?empty — no instances at all.
+      const failList = location.search.includes("fail");
+      const emptyList = location.search.includes("empty");
+
+      window.fetch = async (req) => {
+        const url = typeof req === "string" ? req : req.url;
+        const headers = typeof req === "object" && req.headers ? req.headers : new Headers();
+        const target = headers.get?.("x-amz-target") ?? "";
+        const body = typeof req === "object" && req.body ? await new Response(req.body).text() : "";
+        const action = /Action=([A-Za-z]+)/.exec(body)?.[1] ?? target.split(".").pop() ?? "?";
+        calls.push(action);
+
+        if (target.includes("StartSession")) {
+          return new Response(
+            JSON.stringify({ StreamUrl: "wss://stub.invalid/v1/data-channel/s-1", TokenValue: "tok", SessionId: "s-1" }),
+            { status: 200, headers: { "content-type": "application/x-amz-json-1.1" } },
+          );
+        }
+        if (target) return new Response("{}", { status: 200, headers: { "content-type": "application/x-amz-json-1.1" } });
+
+        if (action === "DescribeInstances") {
+          if (failList) {
+            // A real AccessDenied, so the message the surface prints is the message
+            // AWS would actually give — not a hand-written string.
+            return new Response(
+              `<Response><Errors><Error><Code>UnauthorizedOperation</Code><Message>You are not authorized to perform this operation.</Message></Error></Errors></Response>`,
+              { status: 403, headers: { "content-type": "text/xml" } },
+            );
+          }
+          const xml = emptyList
+            ? INSTANCES.replace(/<reservationSet>[\s\S]*<\/reservationSet>/, "<reservationSet/>")
+            : INSTANCES;
+          return new Response(xml, { status: 200, headers: { "content-type": "text/xml" } });
+        }
+        return new Response("", { status: 200, headers: { "content-type": "text/xml" } });
+      };
+
+      // The SSM data channel. Opens, ACKs nothing, sends nothing — enough for
+      // SsmSession.open() to resolve so the connected UI renders for real.
+      //
+      // Both details below are load-bearing rather than tidiness. A real
+      // WebSocket dispatches `onclose` as a TASK, and is a no-op once already
+      // closing; a stub that fires it synchronously and re-closes recurses forever
+      // through SsmSession.close → onclose → the surface's onClosed → teardown →
+      // dispose → SsmSession.close, because `this.ws = null` hasn't run yet. That
+      // is a defect in the stub, not in the surface — so the stub honours the
+      // contract instead of the surface working around it.
+      window.WebSocket = class StubSocket {
+        constructor(url) {
+          this.url = url;
+          this.readyState = 0; // CONNECTING
+          setTimeout(() => {
+            this.readyState = 1; // OPEN
+            this.onopen?.({});
+          }, 0);
+        }
+        send() {}
+        close() {
+          if (this.readyState > 1) return; // already CLOSING/CLOSED
+          this.readyState = 2; // CLOSING
+          setTimeout(() => {
+            this.readyState = 3; // CLOSED
+            this.onclose?.({ reason: "stub", code: 1000 });
+          }, 0);
+        }
+      };
+      window.WebSocket.CONNECTING = 0;
+      window.WebSocket.OPEN = 1;
+      window.WebSocket.CLOSING = 2;
+      window.WebSocket.CLOSED = 3;
+
+      const { terminalSurface } = await import("./terminal.ts");
+
+      function ctxAt(level) {
+        return {
+          session: {
+            region: "us-east-1",
+            accountId: "000000000000",
+            signedIn: true,
+            level,
+            getCreds: () => ({ accessKeyId: "AKIAHARNESS", secretAccessKey: "s", sessionToken: "t" }),
+            onExpiry: () => () => {},
+          },
+          config: { region: "us-east-1" },
+          level,
+          navigate: () => {},
+        };
+      }
+
+      const checks = [];
+      const assert = (name, cond, detail = "") =>
+        checks.push(`${cond ? "PASS" : "FAIL"} ${name}${detail ? " — " + detail : ""}`);
+      const settle = (ms = 120) => new Promise((r) => setTimeout(r, ms));
+
+      const mounted = {};
+      for (const level of ["guided", "standard", "expert"]) {
+        const el = document.getElementById(level);
+        mounted[level] = { el, d: await terminalSurface.mount(el, ctxAt(level)) };
+      }
+      await settle();
+
+      // The whole reason this file exists: `hidden` must WIN over the display rules
+      // for all three controls, in a real stylesheet. getComputedStyle is the only
+      // check that can see it, and happy-dom cannot do it at all.
+      const q = (level, sel) => mounted[level].el.querySelector(sel);
+      const shown = (node) => node && getComputedStyle(node).display !== "none";
+
+      for (const level of ["guided", "standard", "expert"]) {
+        assert(`${level}: picker visible`, shown(q(level, ".terminal-pick")));
+        assert(`${level}: id field NOT visible`, !shown(q(level, ".terminal-target")), getComputedStyle(q(level, ".terminal-target")).display);
+      }
+      // Only when the list LOADED: a failed lookup deliberately reveals the escape at
+      // guided (asserted in the ?fail block below), so asserting it hidden here
+      // unconditionally would be the harness contradicting itself.
+      if (!failList) {
+        assert(
+          "guided: by-id escape NOT visible",
+          !shown(q("guided", ".terminal-byid")),
+          `[hidden]=${q("guided", ".terminal-byid").hidden} display=${getComputedStyle(q("guided", ".terminal-byid")).display}`,
+        );
+      }
+      assert("standard: by-id escape visible", shown(q("standard", ".terminal-byid")));
+      assert("expert: by-id escape visible", shown(q("expert", ".terminal-byid")));
+
+      if (!failList && !emptyList) {
+        const opts = [...q("standard", ".terminal-pick").options];
+        assert("only running instances offered", opts.length === 2, opts.map((o) => o.value).join(", "));
+        assert("labels carry a recognisable name + type", /trial-run/.test(opts[0].textContent) && /t4g\.xlarge/.test(opts[0].textContent), opts[0].textContent);
+        assert("spot is labelled", opts.some((o) => /\(spot\)/.test(o.textContent)), opts[1].textContent);
+        assert("hostile Name tag did not become an element", q("standard", ".terminal-pick").querySelector("img") === null);
+        assert("Connect enabled once the list arrived", q("standard", ".terminal-open").disabled === false);
+
+        // The swap, in a real stylesheet — each control's visibility must actually
+        // flip, which is the assertion happy-dom can only fake.
+        q("standard", ".terminal-byid").click();
+        assert("after swap: field visible, picker not", shown(q("standard", ".terminal-target")) && !shown(q("standard", ".terminal-pick")));
+        assert("after swap: escape offers the way back", /pick from your instances/i.test(q("standard", ".terminal-byid").textContent));
+        q("standard", ".terminal-byid").click();
+        assert("swapped back: picker visible, field not", shown(q("standard", ".terminal-pick")) && !shown(q("standard", ".terminal-target")));
+
+        // Connect for real (stub socket) and look at the connected state.
+        q("expert", ".terminal-form").dispatchEvent(new Event("submit"));
+        await settle(200);
+        const st = q("expert", ".terminal-status");
+        assert("connected: target controls locked", q("expert", ".terminal-pick").disabled && q("expert", ".terminal-byid").disabled);
+        assert("connected: warning names the header control", /Mode/i.test(st.textContent), st.textContent);
+        assert("connected: warning is styled as a warning", st.classList.contains("warn"));
+        assert("connected: terminal panel visible", shown(q("expert", ".terminal-host")));
+        assert("connected: StartSession went to the PICKED id", calls.includes("StartSession"));
+        assert("disconnect offered", shown(q("expert", ".terminal-close")));
+        q("expert", ".terminal-close").click();
+        await settle();
+        assert("after disconnect: controls re-enabled", !q("expert", ".terminal-pick").disabled && !q("expert", ".terminal-byid").disabled);
+        assert("after disconnect: terminal panel hidden", !shown(q("expert", ".terminal-host")));
+      }
+
+      if (failList) {
+        assert("failed lookup says what failed", /couldn't list your instances/i.test(q("standard", ".terminal-status").textContent), q("standard", ".terminal-status").textContent);
+        assert("failed lookup does NOT claim there are none", !/no spawn-launched/i.test(q("standard", ".terminal-pick").textContent), q("standard", ".terminal-pick").textContent);
+        // The one case a guided user needs the id field: it's the only way in.
+        assert("guided: escape REVEALED when the list fails", shown(q("guided", ".terminal-byid")));
+        assert("Connect disabled with nothing to connect to", q("guided", ".terminal-open").disabled === true);
+      }
+
+      if (emptyList) {
+        assert("empty list says so", /no spawn-launched instances/i.test(q("standard", ".terminal-pick").textContent), q("standard", ".terminal-pick").textContent);
+        assert("empty list points at the way out", /connect to an id/i.test(q("standard", ".terminal-status").textContent), q("standard", ".terminal-status").textContent);
+        assert("Connect disabled", q("standard", ".terminal-open").disabled === true);
+      }
+
+      // ?keep — leave the surfaces mounted for eyeballing (the default run below
+      // disposes them, which empties the page).
+      if (!location.search.includes("keep")) {
+        for (const level of ["guided", "standard", "expert"]) mounted[level].d.dispose();
+        assert("dispose removes the surface", document.querySelectorAll(".terminal-surface").length === 0);
+      }
+
+      const failed = checks.filter((c) => c.startsWith("FAIL"));
+      document.getElementById("verdict").textContent =
+        checks.join("\n") + "\n\n" + (failed.length ? `${failed.length} FAILED` : "ALL PASS") + `\n(AWS calls: ${calls.join(", ")})`;
+      document.title = failed.length ? "HARNESS FAIL" : "HARNESS PASS";
+    </script>
+  </body>
+</html>

--- a/web/app/surfaces/terminal.test.ts
+++ b/web/app/surfaces/terminal.test.ts
@@ -1,0 +1,359 @@
+// The terminal surface picks a target, and what it offers to pick from is the point.
+//
+// What shipped was a text field validated by /^i-[0-9a-f]{8,}$/. That has a usability
+// failure and a blast-radius failure, and they pull in the same direction:
+//
+//   - An instance id is not something a person has. Getting one meant leaving for the
+//     Instances page and copying one, so a surface that never read ctx.level was
+//     effectively expert-only without saying so.
+//   - The regex is a SYNTAX check. It accepts any instance id in the account,
+//     including instances the portal never launched.
+//
+// The IAM fix (scoping ssm:StartSession to spawn:managed=true) is the actual authz
+// boundary and lives in infra/tofu + the CFN template; these tests cover the browser
+// half — that the default set of targets is the spawn-managed set, and that the
+// surface never claims to know something it doesn't.
+//
+// The load-bearing assertions are the negative and the failure ones: that the list is
+// populated from the provider rather than free text, that an empty list and a failed
+// lookup say DIFFERENT things, and that a guided user is never left with a dead end.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionController } from "../session.js";
+import type { PortalConfig, SurfaceContext } from "./types.js";
+import { LEVEL_CONTROL_NAME, type DisclosureLevel } from "../disclosure.js";
+
+/** What the mocked EC2Provider returns from list(). Each test sets what it needs. */
+let instances: Array<Record<string, unknown>> = [];
+/** Set to make list() reject, so the lookup-failed branch is reachable. */
+let listError: Error | null = null;
+/**
+ * Set to hold list() open, so "dispose() lands before the list resolves" is reachable
+ * at all. The default mock resolves in the same microtask, which never reproduces
+ * that race — and a test that cannot reproduce the race it names would pass whether
+ * or not the guard exists.
+ */
+let listGate: Promise<void> | null = null;
+/** Every EC2Provider constructed, so its options are assertable. */
+let providerOpts: Array<Record<string, unknown>> = [];
+/** StartSession targets the surface actually asked for. */
+let started: string[] = [];
+
+vi.mock("@spore-host/spawn-ts", () => ({
+  class: undefined,
+  EC2Provider: class {
+    constructor(opts: Record<string, unknown>) {
+      providerOpts.push(opts);
+    }
+    async list(): Promise<unknown[]> {
+      if (listGate) await listGate;
+      if (listError) throw listError;
+      return instances;
+    }
+  },
+}));
+
+vi.mock("@spore-host/spawn-ts/terminal", () => ({
+  // Resolves to a disposable so a "successful" connect is reachable without xterm.
+  attachTerminal: vi.fn(async () => ({ dispose: vi.fn() })),
+}));
+
+vi.mock("@aws-sdk/client-ssm", () => {
+  class StartSessionCommand {
+    constructor(public input: { Target?: string }) {}
+  }
+  class TerminateSessionCommand {
+    constructor(public input: unknown) {}
+  }
+  class SSMClient {
+    async send(cmd: unknown): Promise<unknown> {
+      if (cmd instanceof StartSessionCommand) {
+        started.push(cmd.input.Target ?? "");
+        return { StreamUrl: "wss://x", TokenValue: "t", SessionId: "s-1" };
+      }
+      return {};
+    }
+  }
+  return { SSMClient, StartSessionCommand, TerminateSessionCommand };
+});
+
+const { terminalSurface } = await import("./terminal.js");
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+const config = { region: "us-east-1" } as PortalConfig;
+
+/** A running spawn-managed instance, as EC2Provider.list() would report it. */
+function inst(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    instanceId: "i-0123456789abcdef0",
+    name: "trial-run",
+    instanceType: "t4g.xlarge",
+    state: "running",
+    spot: false,
+    ...over,
+  };
+}
+
+function ctxAt(level: DisclosureLevel = "standard"): SurfaceContext {
+  const session = new SessionController("us-east-1", null);
+  session.setLevel(level);
+  vi.spyOn(session, "getCreds").mockReturnValue({
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    sessionToken: "token",
+  } as never);
+  return { session, config, level, navigate: vi.fn() };
+}
+
+let host: HTMLElement;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  instances = [inst()];
+  listError = null;
+  listGate = null;
+  providerOpts = [];
+  started = [];
+});
+
+const pick = () => host.querySelector<HTMLSelectElement>(".terminal-pick")!;
+const field = () => host.querySelector<HTMLInputElement>(".terminal-target")!;
+const byId = () => host.querySelector<HTMLButtonElement>(".terminal-byid")!;
+const openBtn = () => host.querySelector<HTMLButtonElement>(".terminal-open")!;
+const status = () => host.querySelector<HTMLElement>(".terminal-status")!;
+const text = () => status().textContent!.replace(/\s+/g, " ");
+
+describe("terminalSurface target picker", () => {
+  it("offers the account's spawn-managed instances instead of asking for an id", async () => {
+    instances = [inst({ instanceId: "i-00000000000000aaa", name: "alpha" }), inst({ instanceId: "i-00000000000000bbb", name: "beta" })];
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+
+    const opts = [...pick().options];
+    expect(opts.map((o) => o.value)).toEqual(["i-00000000000000aaa", "i-00000000000000bbb"]);
+    // The label has to carry something a person recognises. An id-only list would be
+    // the same problem in a different control.
+    expect(opts[0]!.textContent).toContain("alpha");
+    expect(opts[0]!.textContent).toContain("t4g.xlarge");
+    // And the free-text field is the fallback, not the default.
+    expect(field().hidden).toBe(true);
+    expect(pick().hidden).toBe(false);
+    d.dispose();
+  });
+
+  it("lists only running instances", async () => {
+    // A stopped instance fails inside SSM with a message about the agent, which reads
+    // as a broken portal rather than a stopped machine.
+    instances = [
+      inst({ instanceId: "i-000000000000000a1", state: "running" }),
+      inst({ instanceId: "i-000000000000000b2", state: "stopped" }),
+      inst({ instanceId: "i-000000000000000c3", state: "pending" }),
+    ];
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    expect([...pick().options].map((o) => o.value)).toEqual(["i-000000000000000a1"]);
+    d.dispose();
+  });
+
+  it("connects to the picked instance, not to whatever is in the text field", async () => {
+    // Ids are hex — the surface's own /^i-[0-9a-f]{8,}$/ rejects anything else, so a
+    // mnemonic fixture ("i-picked111") fails the id check rather than the assertion.
+    instances = [inst({ instanceId: "i-00000000000000ace" })];
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    // A value in the hidden field must not win: `chosenTarget()` reads the ACTIVE
+    // control, and getting that backwards would connect somewhere unintended.
+    field().value = "i-00000000000000bad";
+    host.querySelector<HTMLFormElement>(".terminal-form")!.dispatchEvent(new Event("submit"));
+    await settle();
+    expect(started).toEqual(["i-00000000000000ace"]);
+    d.dispose();
+  });
+
+  it("constructs the provider read-only, with no instance profile", async () => {
+    // This surface lists and never launches. Passing iamInstanceProfile would imply a
+    // launch path that doesn't exist here.
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    expect(providerOpts).toHaveLength(1);
+    expect(providerOpts[0]).not.toHaveProperty("iamInstanceProfile");
+    expect(providerOpts[0]!.region).toBe("us-east-1");
+    d.dispose();
+  });
+});
+
+describe("terminalSurface when there is nothing to pick", () => {
+  it("distinguishes an empty account from a failed lookup", async () => {
+    // The #63 invariant, in this surface: "you have no instances" and "we couldn't
+    // ask" are different facts, and reporting the first when we only know the second
+    // sends the user hunting for instances they may well have.
+    instances = [];
+    let d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    expect(pick().textContent).toMatch(/no spawn-launched instances/i);
+    expect(text()).not.toMatch(/couldn't list/i);
+    d.dispose();
+
+    host.innerHTML = "";
+    listError = new Error("AccessDenied");
+    d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    expect(text()).toMatch(/couldn't list your instances: AccessDenied/);
+    expect(pick().textContent).not.toMatch(/no spawn-launched/i);
+    d.dispose();
+  });
+
+  it("says how many instances exist when none of them are running", async () => {
+    // "No instances" would be false — they have two, both stopped, and the fix is to
+    // start one rather than to launch another.
+    instances = [inst({ state: "stopped" }), inst({ state: "terminated" })];
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    expect(pick().textContent).toMatch(/none of your 2 instance\(s\) are running/i);
+    d.dispose();
+  });
+
+  it("cannot submit before the list has loaded", async () => {
+    // A Connect click against an empty select would fail the id check and print an
+    // error about the user's own timing.
+    instances = [];
+    const d = await terminalSurface.mount(host, ctxAt());
+    expect(openBtn().disabled).toBe(true);
+    await settle();
+    d.dispose();
+  });
+});
+
+describe("terminalSurface disclosure", () => {
+  it("hides the by-id escape at guided", async () => {
+    // An instance id is not something a guided user has, so a control offering to
+    // take one is a dead end dressed as an option.
+    const d = await terminalSurface.mount(host, ctxAt("guided"));
+    await settle();
+    expect(byId().hidden).toBe(true);
+    // But the picker itself is the whole point of the surface at every level.
+    expect(pick().hidden).toBe(false);
+    expect([...pick().options].map((o) => o.value)).toEqual(["i-0123456789abcdef0"]);
+    d.dispose();
+  });
+
+  it("offers the by-id escape from standard up", async () => {
+    for (const level of ["standard", "expert"] as const) {
+      host.innerHTML = "";
+      const d = await terminalSurface.mount(host, ctxAt(level));
+      await settle();
+      expect(byId().hidden, level).toBe(false);
+      d.dispose();
+    }
+  });
+
+  it("reveals the escape at guided when the list fails, rather than dead-ending", async () => {
+    // The one case where a guided user needs the id field: the list is the only way
+    // in and it didn't load. A dead end is worse than a control they may not
+    // understand.
+    listError = new Error("AccessDenied");
+    const d = await terminalSurface.mount(host, ctxAt("guided"));
+    await settle();
+    expect(byId().hidden).toBe(false);
+    d.dispose();
+  });
+
+  it("swaps between the picker and the field without losing either", async () => {
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    byId().click();
+    expect(pick().hidden).toBe(true);
+    expect(field().hidden).toBe(false);
+    expect(byId().textContent).toMatch(/pick from your instances/i);
+    // Both stay in the DOM: chosenTarget() reads whichever is active, and rebuilding
+    // would throw away a list already fetched.
+    expect(pick().options.length).toBe(1);
+
+    byId().click();
+    expect(pick().hidden).toBe(false);
+    expect(field().hidden).toBe(true);
+    d.dispose();
+  });
+
+  it("connects to a typed id once the escape is taken", async () => {
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    byId().click();
+    field().value = "i-deadbeef00";
+    host.querySelector<HTMLFormElement>(".terminal-form")!.dispatchEvent(new Event("submit"));
+    await settle();
+    expect(started).toEqual(["i-deadbeef00"]);
+    d.dispose();
+  });
+});
+
+describe("terminalSurface while connected", () => {
+  it("locks the target controls and still names what ends the session", async () => {
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    host.querySelector<HTMLFormElement>(".terminal-form")!.dispatchEvent(new Event("submit"));
+    await settle();
+
+    // Changing how you choose a target is meaningless once you have a session, and
+    // leaving it live invites a click that appears to do something and doesn't.
+    expect(pick().disabled).toBe(true);
+    expect(byId().disabled).toBe(true);
+    // The warning from the earlier honesty pass must survive this change: dispose()
+    // terminates the session, and dispose() runs on a Mode change.
+    expect(text()).toContain(LEVEL_CONTROL_NAME);
+    expect(status().className).toContain("warn");
+    d.dispose();
+  });
+
+  it("re-enables the target controls after disconnecting", async () => {
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    host.querySelector<HTMLFormElement>(".terminal-form")!.dispatchEvent(new Event("submit"));
+    await settle();
+    host.querySelector<HTMLButtonElement>(".terminal-close")!.click();
+    await settle();
+    // Or a disconnect would leave a surface that can never connect again.
+    expect(pick().disabled).toBe(false);
+    expect(byId().disabled).toBe(false);
+    expect(openBtn().disabled).toBe(false);
+    d.dispose();
+  });
+});
+
+describe("terminalSurface teardown", () => {
+  it("does not write into a disposed surface when the list resolves late", async () => {
+    // dispose() can land before list() settles — a Mode change immediately after
+    // navigating here. Writing then would touch a detached DOM and, worse, overwrite
+    // whatever the next mount had already rendered.
+    let release = () => {};
+    listGate = new Promise<void>((r) => (release = r));
+
+    const d = await terminalSurface.mount(host, ctxAt());
+    // Captured, not re-queried: dispose() removes the root from `host`, so a fresh
+    // querySelector afterwards returns null and would pass this test for the wrong
+    // reason. The point is that THIS node — the one the pending list() closure holds —
+    // is never written to.
+    const el = pick();
+    const before = el.innerHTML;
+    expect(before, "list must still be pending, or the race isn't under test").toMatch(/loading/i);
+
+    d.dispose();
+    release();
+    await settle();
+    expect(el.innerHTML).toBe(before);
+  });
+
+  it("escapes an instance name from a user-controlled tag", async () => {
+    // `name` comes from the Name tag, which the account's own users write. Not
+    // exploitable in an <option>, which is why it's asserted rather than assumed —
+    // the property belongs to the current markup, not to the data.
+    instances = [inst({ name: `<img src=x onerror=alert(1)>` })];
+    const d = await terminalSurface.mount(host, ctxAt());
+    await settle();
+    expect(pick().querySelector("img")).toBeNull();
+    expect(pick().options[0]!.textContent).toContain("<img");
+    d.dispose();
+  });
+});

--- a/web/app/surfaces/terminal.ts
+++ b/web/app/surfaces/terminal.ts
@@ -6,8 +6,9 @@
 // AND TerminateSession (StartSession leaks a server-side session otherwise).
 import { SSMClient, StartSessionCommand, TerminateSessionCommand } from "@aws-sdk/client-ssm";
 import { attachTerminal, type AttachedTerminal } from "@spore-host/spawn-ts/terminal";
+import { EC2Provider } from "@spore-host/spawn-ts";
 import type { Disposable, SurfaceContext, ToolSurface } from "./types.js";
-import { LEVEL_CONTROL_NAME } from "../disclosure.js";
+import { atLeast, LEVEL_CONTROL_NAME } from "../disclosure.js";
 
 export const terminalSurface: ToolSurface = {
   id: "terminal",
@@ -25,6 +26,15 @@ export const terminalSurface: ToolSurface = {
       sessionToken: creds.sessionToken,
     };
 
+    // Read-only here: this surface lists to populate the picker and never launches,
+    // so no iamInstanceProfile — passing one would imply a launch path that doesn't
+    // exist. `list()` filters `tag:spawn:managed=true` server-side.
+    const provider = new EC2Provider({ region, ...credentials });
+
+    // Guards the two async paths (the list load, and attach) against writing into a
+    // surface the shell has already torn down — dispose() can land first.
+    let disposed = false;
+
     const root = document.createElement("div");
     root.className = "terminal-surface";
     root.innerHTML = `
@@ -34,17 +44,29 @@ export const terminalSurface: ToolSurface = {
           instance must have the SSM agent + an instance profile allowing SSM —
           spawn-launched instances do.</p>
         <form class="terminal-form">
-          <input class="terminal-target" type="text" placeholder="i-0123456789abcdef0" autocomplete="off" spellcheck="false" />
+          <!-- The picker is the primary control and the text field the fallback, not
+               the other way round. Both are always present: the list can only offer
+               spawn-managed instances in this region, and a shell into something the
+               portal didn't launch is a legitimate thing to want. -->
+          <select class="terminal-pick" aria-label="Instance to connect to">
+            <option value="">loading your instances…</option>
+          </select>
+          <input class="terminal-target" type="text" placeholder="i-0123456789abcdef0" autocomplete="off" spellcheck="false" hidden />
           <button type="submit" class="terminal-open">Connect</button>
           <button type="button" class="terminal-close" hidden>Disconnect</button>
         </form>
+        <!-- Hidden at guided: an instance id is not a thing a guided user has, and
+             offering the escape to typing one would be offering a dead end. -->
+        <button type="button" class="terminal-byid">Connect to an id instead →</button>
         <div class="terminal-status" aria-live="polite"></div>
       </div>
       <div class="terminal-host" hidden></div>`;
     host.appendChild(root);
 
     const form = root.querySelector<HTMLFormElement>(".terminal-form")!;
+    const pick = root.querySelector<HTMLSelectElement>(".terminal-pick")!;
     const target = root.querySelector<HTMLInputElement>(".terminal-target")!;
+    const byIdBtn = root.querySelector<HTMLButtonElement>(".terminal-byid")!;
     const openBtn = root.querySelector<HTMLButtonElement>(".terminal-open")!;
     const closeBtn = root.querySelector<HTMLButtonElement>(".terminal-close")!;
     const status = root.querySelector<HTMLElement>(".terminal-status")!;
@@ -52,6 +74,102 @@ export const terminalSurface: ToolSurface = {
 
     let attached: AttachedTerminal | null = null;
     let sessionId: string | null = null;
+
+    // ── Choosing what to connect to ───────────────────────────────────────────
+    //
+    // This surface used to be a bare text field validated by /^i-[0-9a-f]{8,}$/,
+    // which had two problems and only one of them was cosmetic.
+    //
+    // The cosmetic one: an instance id is not something a person has. Getting one
+    // meant leaving for the Instances page, copying an id, and coming back — so a
+    // page that never read ctx.level was effectively expert-only without saying so.
+    //
+    // The other one: that regex is a *syntax* check, so it accepts any instance id
+    // in the account, including instances the portal never launched. The IAM role
+    // scopes ec2:TerminateInstances to `spawn:managed=true` and does NOT scope
+    // ssm:StartSession at all, so the narrowest thing standing between a portal
+    // session and a shell on an unrelated production box was this field. Listing
+    // instead of parsing makes the spawn-managed set the *default* set — the list
+    // comes from EC2Provider.list(), which filters `tag:spawn:managed=true`
+    // server-side. See the note at `byIdBtn` on why that is a usability fix and not
+    // a security boundary.
+    //
+    // The provider is shared with the Instances surface rather than a second
+    // DescribeInstances client of our own, which is what deferred this from the
+    // original disclosure pass: this is already the heaviest chunk in the bundle.
+    const guided = !atLeast(ctx.level, "standard");
+    let byId = false;
+
+    /** Which control the Connect button reads. Keeps one source of truth. */
+    function chosenTarget(): string {
+      return byId ? target.value : pick.value;
+    }
+
+    /**
+     * Swap between the list and the text field.
+     *
+     * Both stay in the DOM either way, because `chosenTarget()` reads whichever is
+     * active and hiding is cheaper than rebuilding — the same reason the lagotto
+     * surface hides its fields rather than removing them.
+     */
+    function setById(on: boolean): void {
+      byId = on;
+      pick.hidden = on;
+      target.hidden = !on;
+      byIdBtn.textContent = on ? "← Pick from your instances" : "Connect to an id instead →";
+      if (on) target.focus();
+    }
+
+    /**
+     * Fill the list from the shared provider.
+     *
+     * Every branch says which fact it knows. "No instances" and "we couldn't ask" are
+     * different states and conflating them would send a user hunting for instances
+     * they have, or vice versa — the same rule the guided picker follows for a failed
+     * catalog lookup.
+     */
+    async function loadInstances(): Promise<void> {
+      try {
+        const all = await provider.list();
+        if (disposed) return;
+        // Only `running` can take a shell. A stopped instance is listed nowhere here
+        // because "Connect" against it fails inside SSM with a message about the
+        // agent, which reads as a broken portal rather than a stopped machine.
+        const usable = all.filter((i) => i.state === "running");
+        if (usable.length === 0) {
+          pick.innerHTML = `<option value="">${
+            all.length === 0
+              ? "no spawn-launched instances in this region"
+              : `none of your ${all.length} instance(s) are running`
+          }</option>`;
+          openBtn.disabled = true;
+          // The id field is the way out of an empty list, so point at it rather than
+          // leaving a disabled button and no next step.
+          if (!guided) status.textContent = "Nothing to connect to — or connect to an id.";
+          return;
+        }
+        pick.innerHTML = usable
+          .map(
+            (i) =>
+              `<option value="${escapeHtml(i.instanceId)}">${escapeHtml(
+                `${i.name || i.instanceId} — ${i.instanceType}${i.spot ? " (spot)" : ""}`,
+              )}</option>`,
+          )
+          .join("");
+        openBtn.disabled = false;
+      } catch (err) {
+        if (disposed) return;
+        pick.innerHTML = `<option value="">couldn't list your instances</option>`;
+        // Not "no instances": we don't know that. Say what failed and leave the id
+        // field as the way through.
+        status.textContent = `couldn't list your instances: ${(err as Error).message}`;
+        openBtn.disabled = true;
+        // A guided user has no id to fall back on, so the escape has to appear even
+        // though it's normally hidden at that level. A dead end is worse than a
+        // control they may not understand.
+        if (guided) byIdBtn.hidden = false;
+      }
+    }
 
     // Best-effort SSM cleanup: close the socket + TerminateSession (a bare
     // StartSession leaves a live session server-side until it times out).
@@ -75,6 +193,10 @@ export const terminalSurface: ToolSurface = {
       closeBtn.hidden = true;
       openBtn.disabled = false;
       target.disabled = false;
+      pick.disabled = false;
+      // Re-offer the swap, which is disabled while connected: switching how you
+      // choose a target has no meaning when you already have a session.
+      byIdBtn.disabled = false;
       // Drop the connected-state styling; the caller sets the next message itself.
       status.className = "terminal-status";
     }
@@ -82,11 +204,18 @@ export const terminalSurface: ToolSurface = {
     async function connect(instanceId: string): Promise<void> {
       const id = instanceId.trim();
       if (!/^i-[0-9a-f]{8,}$/.test(id)) {
-        status.textContent = "enter a valid instance id (i-…)";
+        // Reachable from the picker too, not just the text field: an empty list
+        // leaves `pick.value` as "". Wording covers both, since the user knows which
+        // control they used and we don't need to tell them.
+        status.textContent = byId
+          ? "enter a valid instance id (i-…)"
+          : "pick an instance to connect to";
         return;
       }
       openBtn.disabled = true;
       target.disabled = true;
+      pick.disabled = true;
+      byIdBtn.disabled = true;
       status.textContent = "starting SSM session…";
       try {
         const ssm = new SSMClient({ region, credentials });
@@ -124,15 +253,31 @@ export const terminalSurface: ToolSurface = {
 
     const onSubmit = (e: Event) => {
       e.preventDefault();
-      void connect(target.value);
+      void connect(chosenTarget());
     };
     const onClose = () => {
       void teardown();
       resetUi();
       status.textContent = "disconnected";
     };
+    const onById = () => {
+      setById(!byId);
+      // Clear a stale "pick an instance" / "enter a valid id" from the other mode.
+      if (status.className === "terminal-status") status.textContent = "";
+    };
     form.addEventListener("submit", onSubmit);
     closeBtn.addEventListener("click", onClose);
+    byIdBtn.addEventListener("click", onById);
+
+    // Guided keeps the picker and loses the escape: an instance id is not something a
+    // guided user has, so a button offering to take one is a dead end dressed as an
+    // option. It comes back if the list fails to load, where a dead end is the
+    // alternative rather than the risk (see loadInstances).
+    byIdBtn.hidden = guided;
+    // Nothing to connect to until the list arrives, and a Connect click before then
+    // would fail the id check and print an error about the user's own timing.
+    openBtn.disabled = true;
+    void loadInstances();
 
     // If the session's creds expire, drop the live shell.
     const offExpiry = ctx.session.onExpiry((state) => {
@@ -145,12 +290,31 @@ export const terminalSurface: ToolSurface = {
 
     return {
       dispose() {
+        disposed = true;
         offExpiry();
         form.removeEventListener("submit", onSubmit);
         closeBtn.removeEventListener("click", onClose);
+        byIdBtn.removeEventListener("click", onById);
         void teardown();
         root.remove();
       },
     };
   },
 };
+
+/**
+ * Instance names come from a user-controlled `Name` tag, so both the option label
+ * and its value are interpolated escaped.
+ *
+ * An `<option>`'s text is not a place a `<script>` runs, and instance ids are
+ * AWS-generated — so neither is exploitable as written. It's done anyway because
+ * "this sink happens to be safe" is a property of the current markup, not of the
+ * data, and the value is what `connect()` then trusts. Matches the picker's own
+ * helper (`guided/picker.ts`).
+ */
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -634,7 +634,21 @@ footer {
 .terminal-hint { color: var(--text-muted); font-size: 0.9rem; max-width: 640px; }
 .terminal-form { display: flex; gap: 0.5rem; align-items: center; }
 .terminal-target { flex: 0 1 320px; font: inherit; font-family: ui-monospace, monospace; padding: 0.5rem 0.75rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
-.terminal-target:focus-visible { outline: 2px solid var(--spored); outline-offset: -2px; }
+.terminal-target:focus-visible, .terminal-pick:focus-visible { outline: 2px solid var(--spored); outline-offset: -2px; }
+/* The picker, which is the primary control — a shell needs an instance id, and an
+   instance id is not something a person has. Sized like the field it replaces so
+   swapping between them doesn't reflow the row. */
+.terminal-pick { flex: 0 1 320px; font: inherit; padding: 0.5rem 0.75rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
+/* Both controls live in the DOM at once (see "Choosing what to connect to" in
+   terminal.ts), so the UA's `[hidden] { display: none }` has to survive whatever
+   `display` the rules above imply — the same specificity trap that made the lagotto
+   resume notice show on every mount. Stated explicitly rather than relied on. */
+.terminal-pick[hidden], .terminal-target[hidden], .terminal-byid[hidden] { display: none; }
+/* The escape to typing an id. Styled as a quiet link rather than a button: it's the
+   fallback, and at guided it isn't shown at all. */
+.terminal-byid { align-self: flex-start; font: inherit; font-size: 0.9rem; cursor: pointer; padding: 0; border: 0; background: none; color: var(--text-muted); text-decoration: underline; }
+.terminal-byid:hover:not(:disabled) { color: var(--spored); }
+.terminal-byid:disabled { cursor: default; opacity: 0.5; text-decoration: none; }
 .terminal-form button { font: inherit; cursor: pointer; padding: 0.5rem 1rem; border-radius: var(--radius); border: 1px solid var(--border-strong); background: var(--bg); color: var(--text); }
 .terminal-open { border-color: var(--spored) !important; color: var(--spored) !important; }
 .terminal-status { color: var(--text-muted); font-size: 0.9rem; min-height: 1.2em; }


### PR DESCRIPTION
Closes #512.

## The finding

#512 was filed as a usability issue: the terminal surface asks for an instance id in a text field, and *"the regex accepts **any** instance in the account, including ones spawn never launched."*

Scoping it turned up something worse than a wide text field. **Both** portal IAM policies scoped `ec2:TerminateInstances`/`StopInstances`/`StartInstances` to `spawn:managed=true` and left `ssm:StartSession` on `instance/*` **with no condition at all**:

```hcl
{
  Sid      = "Lifecycle"
  Action   = ["ec2:TerminateInstances", ...]
  Condition = { StringEquals = { "aws:ResourceTag/spawn:managed" = "true" } }
},
...
{
  Action   = ["ssm:StartSession"]
  Resource = "arn:aws:ec2:*:*:instance/*"     # ← no condition
}
```

A shell is at least as powerful as a terminate. So a portal session could open a **root-capable shell on any SSM-registered instance in the account** — an unrelated production box the portal never launched — while being correctly *denied* permission to stop that same instance. The two statements sit next to each other, and the destructive one's comment claims a portal session "can't touch unrelated instances".

The only thing narrowing it was `/^i-[0-9a-f]{8,}$/` on a text field: a **syntax** check, not authorization, running on the client.

## The fix

**IAM (the actual boundary)** — in `infra/tofu/portal-oidc/main.tf` and `deployment/cloudformation/portal-onboarding-role.yaml`:

- `ssm:StartSession` on the instance ARN is now conditioned on `ssm:resourceTag/spawn:managed = true`. That's SSM's own service-specific condition key — `aws:ResourceTag/` is **not** what SSM evaluates for `StartSession` (confirmed against AWS's Session Manager sample policies, Example 3).
- The session **documents** are a separate, deliberately *unconditioned* statement. A document carries no `spawn:managed` tag, so folding it into the conditioned statement would deny **every** session. AWS's own example splits it; so does this.

**Browser (the part you can see)** — the text field becomes a `<select>` populated from the Instances surface's own `EC2Provider`, whose `list()` filters `tag:spawn:managed=true` **server-side**, so the spawn-managed set is the *default* set with no client-side filtering to get wrong.

- **Running only.** A stopped instance fails inside SSM with a message about the agent, which reads as a broken portal rather than a parked machine.
- **`Connect to an id instead →`** keeps the old field — a shell into something the portal didn't launch is a legitimate thing to want. Hidden at `guided`, where an instance id isn't something the user has and offering to take one is a dead end dressed as an option. **One exception:** if the list fails to load, the escape appears at guided too. A control you may not understand beats a page with no way forward.
- **"No instances" and "couldn't ask" are different facts.** A stopped-only account is told how many it has, since the fix there is to start one rather than launch another.

## Drive-by fix, surfaced not caused

`instances.test.ts` never stubbed `fetch`, so mounting the surface fired a **real `DescribeInstances` at AWS** and got a 401 — its own comment claimed "the test never lets a request complete". The run used to finish before the response landed; 16 more tests made it long enough to arrive. It looked clean while making unauthenticated calls to AWS from CI.

## The deferral reason didn't hold

#512 was deferred over bundle cost ("needs an EC2-list dependency in the heaviest chunk"). Rollup hoisted the client into a shared chunk instead of duplicating it:

| chunk | before | after |
|---|---|---|
| `ec2-*.js` | — | **15.21 kB** (new, shared) |
| `instances-*.js` | 125.44 kB | **110.55 kB** (−14.89) |
| `terminal-*.js` | 413.62 kB | **415.86 kB** (+2.24) |

## Verification

- **16 new tests**, and **all 16 fail** against the pre-change surface (stashed `terminal.ts` + `style.css` to confirm).
- **198/198** full suite, 14 files — and now with **no leaked AWS request**.
- `tsc --noEmit` clean; `npm run build` clean.
- `tofu validate` Success, `tofu fmt -check` clean; `cfn-lint` exit 0, `[]` findings.
- **Driven in a real browser** at all three levels via a new `terminal.harness.html` (tracked, matching `lagotto.harness.html` precedent), across three variants — default, `?fail`, `?empty` — **all pass, no page errors**. This is the only check that can see `[hidden]` losing a specificity fight, which is exactly what shipped the lagotto resume notice on every mount, and which happy-dom cannot test **because it applies no CSS**. Screenshots eyeballed in light and dark.

## Deploy notes

- **The IAM change does not auto-apply.** No workflow runs `tofu apply` — `grep -ln "tofu apply\|terraform apply" .github/workflows/*` returns nothing. Per the repo's standing constraint, an IAM apply needs consent naming the specific change; this PR is the definition only.
- **BYOA accounts must redeploy the CloudFormation template** to pick up the scoped `StartSession`.
- Merging this deploys `web/**` to spore.host/app.

## Noted, not fixed here

Clicking **Disconnect** briefly shows `disconnected` and then `session closed: …` when the socket's async `onclose` arrives. Pre-existing and unrelated to #512; the harness made it visible. Happy to file it.