### PR TITLE
test(portal): stop instances.test.ts making real unauthenticated AWS calls

### DIFF
--- a/web/app/surfaces/instances.test.ts
+++ b/web/app/surfaces/instances.test.ts
@@ -14,11 +14,29 @@
 // signal that spawn-ts moved.
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionController } from "../session.js";
 import type { PortalConfig, SurfaceContext } from "./types.js";
 import type { DisclosureLevel } from "../disclosure.js";
-import { instancesSurface } from "./instances.js";
+
+// Swap the real EC2 provider for spawn-ts's own MockProvider. Mounting this surface
+// constructs an EC2Provider and calls client.startMonitor(), which issues
+// DescribeInstances immediately — and the AWS SDK in Node uses its own HTTP handler,
+// not globalThis.fetch, so stubbing fetch does NOT intercept it. Without this mock
+// the suite makes real unauthenticated calls to AWS, and the run reports an unhandled
+// `AuthFailure` rejection whenever it lasts long enough for the response to land.
+// (It passes in isolation either way — the run is too short. The full suite is where
+// it shows, which is why the fetch stub this replaces looked like it worked.)
+//
+// Mocked at the module boundary rather than by injection because the provider is
+// constructed inside mount() and the surface takes no provider argument. Nothing
+// here asserts on instance data, so an empty mock world is enough.
+vi.mock("@spore-host/spawn-ts", async (importActual) => {
+  const actual = await importActual<typeof import("@spore-host/spawn-ts")>();
+  return { ...actual, EC2Provider: actual.MockProvider };
+});
+
+const { instancesSurface } = await import("./instances.js");
 
 const settle = () => new Promise((r) => setTimeout(r, 50));
 
@@ -45,7 +63,7 @@ function ctxAt(level: DisclosureLevel): SurfaceContext {
   const session = new SessionController("us-east-1", null);
   session.setLevel(level);
   // The surface throws without creds. These are the AWS docs' example key, and they
-  // never reach AWS — `fetch` is stubbed below.
+  // never reach AWS — the provider is MockProvider (see vi.mock above).
   vi.spyOn(session, "getCreds").mockReturnValue({
     accessKeyId: "AKIAIOSFODNN7EXAMPLE",
     secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -56,29 +74,11 @@ function ctxAt(level: DisclosureLevel): SurfaceContext {
 
 describe("instancesSurface disclosure", () => {
   let host: HTMLElement;
-  const realFetch = globalThis.fetch;
 
   beforeEach(() => {
     document.body.innerHTML = "";
     host = document.createElement("div");
     document.body.appendChild(host);
-    // Mounting this surface constructs a real EC2Provider and calls
-    // client.startMonitor(), which issues DescribeInstances immediately. Without
-    // this stub those requests go to the actual AWS endpoint and come back 401 —
-    // the run used to finish before the response landed, so it looked clean while
-    // this suite made unauthenticated calls to AWS from CI. An empty reservation
-    // set is enough: nothing here asserts on instance data.
-    globalThis.fetch = vi.fn(
-      async () =>
-        new Response(
-          `<?xml version="1.0" encoding="UTF-8"?><DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/"><requestId>test</requestId><reservationSet/></DescribeInstancesResponse>`,
-          { status: 200, headers: { "content-type": "text/xml" } },
-        ),
-    ) as typeof fetch;
-  });
-
-  afterEach(() => {
-    globalThis.fetch = realFetch;
   });
 
   it("marks the host so the stylesheet can hide the Dashboard's forms at guided", async () => {


### PR DESCRIPTION
## What

`web/app/surfaces/instances.test.ts` mounted `instancesSurface` with a **real `EC2Provider`**. Mounting calls `client.startMonitor()`, which issues `DescribeInstances` immediately, and nothing intercepted it — so every full `npm test` run made unauthenticated `ec2:DescribeInstances` calls to the live AWS endpoint, from developer machines and from CI.

## How it hid

```
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
AuthFailure: AWS was not able to validate the provided access credentials
 ❯ EC2Provider.list node_modules/@spore-host/spawn-ts/src/aws/ec2.ts:131:17
 ❯ SpawnClient.refresh node_modules/@spore-host/spawn-ts/src/core/client.ts:301:26

 Test Files  14 passed (14)
      Tests  198 passed (198)
     Errors  1 error
```

Two things made it easy to miss:

- **`198 passed` next to `Errors 1 error`** reads as green at a glance.
- **It only appears in the full run.** On its own this file finishes before the response lands, so `npx vitest run app/surfaces/instances.test.ts` passes either way — with or without the fix. The full suite is the only discriminator.

That second point is also why **the previous attempt at this fix was wrong**. It stubbed `globalThis.fetch`, which the isolated run appeared to validate. But the AWS SDK uses its own HTTP handler under Node, not `fetch`, so the stub never intercepted anything and the unhandled rejection survived untouched. Corrected here.

## The fix

Mock at the module boundary and substitute spawn-ts's own `MockProvider` — exported from the package root for exactly this:

```ts
vi.mock("@spore-host/spawn-ts", async (importActual) => {
  const actual = await importActual<typeof import("@spore-host/spawn-ts")>();
  return { ...actual, EC2Provider: actual.MockProvider };
});
```

Module-boundary rather than injection because the provider is constructed inside `mount()` and the surface takes no provider argument — there is no seam. An empty mock world is sufficient: nothing in this file asserts on instance data, only on the CSS coupling between the portal's `.guided-instances` rules and the Dashboard's class names.

This is also what the original plan specified ("mount `instancesSurface` at `guided` over `core/mock.js`"); the implementation drifted from it.

**All five assertions are unchanged.** No production code touched.

## Verification

```
$ npm run typecheck    # clean
$ npm test
 Test Files  14 passed (14)
      Tests  198 passed (198)
```

No `Errors` line, no unhandled rejection.