### PR TITLE
feat(portal): the software catalog no longer needs an account to read (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,46 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Fixed
+- **The software catalog no longer requires an account to read** (#515). The catalog is
+  the same five environment formations for everybody — the API's handler takes no
+  arguments and reads nothing per-account — but `GET /api/strata/catalog` was routed
+  *inside* dashboard-api's authenticated switch, so browsing a static list returned
+  `401` and the portal gated the whole surface behind sign-in as a consequence. The
+  route now sits above the auth check (and above the AWS config load, which it doesn't
+  need), alongside the Slack OAuth exemptions.
+  - **`POST /api/strata/resolve` stays authenticated.** It reaches
+    `s3://strata-registry` with the Lambda's own credentials, so only the read-only
+    listing was exempted. A test asserts that, so the two don't drift together later.
+  - The existing catalog test called the handler function directly and so passed
+    whether the route was gated or not — part of why this survived. Replaced with
+    router-level tests that make the anonymous request the way a browser does.
+  - A `401` from this endpoint no longer reports "authentication failed" in the portal:
+    the endpoint doesn't authenticate, so a 401 means the deployed API is older than
+    the page, and blaming auth would send a signed-out reader to a sign-in that can't
+    help.
+- **`GET /teams/{id}` now returns the caller's role** (#514). It already resolved the
+  role to authorize the request and then discarded it, leaving clients to re-derive
+  ownership by comparing `owner_arn` against whatever identity they thought they had.
+  The portal did exactly that, and wrongly: `OwnerARN` is a **display field**, written
+  once at creation and never read for authorization, and its format depends on which
+  auth path created the team — a bare account id for portal-federated callers, a real
+  IAM ARN for CLI ones. `GET /teams` already returned `role`; the detail endpoint not
+  doing so was the gap. `OwnerARN` is now documented as display-only rather than
+  renamed, because its `dynamodbav` tag is the stored attribute name.
+  - This fixes the *browser's* half. The **underlying defect is larger and unfixed**:
+    the portal and the CLI resolve one human to two different `callerARN`s, and that
+    value is the membership row's partition key — so a CLI-created team is invisible in
+    the portal and a portal-created team is invisible to the CLI, with no workaround,
+    since `memberARNRe` rejects the bare account id that would bridge them. Tracked in
+    #531; it needs a decision on stored data before any code.
+- **`instances.test.ts` no longer calls live AWS** (#532). The suite mounted the
+  surface with a real `EC2Provider`, and mounting starts a monitor that issues
+  `DescribeInstances` immediately — so every full test run made unauthenticated calls
+  to the live endpoint, reported as `Errors 1 error` beside `198 passed`. It only
+  appeared in the *full* run (the file alone finishes before the response lands), which
+  is why an earlier `globalThis.fetch` stub looked like it worked: the AWS SDK uses its
+  own HTTP handler under Node, so the stub never intercepted anything. Now mocked at
+  the module boundary with spawn-ts's own `MockProvider`.
 - **`ssm:StartSession` is now scoped to spawn-managed instances** (#512). Both portal
   IAM policies — the OIDC launch role in `infra/tofu/portal-oidc` and the BYOA
   onboarding role in `deployment/cloudformation/portal-onboarding-role.yaml` — scoped

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -172,6 +172,20 @@ Two rules held throughout:
   button is the chart's non-visual equivalent, not a density control, and the people
   who need it are the least likely to have raised the mode.
 
+### Three pages need no account at all
+
+**Find instances**, **Software catalog** and **Connect account** all work signed out.
+That isn't a detail-level decision — it's the same principle one axis over: the pages
+that answer *"what is this and what would it cost me?"* are the ones a first-time
+visitor reaches first, and putting them behind the account they don't have yet inverts
+the order.
+
+The **Software catalog** was gated until recently, and for no better reason than that
+the endpoint serving it sat behind the API's authentication check. The list is the same
+five environment formations for everybody — the API's own handler takes no arguments
+and reads nothing per-account — so signing in bought nothing and cost the one visitor
+most likely to be browsing. It's now readable by anyone.
+
 ### Waiting for capacity, without knowing instance-type names
 
 **Watch capacity** is the page where the split matters most, not least. Its fields

--- a/web/app/surfaces/catalog.test.ts
+++ b/web/app/surfaces/catalog.test.ts
@@ -1,0 +1,168 @@
+// The catalog surface, and specifically the one state that used to be unreachable:
+// signed out.
+//
+// This surface was `requiresAuth: true` purely because the API's endpoint sat behind
+// the Lambda's auth check — not because the data is per-account. It isn't: the handler
+// takes no arguments and returns a fixed five-element list. Now that the endpoint is
+// anonymous, the surface mounts for visitors with no credentials, and that path has
+// two ways to break that a signed-in developer would never see:
+//
+//   1. `getCreds()` returns null and building the credentials header throws, so the
+//      request never leaves the page.
+//   2. A 401 is reported as "authentication failed", sending a signed-out reader to a
+//      sign-in screen that cannot help them — the endpoint doesn't authenticate.
+//
+// Both are asserted below against a stubbed fetch, since nothing here needs the real
+// API and a test that reached api.spore.host would be a live network call in CI.
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { SessionController } from "../session.js";
+import type { PortalConfig, SurfaceContext } from "./types.js";
+import type { DisclosureLevel } from "../disclosure.js";
+import { catalogSurface } from "./catalog.js";
+import { surfaces } from "./registry.js";
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+const config = { region: "us-east-1", apiBase: "https://api.example.invalid" } as PortalConfig;
+
+const FORMATIONS = [
+  { name: "r-research@2024.03", display_name: "R + Quarto", description: "R 4.3, tidyverse" },
+  { name: "python-ml@2024.03", display_name: "Python ML", description: "PyTorch, sklearn" },
+];
+
+/** A context with no credentials — the signed-out visitor. */
+function signedOutCtx(level: DisclosureLevel = "guided"): SurfaceContext {
+  const session = new SessionController("us-east-1", null);
+  session.setLevel(level);
+  return { session, config, level, navigate: vi.fn() };
+}
+
+/** A context whose session has credentials. */
+function signedInCtx(level: DisclosureLevel = "standard"): SurfaceContext {
+  const ctx = signedOutCtx(level);
+  vi.spyOn(ctx.session, "getCreds").mockReturnValue({
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    sessionToken: "token",
+  } as never);
+  return ctx;
+}
+
+describe("catalogSurface without a session", () => {
+  let host: HTMLElement;
+  const realFetch = globalThis.fetch;
+  let calls: Array<{ url: string; headers: Record<string, string> }>;
+
+  /** Stub fetch with a fixed status/body and record what was sent. */
+  function stubFetch(status: number, body: unknown): void {
+    globalThis.fetch = vi.fn(async (input: any, init: any) => {
+      calls.push({ url: String(input), headers: (init?.headers ?? {}) as Record<string, string> });
+      return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    calls = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("is registered as not requiring auth, so the shell mounts it for a visitor", () => {
+    // The shell gates on the *registry* entry (shell.ts: `surface.requiresAuth &&
+    // !signedIn` → sign-in gate), not on the surface module. If these two ever
+    // disagree, the surface's own `requiresAuth: false` is dead and the visitor still
+    // hits a wall — so assert the entry the shell actually reads.
+    expect(surfaces.find((s) => s.id === "catalog")?.requiresAuth).toBe(false);
+    expect(catalogSurface.requiresAuth).toBe(false);
+  });
+
+  it("mounts and loads with no credentials at all", async () => {
+    stubFetch(200, { success: true, formations: FORMATIONS });
+    const d = await catalogSurface.mount(host, signedOutCtx());
+    await settle();
+    await settle();
+
+    expect(calls.length, "no request was made").toBe(1);
+    expect(host.querySelectorAll(".catalog-card").length).toBe(2);
+    expect(host.textContent).toContain("R + Quarto");
+    d.dispose();
+  });
+
+  it("omits the credentials header when there are none, rather than throwing", async () => {
+    // The failure this pins: `credentialsHeader(creds!)` on a null cred object throws
+    // synchronously inside load(), so the request is never sent and the surface sits
+    // on "loading…" forever with no error shown.
+    stubFetch(200, { success: true, formations: FORMATIONS });
+    const d = await catalogSurface.mount(host, signedOutCtx());
+    await settle();
+    await settle();
+
+    expect(calls[0]!.headers["X-AWS-Credentials"]).toBeUndefined();
+    expect(host.querySelector(".catalog-status")?.textContent ?? "").not.toContain("loading");
+    d.dispose();
+  });
+
+  it("still sends the credentials header when signed in", async () => {
+    // Not required by the endpoint, but dropping it unconditionally would be a
+    // separate change to a header other surfaces rely on for the same API.
+    stubFetch(200, { success: true, formations: FORMATIONS });
+    const d = await catalogSurface.mount(host, signedInCtx());
+    await settle();
+    await settle();
+
+    expect(calls[0]!.headers["X-AWS-Credentials"]).toBeTruthy();
+    d.dispose();
+  });
+
+  it("does not blame authentication for a 401", async () => {
+    // A 401 from an endpoint that doesn't authenticate means the deployed API is older
+    // than this page. Telling a signed-out reader "authentication failed" points them
+    // at a sign-in that cannot fix it.
+    stubFetch(401, { success: false, error: "authentication failed" });
+    const d = await catalogSurface.mount(host, signedOutCtx());
+    await settle();
+    await settle();
+
+    const status = host.querySelector(".catalog-status")!;
+    expect(status.classList.contains("error")).toBe(true);
+    expect(status.textContent!.toLowerCase()).not.toContain("authentication");
+    expect(status.textContent!.toLowerCase()).not.toContain("sign in");
+    d.dispose();
+  });
+
+  it("reports a non-401 failure without claiming the catalog is empty", async () => {
+    stubFetch(500, { success: false, error: "boom" });
+    const d = await catalogSurface.mount(host, signedOutCtx());
+    await settle();
+    await settle();
+
+    const status = host.querySelector(".catalog-status")!;
+    expect(status.textContent).toContain("500");
+    expect(host.querySelectorAll(".catalog-card").length).toBe(0);
+    d.dispose();
+  });
+
+  it("escapes formation fields rather than injecting them", async () => {
+    stubFetch(200, {
+      success: true,
+      formations: [
+        { name: "x@1", display_name: "<img src=x onerror=alert(1)>", description: "d" },
+      ],
+    });
+    const d = await catalogSurface.mount(host, signedOutCtx());
+    await settle();
+    await settle();
+
+    expect(host.querySelector("img")).toBeNull();
+    expect(host.textContent).toContain("<img src=x onerror=alert(1)>");
+    d.dispose();
+  });
+});

--- a/web/app/surfaces/catalog.ts
+++ b/web/app/surfaces/catalog.ts
@@ -41,11 +41,16 @@ export const catalogSurface: ToolSurface = {
   id: "catalog",
   label: "Software catalog",
   accent: "--strata",
-  requiresAuth: true,
+  // The catalog is static and shared, not per-account — the API's own handler takes
+  // no arguments and returns a fixed list. It used to be gated only because the
+  // endpoint sat behind the Lambda's auth check, which made a harmless browse of five
+  // formation names require an AWS account. Now anyone can read it, signed in or not.
+  requiresAuth: false,
 
   async mount(host: HTMLElement, ctx: SurfaceContext): Promise<Disposable> {
+    // May be null: this surface mounts for signed-out visitors. The request goes out
+    // without the credentials header in that case rather than not going out at all.
     const creds = ctx.session.getCreds();
-    if (!creds) throw new Error("catalog surface mounted without a session");
 
     const root = document.createElement("div");
     root.className = "catalog-surface";
@@ -53,7 +58,7 @@ export const catalogSurface: ToolSurface = {
       <div class="catalog-head">
         <h2>Software catalog</h2>
         <p class="catalog-hint">Curated environment formations you can launch onto an
-          instance. Served by the shared dashboard-api over your federated session.</p>
+          instance. The same list for everyone — no account needed to read it.</p>
       </div>
       <div class="catalog-results" aria-live="polite"><div class="catalog-status">loading…</div></div>`;
     host.appendChild(root);
@@ -66,11 +71,20 @@ export const catalogSurface: ToolSurface = {
       try {
         const resp = await fetch(`${ctx.config.apiBase}/api/strata/catalog`, {
           method: "GET",
-          headers: { "X-AWS-Credentials": credentialsHeader(creds!) },
+          // Sent only when we have creds. The endpoint ignores them either way, but a
+          // header built from a null cred object would throw before the request left.
+          headers: creds ? { "X-AWS-Credentials": credentialsHeader(creds) } : {},
           signal: controller.signal,
         });
         if (!resp.ok) {
-          const detail = resp.status === 401 ? "authentication failed" : `HTTP ${resp.status}`;
+          // A 401 here is no longer a "you need to sign in" — this endpoint doesn't
+          // authenticate. It means the deployed API is older than this page, so say
+          // that rather than sending a signed-out reader to a sign-in screen that
+          // wouldn't help.
+          const detail =
+            resp.status === 401
+              ? "the API hasn't picked up this change yet"
+              : `HTTP ${resp.status}`;
           results.innerHTML = `<div class="catalog-status error">Couldn't load the catalog (${escapeHtml(detail)}).</div>`;
           return;
         }
@@ -86,18 +100,10 @@ export const catalogSurface: ToolSurface = {
       }
     }
 
-    // Reload if creds expire+refresh isn't wired yet — for now just surface it.
-    const offExpiry = ctx.session.onExpiry((state) => {
-      if (state === "expired") {
-        results.innerHTML = `<div class="catalog-status error">Session expired — sign in again to reload the catalog.</div>`;
-      }
-    });
-
     void load();
 
     return {
       dispose() {
-        offExpiry();
         controller.abort();
         root.remove();
       },

--- a/web/app/surfaces/registry.ts
+++ b/web/app/surfaces/registry.ts
@@ -67,7 +67,9 @@ export const surfaces: ToolSurface[] = [
     id: "catalog",
     label: "Software catalog",
     accent: "--strata",
-    requiresAuth: true,
+    // Static and shared, so readable without an account — see the comment on
+    // catalogSurface. The API serves GET /api/strata/catalog unauthenticated.
+    requiresAuth: false,
     load: () => import("./catalog.js").then((m) => ({ mount: m.catalogSurface.mount })),
   }),
   lazy({


### PR DESCRIPTION
The **browser half** of #515. The API half is `spore-host/spawn#480`, merged as `66cb620` and **not yet deployed** — see [Deploy ordering](#deploy-ordering).

## Why

The catalog is the same five environment formations for everybody. The API's handler takes **no arguments** and reads nothing per-account. It was gated behind sign-in only because the endpoint sat inside dashboard-api's authenticated switch — so `requiresAuth: true` was a consequence of a routing accident, not a decision about the data. The cost fell on the visitor most likely to be browsing a software list: someone deciding whether they want an account at all.

## Changes

- **`requiresAuth: false`** on both the registry entry and the surface. The shell gates on the *registry* entry (`shell.ts:272`), so a test asserts the two agree — otherwise the surface's own flag is dead code and the visitor still hits a wall.
- **The credentials header is sent only when there are credentials.** Previously `credentialsHeader(creds!)` on a null cred object threw synchronously inside `load()`, so the request never left the page and the surface sat on `loading…` forever with no error. Signed-in requests still send it.
- **A 401 no longer reports "authentication failed."** This endpoint doesn't authenticate, so a 401 means the deployed API is older than the page. Blaming auth would send a signed-out reader to a sign-in screen that cannot help them.
- **Dropped the session-expiry handler.** An expired session no longer stops anyone reading a public list, so "sign in again to reload the catalog" was simply false.

## Tests

7 new, and **verified load-bearing** rather than assumed: reverting the source makes 5 of them fail. The 401-wording test passes under that revert — because the header throw masks it — so I reverted *only* the message separately to confirm it isn't vacuous:

```
× does not blame authentication for a 401
  → expected 'couldn\'t load the catalog (authentic…' not to contain 'authentication'
```

## Driven in a real browser

Signed out, which is the state nobody developing this is ever in. The endpoint is intercepted at the network layer to serve what the fixed Lambda returns, so this exercises the **portal** half:

```
===== signed out, API ok =====
PASS surface mounted, not the sign-in gate
PASS the request was actually sent — requests=1
PASS no X-AWS-Credentials header when signed out — header=null
PASS all five formations rendered — cards=5
PASS first card has real layout box — {"width":820,"height":79.4}
PASS the actionable slug is visible — r-research@2024.03

===== signed out, API 401 =====
PASS the 401 is reported — Couldn't load the catalog (the API hasn't picked up this change yet).
PASS does NOT blame authentication
PASS does NOT tell them to sign in

nav order signed out: Connect account · Find instances · Software catalog · Slack · Instances · …
PASS catalog ranks above the auth-gated pages — catalog=2 instances=4
```

The layout-box check is the one unit tests can't make: happy-dom applies no CSS, so a card that renders into the DOM but lays out at zero height would pass there and be invisible in a browser.

## Deploy ordering

This page expects an unauthenticated endpoint. Until the dashboard-api Lambda is deployed — a **manual** `lambda/dashboard-api/deploy.sh`; there is no CI deploy for it — a signed-out visitor sees *"the API hasn't picked up this change yet"* instead of the list. That's the intended degraded state, not a break, and it's why the 401 wording changed.

**Signed-in visitors are unaffected either way**, since the credentials they send still validate against the old and new API alike. So this is safe to merge before or after the Lambda deploy; only the signed-out experience waits on it.

## Verification

`npm run typecheck` clean · **205/205** tests · `npm run build` clean.