### PR TITLE
fix(portal): read the caller's role from the API instead of guessing it (#514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,19 @@ own changelogs for CLI releases.
   IAM ARN for CLI ones. `GET /teams` already returned `role`; the detail endpoint not
   doing so was the gap. `OwnerARN` is now documented as display-only rather than
   renamed, because its `dynamodbav` tag is the stored attribute name.
-  - This fixes the *browser's* half. The **underlying defect is larger and unfixed**:
+  - The portal now reads that field instead of comparing `owner_arn` against
+    `session.accountId`, so an owner who created their team with the CLI gets the owner
+    controls the API says they have. It keeps the old comparison as a **fallback for
+    when `role` is absent**, because the deployed Lambda predates the field and dropping
+    it outright would take owner controls away from every portal-created team until the
+    deploy lands. The discriminator is `role !== undefined`, not `role !== "owner"`: an
+    older API omits the field, while a newer one answering `"member"` is a real answer
+    that must be believed rather than second-guessed by an ARN comparison. The fallback
+    is itself the bug and is tracked for removal in #534.
+  - At expert, `owner_arn` is relabelled **created by**, and a **your role** row is
+    added when the API sent one. Calling a write-once display field "owner" invited
+    precisely the inference that caused this.
+  - This fixes the *symptom*. The **underlying defect is larger and unfixed**:
     the portal and the CLI resolve one human to two different `callerARN`s, and that
     value is the membership row's partition key — so a CLI-created team is invisible in
     the portal and a portal-created team is invisible to the CLI, with no workaround,

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -157,7 +157,7 @@ isn't listed, it looks the same at every level.
 | **Instances** | The curated picker instead of the launch form. The instance list is always shown. | Full launch form | + |
 | **Find instances** | The curated picker instead of the query box | Query box | + per-result hardware detail and price provenance |
 | **Cost history** | Same chart and numbers, plainer labels, and a link to Instances to go stop something | Same chart, shorter labels | + compute/storage/network breakdown, window total, peak hour, a 1-year window, and where the series came from |
-| **Teams** | **Read-only.** Your teams and their members, with no forms. | Create teams, add and remove members, delete a team | + team ids, full ARNs, created dates, and who invited whom |
+| **Teams** | **Read-only.** Your teams and their members, with no forms. | Create teams, add and remove members, delete a team | + team ids, full ARNs, created dates, your own role, and who invited whom |
 | **Watch capacity** | A short list of things worth waiting for, instead of the pattern, price cap, zone and cadence fields. Picking one watches that whole instance family. | The fields, filled in by hand | + |
 | **Terminal** | A list of your running machines to pick from | + **Connect to an id instead →**, for something spawn didn't launch | + |
 | **Connect account** | Technical detail collapsed | Collapsed | Expanded — what the IAM role can do, before the button rather than after |
@@ -171,6 +171,21 @@ Two rules held throughout:
 - **Cost history hides nothing at any level**, including its **Table** button. That
   button is the chart's non-visual equivalent, not a density control, and the people
   who need it are the least likely to have raised the mode.
+
+### Teams: raising Mode doesn't make you an owner
+
+Standard and Expert show the create, add-member, remove and delete controls — but only
+on teams you actually own. That isn't the mode's decision: the API answers "what is
+your role in this team?" and the page shows the controls that answer allows. Every
+write is owner-gated server-side regardless, so a button the mode revealed but the API
+would refuse is a button worth not drawing.
+
+The page used to work this out for itself, by comparing the team's stored owner field
+against your account id. That field is written once when the team is created and its
+format depends on how the team was created — so **a team you made with the `spawn` CLI
+showed you, its owner, a read-only page**. Expert mode now labels that field **created
+by** rather than "owner", and adds **your role** beside it, because the two are not the
+same question.
 
 ### Three pages need no account at all
 

--- a/web/app/surfaces/teams.test.ts
+++ b/web/app/surfaces/teams.test.ts
@@ -51,12 +51,22 @@ const MEMBERS = [
   },
 ];
 
-function stubFetch(): void {
+/**
+ * Stub the API.
+ *
+ * `detail` overrides what GET /teams/{id} returns. The default omits `role`, which is
+ * what the *deployed* Lambda does — so the default path through these tests is the
+ * compatibility fallback, and the tests that care about the new field opt in.
+ */
+function stubFetch(detail: Record<string, unknown> = {}): void {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (url: string) => {
       const path = url.replace(config.apiBase, "");
-      const body = path === "/teams" ? { teams: [TEAM] } : { team: TEAM, members: MEMBERS };
+      const body =
+        path === "/teams"
+          ? { teams: [TEAM] }
+          : { team: TEAM, members: MEMBERS, ...detail };
       return { ok: true, status: 200, json: async () => body } as never;
     }),
   );
@@ -170,6 +180,78 @@ describe("teamsSurface disclosure", () => {
     // Expert's read-only additions are still there — they're information, not authority.
     expect(host.querySelector(".teams-meta")).not.toBeNull();
     d.dispose();
+  });
+
+  describe("who the owner controls are shown to (#514)", () => {
+    // The bug: the surface decided ownership by comparing `owner_arn` against
+    // `session.accountId`. That field is a bare account id for portal-created teams and
+    // a real IAM ARN for CLI-created ones, so an owner who created their team with the
+    // CLI saw a read-only page. The API now answers the question itself with `role`.
+
+    it("believes the API's role over the stored owner_arn", async () => {
+      // The #514 case: a CLI-created team, so `owner_arn` is an IAM ARN that cannot
+      // equal an account id. The old comparison fails here; `role: "owner"` must win.
+      stubFetch({ role: "owner" });
+      const ctx = ctxAt("standard");
+      vi.spyOn(ctx.session, "accountId", "get").mockReturnValue(ACCOUNT);
+      const cliTeam = { ...TEAM, owner_arn: `arn:aws:iam::${ACCOUNT}:user/owner` };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          const path = url.replace(config.apiBase, "");
+          const body =
+            path === "/teams"
+              ? { teams: [cliTeam] }
+              : { team: cliTeam, members: MEMBERS, role: "owner" };
+          return { ok: true, status: 200, json: async () => body } as never;
+        }),
+      );
+      const d = await openDetail(host, ctx);
+      expect(host.querySelector(".teams-addmember")).not.toBeNull();
+      expect(host.querySelector(".teams-danger")).not.toBeNull();
+      d.dispose();
+    });
+
+    it("believes a role of member even when owner_arn matches", async () => {
+      // The other direction, and the reason the check is `role !== undefined` rather
+      // than `role !== "owner"`: a definite "member" from the API is an answer, not a
+      // missing field, so it must not fall through to the ARN guess. Without this the
+      // fallback would silently re-grant controls the API says the caller lacks.
+      stubFetch({ role: "member" });
+      const d = await openDetail(host, ctxAt("standard"));
+      expect(host.querySelector(".teams-addmember")).toBeNull();
+      expect(host.querySelector(".teams-danger")).toBeNull();
+      d.dispose();
+    });
+
+    it("falls back to owner_arn when the API doesn't send a role", async () => {
+      // The deployed Lambda omits the field. Until it ships, dropping the comparison
+      // would take owner controls away from every portal-created team — so this asserts
+      // the change is safe to merge ahead of the deploy. Delete with the fallback.
+      stubFetch(); // no `role`
+      const d = await openDetail(host, ctxAt("standard"));
+      expect(host.querySelector(".teams-addmember")).not.toBeNull();
+      d.dispose();
+    });
+
+    it("shows your role at expert, and only when the API said so", async () => {
+      stubFetch({ role: "member" });
+      let d = await openDetail(host, ctxAt("expert"));
+      let keys = [...host.querySelectorAll(".teams-meta dt")].map((t) => t.textContent);
+      expect(keys).toContain("your role");
+      // `owner_arn` is relabelled: it is written once and never read for authorization,
+      // and calling it "owner" invited the inference that caused this bug.
+      expect(keys).toContain("created by");
+      expect(keys).not.toContain("owner");
+      d.dispose();
+
+      host.innerHTML = "";
+      stubFetch();
+      d = await openDetail(host, ctxAt("expert"));
+      keys = [...host.querySelectorAll(".teams-meta dt")].map((t) => t.textContent);
+      expect(keys, "a guess must not be printed as the answer").not.toContain("your role");
+      d.dispose();
+    });
   });
 
   it("offers a route out of read-only at guided", async () => {

--- a/web/app/surfaces/teams.ts
+++ b/web/app/surfaces/teams.ts
@@ -199,14 +199,24 @@ export const teamsSurface: ToolSurface = {
 
       const team: Team = res.data.team;
       const members: Member[] = res.data.members ?? [];
-      // `owner_arn` holds a bare 12-digit account id for portal-created teams
-      // (dashboard-api's portalAccountFromARN) but a real IAM ARN for CLI-created
-      // ones (cliIamArn) — so this comparison is correct for the former and never
-      // matches the latter, and a CLI-created team shows its own owner no owner
-      // controls. Tracked in spore-host#514; the fix belongs on the API side, not
-      // here — the browser should not be parsing ARN shapes to guess which code path
-      // wrote the record.
-      const iAmOwner = team.owner_arn === ctx.session.accountId;
+      // Read the API's own authorization answer rather than re-deriving it.
+      // GET /teams/{id} returns `role`, resolved from the memberships table — which is
+      // where authorization actually lives — so the browser doesn't have to infer
+      // ownership from a display field. `owner_arn` holds a bare 12-digit account id
+      // for portal-created teams (dashboard-api's portalAccountFromARN) but a real IAM
+      // ARN for CLI-created ones (cliIamArn), so comparing it against accountId was
+      // right for the former and never matched the latter: a CLI-created team showed
+      // its own owner no owner controls (spore-host#514).
+      //
+      // The comparison stays as a fallback because the deployed Lambda predates the
+      // field, and dropping it outright would take owner controls away from every
+      // portal-created team until that deploy lands. `undefined` — not `!== "owner"` —
+      // is the discriminator: an older API omits `role` entirely, while a newer one
+      // answering "member" is a real answer that must be believed. Remove the fallback
+      // once the API is deployed (spore-host#534).
+      const role: string | undefined = res.data?.role;
+      const iAmOwner =
+        role !== undefined ? role === "owner" : team.owner_arn === ctx.session.accountId;
 
       root.append(
         el("div", "teams-head", [
@@ -222,8 +232,15 @@ export const teamsSurface: ToolSurface = {
         const dl = el("dl", "teams-meta", []);
         const rows: Array<[string, string]> = [
           ["team id", team.team_id],
-          ["owner", team.owner_arn],
+          // Labelled "created by" rather than "owner": the stored field is written once
+          // at creation and never read for authorization, and its format depends on
+          // which auth path wrote it. Calling it "owner" invited exactly the inference
+          // that caused #514. `your role` below is the authoritative answer.
+          ["created by", team.owner_arn],
           ["created", fmtDate(team.created_at)],
+          // Only when the API told us. An older Lambda omits it, and printing a guess
+          // here would be the same mistake one line further down the page.
+          ...(role !== undefined ? ([["your role", role]] as Array<[string, string]>) : []),
         ];
         for (const [k, v] of rows) dl.append(el("dt", "", [k]), el("dd", "", [v]));
         root.append(dl);


### PR DESCRIPTION
Closes #514's browser half. The API half merged as spawn `66cb620`.

## The bug

`teams.ts` decided whether to show owner controls like this:

```ts
const iAmOwner = team.owner_arn === ctx.session.accountId;
```

`owner_arn` is a **display field**: written once at team creation, never read for
authorization, and its format depends on which auth path wrote it — a bare 12-digit
account id via `portalAccountFromARN`, a real IAM ARN via `cliIamArn`. So the
comparison was correct for portal-created teams and could **never** match a
CLI-created one. An owner who made their team with `spawn` opened it in the portal and
got a read-only page.

## The fix

`GET /teams/{id}` now returns `role`, which it already resolved from the memberships
table to authorize the request and then discarded. That table is where authorization
actually lives, so read the API's own answer instead of re-deriving it in the browser:

```ts
const role: string | undefined = res.data?.role;
const iAmOwner =
  role !== undefined ? role === "owner" : team.owner_arn === ctx.session.accountId;
```

**Why the fallback is here.** The deployed Lambda predates the field — `curl
https://api.spore.host/api/strata/catalog` still returns 401, same commit — so
dropping the comparison outright would take owner controls away from every
portal-created team until the manual `deploy.sh` lands. It's tracked for removal in
**#534**, because the fallback *is* the bug: leaving it in means a future API that
stops sending `role` silently resurrects this.

**Why `role !== undefined` and not `role !== "owner"`.** An older API omits the field;
a newer one answering `"member"` is a real answer that must be believed. Written the
other way, a definite "member" would fall through to the ARN guess and re-grant
controls the API says the caller lacks. There's a test for that direction specifically.

## Naming

At expert, `owner_arn` is relabelled **created by**, and **your role** is added when
the API sent one. Calling a write-once display field "owner" invited exactly the
inference that caused this bug, and printing a guess under that label would repeat it
one line down the page.

## Verification

- 19 tests in `teams.test.ts` (4 new), 209 across the suite. Three of the four fail
  under a revert of the role check; the fourth pins the fallback, so it passes either
  way by design — that's what makes this safe to merge ahead of the deploy.
- Driven in Chromium against the real page and stylesheet, in all three response
  shapes — `role=owner` on a CLI-created team, `role=member` where `owner_arn` matches,
  and no `role` at all. Checks `getBoundingClientRect`/`getComputedStyle` on the
  add-member form: happy-dom applies no CSS, so it can't distinguish a form that
  rendered from one that's visible.

```
===== cli-owner (owner_arn=IAM ARN, role=owner) =====
  PASS add-member form matches the role — present=true
  PASS the add-member form has a real layout box — {"w":820,"h":42,"display":"flex","visibility":"visible"}
  PASS 'your role' shows the API's answer — owner
===== member (owner_arn=account id, role=member) =====
  PASS add-member form matches the role — present=false
===== legacy (owner_arn=account id, role=ABSENT) =====
  PASS add-member form matches the role — present=true
  PASS 'your role' shown only when the API sent one — team id, created by, created
```

## Not fixed here

The **underlying defect is larger** and needs a decision on stored data: the portal and
the CLI resolve one human to two different `callerARN`s, and that value is the
membership row's partition key — so a CLI-created team is invisible in the portal and a
portal-created team is invisible to the CLI, with no workaround, since `memberARNRe`
rejects the bare account id that would bridge them. Tracked in **#531**. This PR fixes
the symptom for anyone whose membership row *does* match.

Merging deploys to spore.host/app.