### PR TITLE
fix(portal): Disconnect no longer reports the session as closing on its own (#530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ own changelogs for CLI releases.
 ## [Unreleased]
 
 ### Fixed
+- **Clicking Disconnect no longer reports the session as having closed on its own**
+  (#530). Two writers raced and the user-initiated one lost: the Disconnect handler
+  wrote `disconnected` synchronously, then `attachTerminal`'s `onClosed` callback wrote
+  `session closed: <reason>` over it — asynchronously, because a real
+  `WebSocket.close()` dispatches `onclose` as a task rather than inline. The teardown
+  the user asked for announced itself first and the socket's notification landed second.
+  Deliberate closes now suppress the socket's message; an unexpected drop still reports
+  one, since that wording is exactly for a session that ended without being asked to.
+  Credential expiry benefits too — `sign in again` used to be replaced by
+  `session closed`, which names the symptom and drops the instruction.
+  - The flag is cleared in `connect()`, **not** in `resetUi()` as the issue suggested:
+    `resetUi()` runs synchronously right after `teardown()` on every path, i.e. before
+    the async `onClosed` it exists to suppress, so clearing it there would suppress
+    nothing. A new session and a new socket is the real boundary. There's a test for
+    the leak that would otherwise silence a real drop on a second connection.
+  - `terminal.test.ts`'s `attachTerminal` mock never fired `onClosed` at all, which is
+    why this was invisible to the suite and had to be found by driving the harness in a
+    browser. It now defers the callback the way the real socket does — synchronously
+    would run it *inside* `teardown()` and recurse.
 - **The software catalog no longer requires an account to read** (#515). The catalog is
   the same five environment formations for everybody — the API's handler takes no
   arguments and reads nothing per-account — but `GET /api/strata/catalog` was routed

--- a/web/app/surfaces/terminal.test.ts
+++ b/web/app/surfaces/terminal.test.ts
@@ -37,6 +37,17 @@ let listGate: Promise<void> | null = null;
 let providerOpts: Array<Record<string, unknown>> = [];
 /** StartSession targets the surface actually asked for. */
 let started: string[] = [];
+/**
+ * The reason the mocked socket reports when it closes, mirroring what the real data
+ * channel supplies. Only read by the unexpected-drop path — a deliberate close must
+ * not print it at all.
+ */
+let closeReason: string | undefined = "stub";
+/**
+ * Fires the surface's onClosed callback, so a drop the user did NOT ask for can be
+ * simulated without going through dispose().
+ */
+let dropSocket: (() => void) | null = null;
 
 vi.mock("@spore-host/spawn-ts", () => ({
   class: undefined,
@@ -54,7 +65,33 @@ vi.mock("@spore-host/spawn-ts", () => ({
 
 vi.mock("@spore-host/spawn-ts/terminal", () => ({
   // Resolves to a disposable so a "successful" connect is reachable without xterm.
-  attachTerminal: vi.fn(async () => ({ dispose: vi.fn() })),
+  //
+  // `dispose()` now fires the surface's `onClosed` callback **on a later task**,
+  // because that is what the real thing does: `WebSocket.close()` dispatches `onclose`
+  // as a task rather than inline. The mock never fired it at all, which is why
+  // spore-host#530 — the socket's own "session closed: …" landing after and
+  // overwriting the user's "disconnected" — was invisible to this suite and had to be
+  // found by driving the harness in a browser.
+  //
+  // The deferral is what makes it meaningful. Calling onClosed synchronously would run
+  // it *inside* teardown(), before the message it races with has been written, and
+  // would recurse: close → onClosed → teardown → dispose → close.
+  attachTerminal: vi.fn(
+    async (_host: unknown, _session: unknown, onClosed: (reason?: string) => void) => {
+      dropSocket = () => onClosed(closeReason);
+      let closed = false;
+      return {
+        dispose: vi.fn(() => {
+          // Idempotent, like the real socket: teardown() can run more than once per
+          // session (the onClosed path calls it again), and a second onClosed would
+          // re-enter the same race this exists to test.
+          if (closed) return;
+          closed = true;
+          setTimeout(() => onClosed(closeReason), 0);
+        }),
+      };
+    },
+  ),
 }));
 
 vi.mock("@aws-sdk/client-ssm", () => {
@@ -116,6 +153,8 @@ beforeEach(() => {
   listGate = null;
   providerOpts = [];
   started = [];
+  closeReason = "stub";
+  dropSocket = null;
 });
 
 const pick = () => host.querySelector<HTMLSelectElement>(".terminal-pick")!;
@@ -319,6 +358,98 @@ describe("terminalSurface while connected", () => {
     expect(byId().disabled).toBe(false);
     expect(openBtn().disabled).toBe(false);
     d.dispose();
+  });
+
+  describe("what the status line says when the session ends (#530)", () => {
+    /** Connect, then run out the deferred onClosed the mocked socket schedules. */
+    async function connectThen(act: () => void): Promise<void> {
+      host.querySelector<HTMLFormElement>(".terminal-form")!.dispatchEvent(new Event("submit"));
+      await settle();
+      act();
+      // Two: one for the click's own synchronous work, one for the task the socket's
+      // close is dispatched on. A single settle() would let the bug pass.
+      await settle();
+      await settle();
+    }
+
+    it("does not overwrite 'disconnected' with the socket's own message", async () => {
+      // The bug: Disconnect wrote "disconnected" synchronously, then the socket's
+      // onclose landed a task later and replaced it with "session closed: stub".
+      // `session closed: <reason>` is the wording for a session that ended on its own,
+      // so using it for a disconnect the user just clicked reports a requested event as
+      // an unexpected one.
+      const d = await terminalSurface.mount(host, ctxAt());
+      await settle();
+      await connectThen(() => host.querySelector<HTMLButtonElement>(".terminal-close")!.click());
+
+      expect(text()).toBe("disconnected");
+      expect(text()).not.toContain("session closed");
+      d.dispose();
+    });
+
+    it("still reports a drop the user did not ask for", async () => {
+      // The other direction, and the reason this isn't just "never print that message".
+      // An agent exit or a dropped socket is exactly what the wording is for, and
+      // suppressing it would leave a dead terminal with a stale "Connected." above it —
+      // a worse bug than the one being fixed.
+      const d = await terminalSurface.mount(host, ctxAt());
+      await settle();
+      await connectThen(() => dropSocket!());
+
+      expect(text()).toContain("session closed");
+      expect(text()).toContain("stub");
+      // And the surface is usable again, not stuck in the connected state.
+      expect(openBtn().disabled).toBe(false);
+      expect(host.querySelector<HTMLElement>(".terminal-close")!.hidden).toBe(true);
+      d.dispose();
+    });
+
+    it("reports a drop with no reason without a trailing colon", async () => {
+      closeReason = undefined;
+      const d = await terminalSurface.mount(host, ctxAt());
+      await settle();
+      await connectThen(() => dropSocket!());
+
+      expect(text()).toBe("session closed");
+      d.dispose();
+    });
+
+    it("keeps the expiry message rather than replacing it with the socket's", async () => {
+      // Credential expiry also tears down deliberately, and "sign in again" is the
+      // actionable half. `session closed: stub` in its place names the symptom and
+      // drops the instruction.
+      // The surface's own listener is captured as it subscribes, rather than reaching
+      // for a private emit() or adding a test-only method to SessionController.
+      const ctx = ctxAt();
+      let fireExpiry: ((s: "warning" | "expired") => void) | null = null;
+      const realOnExpiry = ctx.session.onExpiry.bind(ctx.session);
+      vi.spyOn(ctx.session, "onExpiry").mockImplementation((fn) => {
+        fireExpiry = fn;
+        return realOnExpiry(fn);
+      });
+      const d = await terminalSurface.mount(host, ctx);
+      await settle();
+      await connectThen(() => fireExpiry!("expired"));
+
+      expect(text()).toContain("sign in again");
+      expect(text()).not.toContain("session closed");
+      d.dispose();
+    });
+
+    it("does not suppress a drop on the next session after a deliberate close", async () => {
+      // The flag has to be cleared when a new session starts. If it leaked, a real drop
+      // on the second connection would be silent — the failure mode this fix could
+      // introduce, and the reason it's cleared in connect() rather than in resetUi()
+      // (which runs synchronously before the onClosed it exists to suppress).
+      const d = await terminalSurface.mount(host, ctxAt());
+      await settle();
+      await connectThen(() => host.querySelector<HTMLButtonElement>(".terminal-close")!.click());
+      expect(text()).toBe("disconnected");
+
+      await connectThen(() => dropSocket!());
+      expect(text()).toContain("session closed");
+      d.dispose();
+    });
   });
 });
 

--- a/web/app/surfaces/terminal.ts
+++ b/web/app/surfaces/terminal.ts
@@ -171,9 +171,31 @@ export const terminalSurface: ToolSurface = {
       }
     }
 
+    // Set by every path that ends the session *deliberately* — the Disconnect button,
+    // credential expiry, dispose() — and read by attachTerminal's onClosed callback,
+    // which fires asynchronously because a real `WebSocket.close()` dispatches
+    // `onclose` as a task rather than inline. Without it the socket's own notification
+    // lands after the user-initiated message and overwrites it: click Disconnect, read
+    // "disconnected", then watch it become "session closed: …" a moment later
+    // (spore-host#530).
+    //
+    // `session closed: <reason>` is the wording for a session that ended on its own —
+    // the agent exited, the socket dropped, the instance went away. Using it for a
+    // disconnect the user just asked for reports a requested event as an unexpected
+    // one, and trains the reader to treat the message as noise for the next time it
+    // appears unprompted and means something.
+    //
+    // Deliberately NOT cleared in resetUi(): that runs synchronously right after
+    // teardown() on every path, i.e. before the async onclose it exists to suppress.
+    // connect() clears it, which is the real boundary — a new session, a new socket.
+    let intentionalClose = false;
+
     // Best-effort SSM cleanup: close the socket + TerminateSession (a bare
     // StartSession leaves a live session server-side until it times out).
+    // Every caller is a deliberate end, so this is where the flag is set rather than
+    // in each of the three of them.
     async function teardown(): Promise<void> {
+      intentionalClose = true;
       attached?.dispose();
       attached = null;
       const sid = sessionId;
@@ -217,6 +239,9 @@ export const terminalSurface: ToolSurface = {
       pick.disabled = true;
       byIdBtn.disabled = true;
       status.textContent = "starting SSM session…";
+      // A new session and a new socket, so the previous session's deliberate-close
+      // flag must not carry over and silence a real drop on this one.
+      intentionalClose = false;
       try {
         const ssm = new SSMClient({ region, credentials });
         const started = await ssm.send(new StartSessionCommand({ Target: id }));
@@ -238,7 +263,14 @@ export const terminalSurface: ToolSurface = {
           termHost,
           { streamUrl: started.StreamUrl, tokenValue: started.TokenValue, sessionId: started.SessionId },
           (reason) => {
-            status.textContent = `session closed${reason ? ": " + reason : ""}`;
+            // The socket closed. If we closed it, the path that did so has already
+            // said what happened in words that fit — leave its message alone and just
+            // finish the cleanup. teardown() and resetUi() are both idempotent, so
+            // running them again here is harmless and keeps the unexpected-drop path
+            // (where nothing else has run) complete.
+            if (!intentionalClose) {
+              status.textContent = `session closed${reason ? ": " + reason : ""}`;
+            }
             void teardown();
             resetUi();
           },


### PR DESCRIPTION
Closes #530.

## The race

Click **Disconnect** and the status line said `disconnected`, then replaced it with
`session closed: <reason>` a moment later. Two writers, and the *user-initiated* one
lost:

| Writer | When |
|---|---|
| `onClose` → `"disconnected"` | **synchronously**, on click |
| `attachTerminal`'s `onClosed` → `` `session closed${…}` `` | **asynchronously** — a real `WebSocket.close()` dispatches `onclose` as a task, not inline |

So the teardown the user asked for announced itself first and the socket's own
notification landed second and overwrote it.

## Why it's worth fixing

`session closed: <reason>` is the wording for a session that ended **on its own** — the
agent exited, the socket dropped, the instance went away. Using it for a disconnect the
user just clicked reports a requested event as an unexpected one. Minor in isolation,
but this surface's copy was deliberately worked over for exactly this class of honesty
problem (the "Leaving this page … ends this session" warning), and a spurious
`session closed` undercuts it: the next time it appears *unprompted* it means
something, and it will have been trained to read as noise.

## The fix

`teardown()` — which every deliberate path calls — sets `intentionalClose`, and the
`onClosed` callback leaves the status line alone when it's set. It still runs
`teardown()`/`resetUi()`, both idempotent, so the unexpected-drop path stays complete.

Credential expiry benefits too: `session expired — sign in again` used to be replaced by
`session closed`, which names the symptom and drops the instruction.

**An unexpected drop still reports itself.** Suppressing that would leave a dead
terminal under a stale "Connected." — a worse bug than this one. Two of the five tests
pin that direction.

**The flag is cleared in `connect()`, not `resetUi()`** as the issue suggested.
`resetUi()` runs synchronously right after `teardown()` on every path — *before* the
async `onClosed` it exists to suppress — so clearing it there would suppress nothing. A
new session and a new socket is the real boundary. There's a test for the leak that
would otherwise silence a real drop on a second connection.

## Verification

The mock's `attachTerminal` **never fired `onClosed` at all**, which is why this was
invisible to the suite and had to be found by driving the harness in a browser. It now
defers the callback the way the real socket does — synchronously would run it *inside*
`teardown()`, before the message it races with is written, and would recurse
(`close → onClosed → teardown → dispose → close`).

5 new tests (21 in the file, 214 across the suite). Three fail under a revert of the
fix; the other two pass either way by design, because they pin what must not break.

Re-verified in the harness that found it, by observing the status node's **mutation
trail** rather than its end state — the bug wrote `disconnected` and then overwrote it,
so a single read of `textContent` cannot see it:

```
status mutation trail:
  "starting SSM session…"
  "Connected. Leaving this page, reloading, or changing Mode in the header ends this session."
  "disconnected"
PASS the final message is the user's, not the socket's — disconnected
PASS 'session closed' never appears for a click the user made — (absent)
```

And with the fix reverted, the probe reproduces the issue's exact four-line trail —
so it isn't a probe that passes regardless:

```
  "disconnected"
  "session closed: stub"      ← the bug
2 FAILED
```

Merging deploys to spore.host/app.