### PR TITLE
fix(portal): authorization comes from the API's role, not the stored owner_arn (#534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,16 +61,24 @@ own changelogs for CLI releases.
   renamed, because its `dynamodbav` tag is the stored attribute name.
   - The portal now reads that field instead of comparing `owner_arn` against
     `session.accountId`, so an owner who created their team with the CLI gets the owner
-    controls the API says they have. It keeps the old comparison as a **fallback for
-    when `role` is absent**, because the deployed Lambda predates the field and dropping
-    it outright would take owner controls away from every portal-created team until the
-    deploy lands. The discriminator is `role !== undefined`, not `role !== "owner"`: an
-    older API omits the field, while a newer one answering `"member"` is a real answer
-    that must be believed rather than second-guessed by an ARN comparison. The fallback
-    is itself the bug and is tracked for removal in #534.
-  - At expert, `owner_arn` is relabelled **created by**, and a **your role** row is
-    added when the API sent one. Calling a write-once display field "owner" invited
-    precisely the inference that caused this.
+    controls the API says they have. It shipped keeping the old comparison as a fallback
+    for when `role` was absent, because the deployed Lambda predated the field; that
+    Lambda is now deployed and **the fallback is gone** (#534) — `role === "owner"` is
+    the whole check, and nothing in the surface consults `owner_arn` for authorization
+    any more. A 200 always carries a role, since the handler answers 403 unless it
+    resolves a membership row, so a missing one is a broken response rather than an
+    older API. It **fails closed**: no owner controls, and the member list still renders,
+    because a read-only page is recoverable and a Delete button on someone else's team
+    is not. There's a test for that direction — the fixture gives `owner_arn` the
+    matching account id, so the deleted fallback would have granted the full set.
+  - At expert, `owner_arn` is relabelled **created by**, and a **your role** row shows
+    the API's answer — `unknown` if it somehow sent none, never an inference. Calling a
+    write-once display field "owner" invited precisely the inference that caused this.
+  - One existing test had to change with the fallback: "shows a non-owner no write
+    controls even at expert" expressed non-ownership by mocking a mismatching
+    `accountId`, which only worked *because* of the ARN comparison. It now states the
+    role the way the API does. Left alone it would have kept passing for a reason
+    unrelated to what it claims to check.
   - This fixes the *symptom*. The **underlying defect is larger and unfixed**:
     the portal and the CLI resolve one human to two different `callerARN`s, and that
     value is the membership row's partition key — so a CLI-created team is invisible in

--- a/docs/guides/portal-detail-levels.md
+++ b/docs/guides/portal-detail-levels.md
@@ -187,6 +187,11 @@ showed you, its owner, a read-only page**. Expert mode now labels that field **c
 by** rather than "owner", and adds **your role** beside it, because the two are not the
 same question.
 
+If the API ever fails to answer that question, the page shows the read-only view and
+says `unknown` for your role rather than guessing from the stored field. On a team you
+do own that's a nuisance — reload, or check that the API is reachable — but the
+alternative is offering **Delete team** to someone the API never said was an owner.
+
 ### Three pages need no account at all
 
 **Find instances**, **Software catalog** and **Connect account** all work signed out.

--- a/web/app/surfaces/teams.test.ts
+++ b/web/app/surfaces/teams.test.ts
@@ -54,9 +54,11 @@ const MEMBERS = [
 /**
  * Stub the API.
  *
- * `detail` overrides what GET /teams/{id} returns. The default omits `role`, which is
- * what the *deployed* Lambda does — so the default path through these tests is the
- * compatibility fallback, and the tests that care about the new field opt in.
+ * `detail` overrides what GET /teams/{id} returns. The default sends `role: "owner"`,
+ * which is what the deployed Lambda does: the handler resolves the caller's role from
+ * the memberships table and answers 403 rather than 200 without one, so a 200 always
+ * carries it. Tests wanting a different role — or a malformed response with none — say
+ * so explicitly, e.g. `stubFetch({ role: undefined })`.
  */
 function stubFetch(detail: Record<string, unknown> = {}): void {
   vi.stubGlobal(
@@ -66,7 +68,7 @@ function stubFetch(detail: Record<string, unknown> = {}): void {
       const body =
         path === "/teams"
           ? { teams: [TEAM] }
-          : { team: TEAM, members: MEMBERS, ...detail };
+          : { team: TEAM, members: MEMBERS, role: "owner", ...detail };
       return { ok: true, status: 200, json: async () => body } as never;
     }),
   );
@@ -171,9 +173,14 @@ describe("teamsSurface disclosure", () => {
     // Raising the mode cannot grant authority. The API owner-gates every write with a
     // 403 regardless, so this is about not offering a button that can only fail — and
     // the action column goes with it, since Remove was the only thing in it.
-    const ctx = ctxAt("expert");
-    vi.spyOn(ctx.session, "accountId", "get").mockReturnValue("999999999999");
-    const d = await openDetail(host, ctx);
+    //
+    // Non-ownership is stated the way the API states it, with `role`. This test used to
+    // mock a mismatching `accountId` instead, which only worked because the surface
+    // compared that against `owner_arn` — the #514 bug. A mismatching account id now
+    // proves nothing about authority, so asserting through it would leave this passing
+    // for a reason unrelated to what it claims to check.
+    stubFetch({ role: "member" });
+    const d = await openDetail(host, ctxAt("expert"));
     expect(host.querySelector(".teams-addmember")).toBeNull();
     expect(host.querySelector(".teams-danger")).toBeNull();
     expect(host.querySelector(".teams-memb-action")).toBeNull();
@@ -213,10 +220,9 @@ describe("teamsSurface disclosure", () => {
     });
 
     it("believes a role of member even when owner_arn matches", async () => {
-      // The other direction, and the reason the check is `role !== undefined` rather
-      // than `role !== "owner"`: a definite "member" from the API is an answer, not a
-      // missing field, so it must not fall through to the ARN guess. Without this the
-      // fallback would silently re-grant controls the API says the caller lacks.
+      // The other direction: a portal-created team, so `owner_arn` DOES equal the
+      // account id, and the old comparison would have granted owner controls. The API
+      // says "member", and that is the answer.
       stubFetch({ role: "member" });
       const d = await openDetail(host, ctxAt("standard"));
       expect(host.querySelector(".teams-addmember")).toBeNull();
@@ -224,32 +230,47 @@ describe("teamsSurface disclosure", () => {
       d.dispose();
     });
 
-    it("falls back to owner_arn when the API doesn't send a role", async () => {
-      // The deployed Lambda omits the field. Until it ships, dropping the comparison
-      // would take owner controls away from every portal-created team — so this asserts
-      // the change is safe to merge ahead of the deploy. Delete with the fallback.
-      stubFetch(); // no `role`
+    it("shows no owner controls when the API sends no role at all", async () => {
+      // A 200 without `role` is a broken response, not a supported shape — the handler
+      // can only answer 200 after resolving a membership row. This asserts which way it
+      // fails: closed. `owner_arn` here equals the account id, so the fallback this
+      // replaces (spore-host#534) would have granted the full set of owner controls,
+      // including irreversible Delete, on the strength of a display field.
+      stubFetch({ role: undefined });
       const d = await openDetail(host, ctxAt("standard"));
-      expect(host.querySelector(".teams-addmember")).not.toBeNull();
+      expect(host.querySelector(".teams-addmember")).toBeNull();
+      expect(host.querySelector(".teams-danger")).toBeNull();
+      expect(host.querySelector(".teams-remove")).toBeNull();
+      // Still readable, though: a member list is information about your own account, and
+      // a missing field is no reason to withhold it.
+      expect(host.querySelectorAll(".teams-members tbody tr")).toHaveLength(2);
       d.dispose();
     });
 
-    it("shows your role at expert, and only when the API said so", async () => {
+    it("shows your role at expert, never a guess", async () => {
       stubFetch({ role: "member" });
       let d = await openDetail(host, ctxAt("expert"));
       let keys = [...host.querySelectorAll(".teams-meta dt")].map((t) => t.textContent);
       expect(keys).toContain("your role");
+      expect(host.querySelector(".teams-meta")!.textContent).toContain("member");
       // `owner_arn` is relabelled: it is written once and never read for authorization,
       // and calling it "owner" invited the inference that caused this bug.
       expect(keys).toContain("created by");
       expect(keys).not.toContain("owner");
       d.dispose();
 
+      // With no role, the row says so rather than inferring one from `owner_arn` — which
+      // matches the account id in this fixture, so "owner" is exactly the wrong answer
+      // an inference would produce.
       host.innerHTML = "";
-      stubFetch();
+      stubFetch({ role: undefined });
       d = await openDetail(host, ctxAt("expert"));
-      keys = [...host.querySelectorAll(".teams-meta dt")].map((t) => t.textContent);
-      expect(keys, "a guess must not be printed as the answer").not.toContain("your role");
+      const meta = host.querySelector(".teams-meta")!;
+      keys = [...meta.querySelectorAll("dt")].map((t) => t.textContent);
+      expect(keys).toContain("your role");
+      const values = [...meta.querySelectorAll("dd")].map((v) => v.textContent);
+      expect(values, "a guess must not be printed as the answer").toContain("unknown");
+      expect(values).not.toContain("owner");
       d.dispose();
     });
   });

--- a/web/app/surfaces/teams.ts
+++ b/web/app/surfaces/teams.ts
@@ -201,22 +201,25 @@ export const teamsSurface: ToolSurface = {
       const members: Member[] = res.data.members ?? [];
       // Read the API's own authorization answer rather than re-deriving it.
       // GET /teams/{id} returns `role`, resolved from the memberships table — which is
-      // where authorization actually lives — so the browser doesn't have to infer
-      // ownership from a display field. `owner_arn` holds a bare 12-digit account id
-      // for portal-created teams (dashboard-api's portalAccountFromARN) but a real IAM
-      // ARN for CLI-created ones (cliIamArn), so comparing it against accountId was
-      // right for the former and never matched the latter: a CLI-created team showed
-      // its own owner no owner controls (spore-host#514).
+      // where authorization actually lives. It is present on every 200: the handler
+      // answers 403 unless resolveTeamContext finds a membership row, and every writer
+      // of that row sets the field. So a missing `role` is a broken response, and
+      // treating it as "not the owner" is the right way to fail — a read-only page is
+      // recoverable, a page offering Delete on someone else's team is not.
       //
-      // The comparison stays as a fallback because the deployed Lambda predates the
-      // field, and dropping it outright would take owner controls away from every
-      // portal-created team until that deploy lands. `undefined` — not `!== "owner"` —
-      // is the discriminator: an older API omits `role` entirely, while a newer one
-      // answering "member" is a real answer that must be believed. Remove the fallback
-      // once the API is deployed (spore-host#534).
-      const role: string | undefined = res.data?.role;
-      const iAmOwner =
-        role !== undefined ? role === "owner" : team.owner_arn === ctx.session.accountId;
+      // Nothing here consults `owner_arn`. That field is written once at creation and
+      // its format depends on which auth path wrote it — a bare 12-digit account id for
+      // portal-created teams (dashboard-api's portalAccountFromARN), a real IAM ARN for
+      // CLI-created ones (cliIamArn) — so comparing it against accountId matched the
+      // former and never the latter, and a team made with the `spawn` CLI showed its own
+      // owner a read-only page (spore-host#514). That comparison lived on here as a
+      // compatibility fallback while the API predated `role`; the Lambda is deployed
+      // (spawn 66cb620), so it is gone (spore-host#534).
+      // Typed as possibly-absent because this is parsed JSON and the type is a claim
+      // about the wire, not a guarantee — but no branch below treats absence as a
+      // supported shape.
+      const role: string | undefined = res.data.role;
+      const iAmOwner = role === "owner";
 
       root.append(
         el("div", "teams-head", [
@@ -238,9 +241,13 @@ export const teamsSurface: ToolSurface = {
           // that caused #514. `your role` below is the authoritative answer.
           ["created by", team.owner_arn],
           ["created", fmtDate(team.created_at)],
-          // Only when the API told us. An older Lambda omits it, and printing a guess
-          // here would be the same mistake one line further down the page.
-          ...(role !== undefined ? ([["your role", role]] as Array<[string, string]>) : []),
+          // Always shown, because the API always sends it. `unknown` rather than a
+          // dropped row if it somehow doesn't: this is the field that decides which
+          // controls the page offers, so an expert reader debugging a page that looks
+          // wrong should be told the answer is missing, not shown a gap they have to
+          // notice. Never a guess — printing an inference here would be the same
+          // mistake that caused #514.
+          ["your role", role ?? "unknown"],
         ];
         for (const [k, v] of rows) dl.append(el("dt", "", [k]), el("dd", "", [v]));
         root.append(dl);


### PR DESCRIPTION
Closes #534.

`web/app/surfaces/teams.ts` read `role` from `GET /teams/{id}` but kept comparing
`owner_arn` against `session.accountId` as a fallback, because the deployed Lambda
predated the field. That Lambda is deployed now (`spawn` `66cb620`, deployed today), so
the fallback goes:

```diff
-const role: string | undefined = res.data?.role;
-const iAmOwner =
-  role !== undefined ? role === "owner" : team.owner_arn === ctx.session.accountId;
+const role: string | undefined = res.data.role;
+const iAmOwner = role === "owner";
```

## Why the fallback had to go rather than stay harmlessly

It was the bug it shipped alongside. `owner_arn` is a **display field** — written once at
creation, never read for authorization — and its format depends on which auth path wrote
it: a bare 12-digit account id via `portalAccountFromARN`, a real IAM ARN via
`cliIamArn`. Comparing it against a caller identity matched the former and never the
latter, which is exactly why a team created with the `spawn` CLI showed its own owner a
read-only page (#514). Leaving the comparison in place meant an API that stopped sending
`role` would silently resurrect that bug instead of failing loudly.

## `role` is genuinely always there

Not an assumption — traced through the handler. `handleGetTeam` answers `403` unless
`resolveTeamContext` finds a membership row, and both writers of that row set `Role`
(`"owner"` at create, `"member"` at add-member). So a 200 always carries a role, and a
missing one is a **broken response**, not an older API.

## Which way it fails

Closed. No owner controls — and the member list still renders, because a read-only page
is recoverable and a **Delete team** button on someone else's team is not. At expert the
`your role` row says `unknown` rather than inferring one, and is now *always* present
rather than conditional: a reader debugging a page that looks wrong should be told the
answer is missing, not left to notice a gap where a row used to be.

## Tests

- **New** — "shows no owner controls when the API sends no role at all". The fixture
  gives `owner_arn` the *matching* account id, so the deleted fallback would have granted
  add-member, remove and delete. Verified load-bearing: restoring the fallback makes this
  the only failure in the file.
- **`stubFetch`'s default now sends `role: "owner"`**, which is what the deployed API
  does. It previously *omitted* the field so the suite's default path exercised the
  fallback; that default would now mean "not owner" and misrepresent the wire.
- **Changed** — "shows a non-owner no write controls even at expert" expressed
  non-ownership by mocking a mismatching `accountId`, which only worked *because* of the
  ARN comparison. It now states the role the way the API states it. Left alone it would
  have kept passing for a reason unrelated to what it claims to check.
- **Deleted** — "falls back to owner_arn when the API doesn't send a role", with the
  fallback it existed to cover.

## Verification

`214` web tests pass; `typecheck` and `build` clean.

Driven in Chromium against all three response shapes, checking real layout boxes rather
than DOM presence — happy-dom applies no CSS, so it can't distinguish a form that
rendered from one that's visible. In all three fixtures `owner_arn` equals the account
id, i.e. the shape the deleted fallback matched, so any surviving trace of it shows up as
owner controls appearing where the API said they shouldn't:

```
=== owner ===
  PASS add-member form is visibly laid out — {"w":820,"h":41.97,"display":"flex","visibility":"visible"}
  PASS the delete block is visibly laid out — {"w":820,"h":58.97,"display":"block","visibility":"visible"}
  PASS exactly one removable row (not the owner) — removes=1
  PASS "your role" reads "owner"
=== member ===
  PASS no add-member form in the DOM at all — null
  PASS no delete block — the irreversible one — null
  PASS "your role" reads "member"
=== no-role (malformed 200) ===
  PASS the member list renders regardless of role — rows=2
  PASS no add-member form in the DOM at all — null
  PASS "your role" reads "unknown"
```

Docs: the guide's "raising Mode doesn't make you an owner" section gains a paragraph on
what a missing answer looks like and why it errs that way. The CHANGELOG's #514 entry is
updated from "keeps a fallback, tracked in #534" to what the code now does.

## Still open, deliberately

#531 — the portal and the CLI resolve one human to two different `callerARN`s, and that
value is the membership row's partition key. This makes the *portal* believe the API
instead of guessing; it does not make a CLI-created team appear in the portal's list at
all. That needs a decision on stored data before any code.